### PR TITLE
🔍 fix: Tell the Model When a Web Search Failed

### DIFF
--- a/src/tools/search/format.test.ts
+++ b/src/tools/search/format.test.ts
@@ -240,3 +240,40 @@ describe('formatResultsForLLM highlight budget', () => {
     expect(output).toContain('_[1 additional highlight omitted to fit the context budget');
   });
 });
+
+describe('formatResultsForLLM on a failed search', () => {
+  test('tells the model the search failed instead of returning an empty output', () => {
+    const results: t.SearchResultData = {
+      organic: [],
+      topStories: [],
+      images: [],
+      videos: [],
+      news: [],
+      relatedSearches: [],
+      error: 'search provider request failed',
+    };
+
+    const { output, references } = formatResultsForLLM(0, results, 50000);
+
+    expect(output).toBe('Search failed: search provider request failed');
+    expect(references).toEqual([]);
+  });
+
+  test('keeps any partial results after the failure notice', () => {
+    const results: t.SearchResultData = {
+      organic: [makeOrganic('https://a.com', [highlight('A')])],
+      error: 'news lookup failed',
+    };
+
+    const { output } = formatResultsForLLM(0, results, 50000);
+
+    expect(output).toMatch(/^Search failed: news lookup failed/);
+    expect(output).toContain('=== Web Results, Turn 0 ===');
+  });
+
+  test('ignores an empty-string error', () => {
+    const results: t.SearchResultData = { organic: [], error: '' };
+
+    expect(formatResultsForLLM(0, results, 50000).output).toBe('');
+  });
+});

--- a/src/tools/search/format.ts
+++ b/src/tools/search/format.ts
@@ -239,6 +239,10 @@ export function formatResultsForLLM(
 
   const references: t.ResultReference[] = [];
 
+  if (results.error != null && results.error !== '') {
+    outputLines.push(`Search failed: ${results.error}`);
+  }
+
   // Organic (web) results
   if (results.organic?.length != null && results.organic.length > 0) {
     addSection(`Web Results, Turn ${turn}`);


### PR DESCRIPTION
## Summary

I made a failed web search visible to the model. When the search provider fails (bad or missing API key → HTTP 401, network error, quota), `createSearchProcessor` catches the error and returns empty collections with the message in `error`. `resolveSearchOutcome` turns that into the `Search failed for "…"` outcome label for the UI, but `formatResultsForLLM` never reads `error`, so the model received an empty string — indistinguishable from a search with zero hits. In practice the model then answered from memory: in our deployment an agent listed pages as "sources used" after every search had failed with 401, and a downstream checking agent marked the claims "verified" without a single page having been opened. The failure was visible only in the server log.

- Lead the LLM output of `formatResultsForLLM` with `Search failed: <error>` when `results.error` is set, so the model can tell a broken tool from an empty result.
- Ignore an empty-string error, the same rule `resolveSearchOutcome` already applies.
- Keep any partial results after the notice; the UI artifact and outcome label are unchanged.
- Add tests: a failed search yields the notice as the whole output with no references, partial results survive after the notice, and an empty-string error is ignored.

Before (tool output for any failed search): an empty string.

After:

Search failed: <the provider's error message, e.g. an HTTP 401 for a bad API key>

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `NODE_OPTIONS='--experimental-vm-modules' npx jest src/tools/search/format.test.ts src/tools/search/outcome.test.ts` — 24 tests passed (3 new).
- `npx eslint src/tools/search/format.ts src/tools/search/format.test.ts` — clean.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `git diff --check` — clean.
- Behaviour confirmed end to end on a LibreChat v0.8.8-rc2 deployment with a placeholder search API key: with the equivalent change applied to the built package, the agent reports that web search is unavailable and quotes the provider error instead of citing sources it never opened.

## Test Configuration

- Node.js: 22.14 (local; the repository asks for >= 24)
- Test framework: Jest with ts-jest

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes