### PR TITLE
🛡️ fix: Guard Nullish Search Results

### DIFF
--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -1410,7 +1410,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
 
     // Squeeze hard — OpenAI tool-schema overhead is lower than Anthropic,
     // so we need tighter budgets to force pruning + summarization.
-    run = await createRun(800);
+    run = await createRun(1200);
     await runTurn(
       { run, conversationHistory },
       'Calculate 999999 / 7 with calculator. Remind me of prior results too.',
@@ -1419,7 +1419,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
     logTurn('T6', conversationHistory);
 
     if (spies.onSummarizeStartSpy.mock.calls.length === 0) {
-      run = await createRun(600);
+      run = await createRun(1200);
       await runTurn(
         { run, conversationHistory },
         'What is 50 + 50? Calculator.',
@@ -1429,7 +1429,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
     }
 
     if (spies.onSummarizeStartSpy.mock.calls.length === 0) {
-      run = await createRun(400);
+      run = await createRun(1000);
       await runTurn(
         { run, conversationHistory },
         'What is 1+1? Calculator.',

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -1410,7 +1410,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
 
     // Squeeze hard — OpenAI tool-schema overhead is lower than Anthropic,
     // so we need tighter budgets to force pruning + summarization.
-    run = await createRun(1200);
+    run = await createRun(800);
     await runTurn(
       { run, conversationHistory },
       'Calculate 999999 / 7 with calculator. Remind me of prior results too.',
@@ -1419,7 +1419,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
     logTurn('T6', conversationHistory);
 
     if (spies.onSummarizeStartSpy.mock.calls.length === 0) {
-      run = await createRun(1200);
+      run = await createRun(600);
       await runTurn(
         { run, conversationHistory },
         'What is 50 + 50? Calculator.',
@@ -1429,7 +1429,7 @@ const hasOpenAI = hasEnv('OPENAI_API_KEY');
     }
 
     if (spies.onSummarizeStartSpy.mock.calls.length === 0) {
-      run = await createRun(1000);
+      run = await createRun(400);
       await runTurn(
         { run, conversationHistory },
         'What is 1+1? Calculator.',

--- a/src/tools/search/format.test.ts
+++ b/src/tools/search/format.test.ts
@@ -242,6 +242,12 @@ describe('formatResultsForLLM highlight budget', () => {
 });
 
 describe('formatResultsForLLM on a failed search', () => {
+  test.each([null, undefined])('handles %p result data', (results) => {
+    expect(formatResultsForLLM(0, results).output).toBe(
+      'Search failed: Search provider returned no result data'
+    );
+  });
+
   test('tells the model the search failed instead of returning an empty output', () => {
     const results: t.SearchResultData = {
       organic: [],

--- a/src/tools/search/format.ts
+++ b/src/tools/search/format.ts
@@ -11,6 +11,9 @@ const DEFAULT_MAX_LLM_OUTPUT_CHARS = 50000;
  *  this we drop it whole rather than emit a useless sliver. */
 const MIN_PARTIAL_HIGHLIGHT_CHARS = 200;
 
+export const MISSING_SEARCH_RESULT_DATA_ERROR =
+  'Search provider returned no result data';
+
 /** Resolves the per-search highlight budget from config, the
  *  `SEARCH_MAX_LLM_OUTPUT_CHARS` env var, or the default (50,000 chars). */
 export function resolveMaxLLMOutputChars(maxOutputChars?: number): number {
@@ -224,7 +227,7 @@ export function formatResultsForLLM(
 ): { output: string; references: t.ResultReference[] } {
   if (results == null) {
     return {
-      output: 'Search failed: Search provider returned no result data',
+      output: `Search failed: ${MISSING_SEARCH_RESULT_DATA_ERROR}`,
       references: [],
     };
   }

--- a/src/tools/search/format.ts
+++ b/src/tools/search/format.ts
@@ -219,9 +219,16 @@ function formatSource(
 
 export function formatResultsForLLM(
   turn: number,
-  results: t.SearchResultData,
+  results?: t.SearchResultData | null,
   maxOutputChars?: number
 ): { output: string; references: t.ResultReference[] } {
+  if (results == null) {
+    return {
+      output: 'Search failed: Search provider returned no result data',
+      references: [],
+    };
+  }
+
   /** Bound highlight content to the per-search budget before formatting */
   const trimmedHighlights = trimHighlightsToBudget(
     results,

--- a/src/tools/search/outcome.test.ts
+++ b/src/tools/search/outcome.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect } from '@jest/globals';
 import type * as t from './types';
-import { resolveSearchOutcome } from './tool';
+import { normalizeSearchResultData, resolveSearchOutcome } from './tool';
 
 const data = (partial: Partial<t.SearchResultData>): t.SearchResultData =>
   ({ turn: 0, ...partial }) as t.SearchResultData;
 
 describe('resolveSearchOutcome', () => {
+  test.each([null, undefined])('normalizes %p result data as a failure', (result) => {
+    expect(resolveSearchOutcome(normalizeSearchResultData(result), 'oauth')).toBe(
+      'Search failed for "oauth"'
+    );
+  });
+
   it('authors a FAILURE label when the processor caught an error', () => {
     expect(
       resolveSearchOutcome(

--- a/src/tools/search/tool.ts
+++ b/src/tools/search/tool.ts
@@ -21,7 +21,10 @@ import { INTENT_PROPERTY } from '@/tools/intentArg';
 import { createCrwScraper } from './crw-scraper';
 import { expandHighlights } from './highlights';
 import { createSearchMetrics } from './metrics';
-import { formatResultsForLLM } from './format';
+import {
+  formatResultsForLLM,
+  MISSING_SEARCH_RESULT_DATA_ERROR,
+} from './format';
 import { createDefaultLogger } from './utils';
 import { createReranker } from './rerankers';
 import { Constants } from '@/common';
@@ -64,6 +67,12 @@ export function resolveSearchOutcome(
     return undefined;
   }
   return `Found ${count} result${count === 1 ? '' : 's'} for "${query}"`;
+}
+
+export function normalizeSearchResultData(
+  result: t.SearchResultData | null | undefined
+): t.SearchResultData {
+  return result ?? { error: MISSING_SEARCH_RESULT_DATA_ERROR };
 }
 
 /** Distinct rows across the main search's two collections. SearXNG derives
@@ -431,12 +440,13 @@ function createTool({
         }),
       });
       const turn = runnableConfig.toolCall?.turn ?? 0;
+      const resultData = normalizeSearchResultData(searchResult);
       const { output, references } = formatResultsForLLM(
         turn,
-        searchResult,
+        resultData,
         maxOutputChars
       );
-      const data: t.SearchResultData = { turn, ...searchResult, references };
+      const data: t.SearchResultData = { turn, ...resultData, references };
       const outcome = resolveSearchOutcome(data, query);
       return [
         output,


### PR DESCRIPTION
## Summary

I added a runtime guard so a nullish web-search result is represented as a model-visible failure instead of throwing during result formatting.

- Normalize null and undefined payloads into failed `SearchResultData` before formatting and outcome creation.
- Return a stable failure message and no references for nullish result payloads.
- Extend formatter and outcome coverage for both nullish result variants.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `npx jest src/tools/search/format.test.ts src/tools/search/outcome.test.ts --runInBand`
- `npx tsc --noEmit`
- `npx eslint src/tools/search/format.ts src/tools/search/tool.ts src/tools/search/format.test.ts src/tools/search/outcome.test.ts`

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented in any complex areas of my code
- [ ] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes