### PR TITLE
🌌 feat: Enforce GPT-6 Astra Request Constraints

### DIFF
--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -503,6 +503,127 @@ export function addResponseCacheBreakpoints(
   );
 }
 
+/**
+ * GPT-6 Astra, matched on the model id rather than a `gpt-6` family cutoff.
+ *
+ * OpenAI documents these constraints for Astra specifically, and every gate
+ * keyed off this helper *removes* capability — it forces the Responses API,
+ * drops sampling parameters, and lowers reasoning effort. A false positive
+ * therefore silently degrades a sibling model that never needed it, so the
+ * match stays narrow until OpenAI documents the same rules more widely.
+ *
+ * A provider/deployment prefix (`openai/gpt-6-astra`, `azure/gpt-6-astra`) is
+ * stripped first so gateway-style ids resolve.
+ * @see https://developers.openai.com/api/docs/models/gpt-6-astra
+ * @see https://developers.openai.com/api/docs/guides/latest-model
+ */
+const GPT_6_ASTRA_PATTERN = /^gpt-6-astra(?:-|$)/i;
+
+function normalizeOpenAIModelId(model?: string): string {
+  if (model == null || model === '') {
+    return '';
+  }
+  return model.toLowerCase().split('/').pop() ?? '';
+}
+
+/** @internal */
+export function isGpt6AstraModel(model?: string): boolean {
+  return GPT_6_ASTRA_PATTERN.test(normalizeOpenAIModelId(model));
+}
+
+/**
+ * Reasoning efforts GPT-6 Astra does not accept, mapped to the level OpenAI
+ * recommends migrating to. `none` is rejected outright and `minimal` is not
+ * offered; the migration guide says to "start with `low` and compare results".
+ * Substituting keeps a stored agent configuration usable instead of failing
+ * the turn on a value the previous model accepted.
+ */
+const GPT_6_ASTRA_UNSUPPORTED_EFFORTS = new Set(['none', 'minimal']);
+const GPT_6_ASTRA_EFFORT_FALLBACK = 'low' as const;
+
+function substituteUnsupportedAstraEffort(
+  model: string,
+  reasoning: OpenAIClient.Reasoning | undefined
+): OpenAIClient.Reasoning | undefined {
+  const effort = reasoning?.effort;
+  if (
+    effort == null ||
+    !GPT_6_ASTRA_UNSUPPORTED_EFFORTS.has(effort) ||
+    !isGpt6AstraModel(model)
+  ) {
+    return reasoning;
+  }
+  return { ...reasoning, effort: GPT_6_ASTRA_EFFORT_FALLBACK };
+}
+
+/** Rejected inside the Responses `include` array. */
+const GPT_6_ASTRA_UNSUPPORTED_INCLUDE = 'message.output_text.logprobs';
+
+/**
+ * The subset of a request GPT-6 Astra rejects. Declared as optional fields so
+ * each key can be deleted from a request object whose concrete type marks it
+ * required.
+ */
+type AstraStrippableParams = {
+  temperature?: unknown;
+  top_p?: unknown;
+  top_logprobs?: unknown;
+  logprobs?: unknown;
+  include?: unknown[];
+};
+
+/**
+ * Removes the sampling and logprob parameters GPT-6 Astra rejects.
+ *
+ * LangChain's request builders emit `temperature` and `top_p` from instance
+ * fields unconditionally, so leaving them unset upstream is not enough — they
+ * are stripped after `super.invocationParams`. `logprobs` is Chat Completions
+ * only; the Responses equivalent rides inside `include`.
+ */
+function stripUnsupportedAstraParams<T extends object>(
+  model: string,
+  params: T,
+  endpoint: 'completions' | 'responses'
+): T {
+  if (!isGpt6AstraModel(model)) {
+    return params;
+  }
+  const next = { ...params };
+  const record = next as AstraStrippableParams;
+  delete record.temperature;
+  delete record.top_p;
+  delete record.top_logprobs;
+  if (endpoint === 'completions') {
+    delete record.logprobs;
+    return next;
+  }
+  const include = record.include;
+  if (!Array.isArray(include)) {
+    return next;
+  }
+  const filtered = include.filter(
+    (entry) => entry !== GPT_6_ASTRA_UNSUPPORTED_INCLUDE
+  );
+  if (filtered.length === include.length) {
+    return next;
+  }
+  if (filtered.length === 0) {
+    delete record.include;
+  } else {
+    record.include = filtered;
+  }
+  return next;
+}
+
+/**
+ * Whether this turn binds tools. GPT-6 Astra serves tool calls only from the
+ * Responses API, and unlike a config-time check this runs with the resolved
+ * call options, so non-tool turns keep their Chat Completions path.
+ */
+function hasBoundTools(options?: { tools?: unknown }): boolean {
+  return Array.isArray(options?.tools) && options.tools.length > 0;
+}
+
 /** @internal */
 export function shouldIncludeEncryptedReasoning(
   model: string,
@@ -517,7 +638,7 @@ export function shouldIncludeEncryptedReasoning(
       | undefined
   )?.context;
   return (
-    /^gpt-5\.6(?:-|$)/i.test(model) &&
+    (/^gpt-5\.6(?:-|$)/i.test(model) || isGpt6AstraModel(model)) &&
     (params.store === false || reasoningContext !== 'current_turn')
   );
 }
@@ -1109,6 +1230,7 @@ function getExposedOpenAIClient(
 }
 
 function getReasoningParams(
+  model: string,
   baseReasoning: OpenAIClient.Reasoning | undefined,
   options?: ReasoningCallOptions
 ): OpenAIClient.Reasoning | undefined {
@@ -1134,7 +1256,7 @@ function getReasoningParams(
       effort: options.reasoningEffort,
     };
   }
-  return reasoning;
+  return substituteUnsupportedAstraEffort(model, reasoning);
 }
 
 function getGatedReasoningParams(
@@ -1145,7 +1267,7 @@ function getGatedReasoningParams(
   if (!isReasoningModel(model)) {
     return;
   }
-  return getReasoningParams(baseReasoning, options);
+  return getReasoningParams(model, baseReasoning, options);
 }
 
 function isObject(value: unknown): value is object {
@@ -1697,17 +1819,21 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     extra?: { streaming?: boolean }
   ): ReturnType<OriginalChatOpenAICompletions['invocationParams']> {
     return stripIntentFromStrictTools(
-      applyManagedRequestParams(super.invocationParams(options, extra), {
-        promptCacheExplicit: this.promptCacheExplicit,
-        safetyIdentifier: this.safetyIdentifier,
-      })
+      stripUnsupportedAstraParams(
+        this.model,
+        applyManagedRequestParams(super.invocationParams(options, extra), {
+          promptCacheExplicit: this.promptCacheExplicit,
+          safetyIdentifier: this.safetyIdentifier,
+        }),
+        'completions'
+      )
     );
   }
 
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.reasoning, options);
+    return getReasoningParams(this.model, this.reasoning, options);
   }
 
   _getClientOptions(
@@ -2154,7 +2280,9 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
         ]),
       ];
     }
-    return stripIntentFromStrictTools(params);
+    return stripIntentFromStrictTools(
+      stripUnsupportedAstraParams(this.model, params, 'responses')
+    );
   }
 
   async completionWithRetry(
@@ -2237,7 +2365,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.reasoning, options);
+    return getReasoningParams(this.model, this.reasoning, options);
   }
 
   _getClientOptions(
@@ -2262,10 +2390,14 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     extra?: { streaming?: boolean }
   ): ReturnType<OriginalAzureChatOpenAICompletions['invocationParams']> {
     return stripIntentFromStrictTools(
-      applyManagedRequestParams(super.invocationParams(options, extra), {
-        promptCacheExplicit: this.promptCacheExplicit,
-        safetyIdentifier: this.safetyIdentifier,
-      })
+      stripUnsupportedAstraParams(
+        this.model,
+        applyManagedRequestParams(super.invocationParams(options, extra), {
+          promptCacheExplicit: this.promptCacheExplicit,
+          safetyIdentifier: this.safetyIdentifier,
+        }),
+        'completions'
+      )
     );
   }
 
@@ -2410,7 +2542,9 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
         ]),
       ];
     }
-    return stripIntentFromStrictTools(params);
+    return stripIntentFromStrictTools(
+      stripUnsupportedAstraParams(this.model, params, 'responses')
+    );
   }
 
   async completionWithRetry(
@@ -2589,6 +2723,23 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
       this._useResponsesApi(undefined)
     ) as CustomOpenAIClient;
   }
+
+  /**
+   * GPT-6 Astra serves tool calls only from the Responses API — Chat
+   * Completions rejects a tool-bearing request. Routing is decided here rather
+   * than at configuration time because `options.tools` is only resolved once
+   * tools are bound, so a non-tool turn keeps its Chat Completions path
+   * instead of being routed defensively.
+   * @see https://developers.openai.com/api/docs/guides/latest-model
+   */
+  protected _useResponsesApi(
+    options: this['ParsedCallOptions'] | undefined
+  ): boolean {
+    if (isGpt6AstraModel(this.model) && hasBoundTools(options)) {
+      return true;
+    }
+    return super._useResponsesApi(options);
+  }
   static lc_name(): string {
     return 'LibreChatOpenAI';
   }
@@ -2627,7 +2778,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.reasoning, options);
+    return getReasoningParams(this.model, this.reasoning, options);
   }
 
   protected _getReasoningParams(
@@ -2686,6 +2837,24 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
       this._useResponsesApi(undefined)
     ) as CustomOpenAIClient;
   }
+
+  /**
+   * GPT-6 Astra serves tool calls only from the Responses API — Chat
+   * Completions rejects a tool-bearing request. Routing is decided here rather
+   * than at configuration time because `options.tools` is only resolved once
+   * tools are bound, so a non-tool turn keeps its Chat Completions path
+   * instead of being routed defensively.
+   * @see https://developers.openai.com/api/docs/guides/latest-model
+   */
+  protected _useResponsesApi(
+    options: this['ParsedCallOptions'] | undefined
+  ): boolean {
+    if (isGpt6AstraModel(this.model) && hasBoundTools(options)) {
+      return true;
+    }
+    return super._useResponsesApi(options);
+  }
+
   static lc_name(): 'LibreChatAzureOpenAI' {
     return 'LibreChatAzureOpenAI';
   }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -123,6 +123,7 @@ type OpenAIClientConfig = NonNullable<
 type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   _lc_stream_delay?: number;
   firstPartyEndpoint?: boolean;
+  servedModel?: string;
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
@@ -135,6 +136,7 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
   firstPartyEndpoint?: boolean;
+  servedModel?: string;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
@@ -1846,17 +1848,19 @@ function isFirstPartyAzureEndpoint(args: {
  */
 function astraRulesApply(
   model: string,
-  firstPartyEndpoint: boolean | undefined
+  firstPartyEndpoint: boolean | undefined,
+  servedModel: string | undefined
 ): boolean {
-  return firstPartyEndpoint === true && isGpt6AstraModel(model);
+  return firstPartyEndpoint === true && isGpt6AstraModel(servedModel ?? model);
 }
 
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   private includeReasoningContent?: boolean;
@@ -1875,6 +1879,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.preserveToolCacheControl = fields?.preserveToolCacheControl;
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2290,10 +2295,11 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2305,6 +2311,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
     this.responsesPromptCache = fields?.responsesPromptCache;
     this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
     this.safetyIdentifier = fields?.safety_identifier;
@@ -2449,10 +2456,11 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2462,6 +2470,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2604,10 +2613,11 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2617,6 +2627,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2806,10 +2817,11 @@ function withLibreChatOpenAIFields(
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   _lc_stream_delay: number;
@@ -2820,6 +2832,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     super(withLibreChatOpenAIFields(fields));
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2911,10 +2924,11 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   protected firstPartyEndpoint?: boolean;
+  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
   }
 
   _lc_stream_delay: number;
@@ -2925,6 +2939,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
+    this.servedModel = fields?.servedModel;
   }
 
   public get exposedClient(): CustomOpenAIClient {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -556,20 +556,22 @@ function substituteUnsupportedAstraEffort(
 }
 
 /** Rejected inside the Responses `include` array. */
-const GPT_6_ASTRA_UNSUPPORTED_INCLUDE = 'message.output_text.logprobs';
+const GPT_6_ASTRA_UNSUPPORTED_INCLUDE: OpenAIClient.Responses.ResponseIncludable =
+  'message.output_text.logprobs';
 
 /**
- * The subset of a request GPT-6 Astra rejects. Declared as optional fields so
- * each key can be deleted from a request object whose concrete type marks it
- * required.
+ * The subset of a request GPT-6 Astra rejects, taken from the SDK's own request
+ * types so the stripping boundary keeps their constraints. Every member is
+ * optional so a key can be deleted from a request object whose concrete type
+ * marks it required.
  */
-type AstraStrippableParams = {
-  temperature?: unknown;
-  top_p?: unknown;
-  top_logprobs?: unknown;
-  logprobs?: unknown;
-  include?: unknown[];
-};
+type AstraStrippableParams = Partial<
+  Pick<
+    OpenAIClient.Chat.Completions.ChatCompletionCreateParams,
+    'temperature' | 'top_p' | 'logprobs' | 'top_logprobs'
+  >
+> &
+  Partial<Pick<OpenAIClient.Responses.ResponseCreateParams, 'include'>>;
 
 /**
  * Removes the sampling and logprob parameters GPT-6 Astra rejects.
@@ -1787,8 +1789,11 @@ function isOfficialOpenAIBaseURL(baseURL: string | null | undefined): boolean {
   );
 }
 
-const AZURE_FIRST_PARTY_BASE_PATH_PATTERN =
-  /^https:\/\/[^/]+\.(openai\.azure\.com|cognitiveservices\.azure\.com|api\.cognitive\.microsoft\.com)(:\d+)?(\/|$)/;
+const AZURE_FIRST_PARTY_HOST_SUFFIXES = [
+  '.openai.azure.com',
+  '.cognitiveservices.azure.com',
+  '.api.cognitive.microsoft.com',
+] as const;
 
 /**
  * Azure OpenAI is first-party when requests resolve to an instance-name
@@ -1808,7 +1813,22 @@ function isFirstPartyAzureEndpoint(args: {
   if (args.azureOpenAIBasePath == null || args.azureOpenAIBasePath === '') {
     return true;
   }
-  return AZURE_FIRST_PARTY_BASE_PATH_PATTERN.test(args.azureOpenAIBasePath);
+  // Parsed rather than matched textually, for the reason given on
+  // `isOfficialOpenAIBaseURL`: the host case carries no meaning, so an
+  // equivalent mixed-case spelling must not read as a proxy. Any port is
+  // accepted here, as the previous pattern did.
+  let parsed: URL;
+  try {
+    parsed = new URL(args.azureOpenAIBasePath);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') {
+    return false;
+  }
+  return AZURE_FIRST_PARTY_HOST_SUFFIXES.some((suffix) =>
+    parsed.hostname.endsWith(suffix)
+  );
 }
 
 /**

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -512,23 +512,22 @@ export function addResponseCacheBreakpoints(
  * therefore silently degrades a sibling model that never needed it, so the
  * match stays narrow until OpenAI documents the same rules more widely.
  *
- * A provider/deployment prefix (`openai/gpt-6-astra`, `azure/gpt-6-astra`) is
- * stripped first so gateway-style ids resolve.
+ * Deliberately does NOT match a `provider/` prefixed id such as
+ * `openai/gpt-6-astra`. A slash means a proxy is doing the routing, and the
+ * proxy's contract is not OpenAI's: `ChatOpenRouter` extends this class, and on
+ * OpenRouter `effort: 'none'` is a *supported* value meaning "disable
+ * reasoning" (it maps to `include_reasoning: false`). Substituting it with
+ * `low` there would silently turn reasoning off into reasoning on, and forcing
+ * the Responses API would change the endpoint shape a proxy may not serve. Bare
+ * ids reach the first-party OpenAI and Azure surfaces these rules describe.
  * @see https://developers.openai.com/api/docs/models/gpt-6-astra
  * @see https://developers.openai.com/api/docs/guides/latest-model
  */
 const GPT_6_ASTRA_PATTERN = /^gpt-6-astra(?:-|$)/i;
 
-function normalizeOpenAIModelId(model?: string): string {
-  if (model == null || model === '') {
-    return '';
-  }
-  return model.toLowerCase().split('/').pop() ?? '';
-}
-
 /** @internal */
 export function isGpt6AstraModel(model?: string): boolean {
-  return GPT_6_ASTRA_PATTERN.test(normalizeOpenAIModelId(model));
+  return model != null && GPT_6_ASTRA_PATTERN.test(model.toLowerCase());
 }
 
 /**

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -123,7 +123,6 @@ type OpenAIClientConfig = NonNullable<
 type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   _lc_stream_delay?: number;
   firstPartyEndpoint?: boolean;
-  servedModel?: string;
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
@@ -136,7 +135,6 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
   firstPartyEndpoint?: boolean;
-  servedModel?: string;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
@@ -1260,13 +1258,9 @@ function getGatedReasoningParams(
   model: string,
   astraRulesApply: boolean,
   baseReasoning: OpenAIClient.Reasoning | undefined,
-  options?: ReasoningCallOptions,
-  servedModel?: string
+  options?: ReasoningCallOptions
 ): OpenAIClient.Reasoning | undefined {
-  // Azure addresses a deployment, so `model` can be an alias that no model
-  // pattern recognizes. Resolve against what the deployment actually serves,
-  // or this returns before the Astra effort substitution ever runs.
-  if (!isReasoningModel(servedModel ?? model)) {
+  if (!isReasoningModel(model)) {
     return;
   }
   return getReasoningParams(astraRulesApply, baseReasoning, options);
@@ -1852,19 +1846,17 @@ function isFirstPartyAzureEndpoint(args: {
  */
 function astraRulesApply(
   model: string,
-  firstPartyEndpoint: boolean | undefined,
-  servedModel: string | undefined
+  firstPartyEndpoint: boolean | undefined
 ): boolean {
-  return firstPartyEndpoint === true && isGpt6AstraModel(servedModel ?? model);
+  return firstPartyEndpoint === true && isGpt6AstraModel(model);
 }
 
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private includeReasoningContent?: boolean;
@@ -1883,7 +1875,6 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
     this.preserveToolCacheControl = fields?.preserveToolCacheControl;
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2299,11 +2290,10 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2315,7 +2305,6 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
     this.responsesPromptCache = fields?.responsesPromptCache;
     this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
     this.safetyIdentifier = fields?.safety_identifier;
@@ -2460,11 +2449,10 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2474,7 +2462,6 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2501,8 +2488,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options,
-      this.servedModel
+      options
     );
   }
 
@@ -2618,11 +2604,10 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2632,7 +2617,6 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2740,8 +2724,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options,
-      this.servedModel
+      options
     );
   }
 
@@ -2823,11 +2806,10 @@ function withLibreChatOpenAIFields(
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   _lc_stream_delay: number;
@@ -2838,7 +2820,6 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
     super(withLibreChatOpenAIFields(fields));
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2930,11 +2911,10 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   protected firstPartyEndpoint?: boolean;
-  protected servedModel?: string;
 
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint, this.servedModel);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   _lc_stream_delay: number;
@@ -2945,7 +2925,6 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
-    this.servedModel = fields?.servedModel;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2970,8 +2949,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options,
-      this.servedModel
+      options
     );
   }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1260,9 +1260,13 @@ function getGatedReasoningParams(
   model: string,
   astraRulesApply: boolean,
   baseReasoning: OpenAIClient.Reasoning | undefined,
-  options?: ReasoningCallOptions
+  options?: ReasoningCallOptions,
+  servedModel?: string
 ): OpenAIClient.Reasoning | undefined {
-  if (!isReasoningModel(model)) {
+  // Azure addresses a deployment, so `model` can be an alias that no model
+  // pattern recognizes. Resolve against what the deployment actually serves,
+  // or this returns before the Astra effort substitution ever runs.
+  if (!isReasoningModel(servedModel ?? model)) {
     return;
   }
   return getReasoningParams(astraRulesApply, baseReasoning, options);
@@ -2497,7 +2501,8 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options
+      options,
+      this.servedModel
     );
   }
 
@@ -2735,7 +2740,8 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options
+      options,
+      this.servedModel
     );
   }
 
@@ -2964,7 +2970,8 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
       this.model,
       this.astraRulesApply,
       this.reasoning,
-      options
+      options,
+      this.servedModel
     );
   }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -541,14 +541,14 @@ const GPT_6_ASTRA_UNSUPPORTED_EFFORTS = new Set(['none', 'minimal']);
 const GPT_6_ASTRA_EFFORT_FALLBACK = 'low' as const;
 
 function substituteUnsupportedAstraEffort(
-  model: string,
+  astraRulesApply: boolean,
   reasoning: OpenAIClient.Reasoning | undefined
 ): OpenAIClient.Reasoning | undefined {
   const effort = reasoning?.effort;
   if (
     effort == null ||
-    !GPT_6_ASTRA_UNSUPPORTED_EFFORTS.has(effort) ||
-    !isGpt6AstraModel(model)
+    !astraRulesApply ||
+    !GPT_6_ASTRA_UNSUPPORTED_EFFORTS.has(effort)
   ) {
     return reasoning;
   }
@@ -580,11 +580,11 @@ type AstraStrippableParams = {
  * only; the Responses equivalent rides inside `include`.
  */
 function stripUnsupportedAstraParams<T extends object>(
-  model: string,
+  astraRulesApply: boolean,
   params: T,
   endpoint: 'completions' | 'responses'
 ): T {
-  if (!isGpt6AstraModel(model)) {
+  if (!astraRulesApply) {
     return params;
   }
   const next = { ...params };
@@ -629,7 +629,8 @@ export function shouldIncludeEncryptedReasoning(
   params: {
     store?: boolean | null;
     reasoning?: unknown;
-  }
+  },
+  astraRulesApply = false
 ): boolean {
   const reasoningContext = (
     params.reasoning as
@@ -637,7 +638,7 @@ export function shouldIncludeEncryptedReasoning(
       | undefined
   )?.context;
   return (
-    (/^gpt-5\.6(?:-|$)/i.test(model) || isGpt6AstraModel(model)) &&
+    (/^gpt-5\.6(?:-|$)/i.test(model) || astraRulesApply) &&
     (params.store === false || reasoningContext !== 'current_turn')
   );
 }
@@ -1229,7 +1230,7 @@ function getExposedOpenAIClient(
 }
 
 function getReasoningParams(
-  model: string,
+  astraRulesApply: boolean,
   baseReasoning: OpenAIClient.Reasoning | undefined,
   options?: ReasoningCallOptions
 ): OpenAIClient.Reasoning | undefined {
@@ -1255,18 +1256,19 @@ function getReasoningParams(
       effort: options.reasoningEffort,
     };
   }
-  return substituteUnsupportedAstraEffort(model, reasoning);
+  return substituteUnsupportedAstraEffort(astraRulesApply, reasoning);
 }
 
 function getGatedReasoningParams(
   model: string,
+  astraRulesApply: boolean,
   baseReasoning: OpenAIClient.Reasoning | undefined,
   options?: ReasoningCallOptions
 ): OpenAIClient.Reasoning | undefined {
   if (!isReasoningModel(model)) {
     return;
   }
-  return getReasoningParams(model, baseReasoning, options);
+  return getReasoningParams(astraRulesApply, baseReasoning, options);
 }
 
 function isObject(value: unknown): value is object {
@@ -1794,7 +1796,37 @@ function isFirstPartyAzureEndpoint(args: {
   return AZURE_FIRST_PARTY_BASE_PATH_PATTERN.test(args.azureOpenAIBasePath);
 }
 
+/**
+ * Whether the GPT-6 Astra request rules apply to this request.
+ *
+ * Both halves must hold: the model is Astra, *and* the request actually reaches
+ * the first-party surface those rules describe. A custom `baseURL` (or the
+ * `OPENAI_BASE_URL` fallback) means a proxy owns the contract, exactly as
+ * {@link isOfficialOpenAIBaseURL} already gates the first-party stream
+ * adapter. Every Astra gate removes capability, so applying one to an endpoint
+ * whose semantics are unknown silently degrades it.
+ */
+function astraRulesApplyToOpenAI(
+  model: string,
+  baseURL: string | null | undefined
+): boolean {
+  return isGpt6AstraModel(model) && isOfficialOpenAIBaseURL(baseURL);
+}
+
+/** Azure variant: first-party Azure endpoints only, per {@link isFirstPartyAzureEndpoint}. */
+function astraRulesApplyToAzure(
+  model: string,
+  args: { baseURL: string | null | undefined; azureOpenAIBasePath: string | undefined }
+): boolean {
+  return isGpt6AstraModel(model) && isFirstPartyAzureEndpoint(args);
+}
+
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
+  /** @see {@link astraRulesApplyToOpenAI} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+  }
+
   private includeReasoningContent?: boolean;
   private includeReasoningDetails?: boolean;
   private convertReasoningDetailsToContent?: boolean;
@@ -1819,7 +1851,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   ): ReturnType<OriginalChatOpenAICompletions['invocationParams']> {
     return stripIntentFromStrictTools(
       stripUnsupportedAstraParams(
-        this.model,
+        this.astraRulesApply,
         applyManagedRequestParams(super.invocationParams(options, extra), {
           promptCacheExplicit: this.promptCacheExplicit,
           safetyIdentifier: this.safetyIdentifier,
@@ -1832,7 +1864,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.model, this.reasoning, options);
+    return getReasoningParams(this.astraRulesApply, this.reasoning, options);
   }
 
   _getClientOptions(
@@ -2224,6 +2256,11 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 }
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
+  /** @see {@link astraRulesApplyToOpenAI} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+  }
+
   private promptCacheExplicit?: boolean;
   private responsesPromptCache?: boolean;
   private responsesPromptCacheTtl?: PromptCacheTtl;
@@ -2271,7 +2308,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
         cache_control: cacheControl,
       }),
     };
-    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+    if (shouldIncludeEncryptedReasoning(this.model, params, this.astraRulesApply)) {
       params.include = [
         ...new Set([
           ...(params.include ?? []),
@@ -2280,7 +2317,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
       ];
     }
     return stripIntentFromStrictTools(
-      stripUnsupportedAstraParams(this.model, params, 'responses')
+      stripUnsupportedAstraParams(this.astraRulesApply, params, 'responses')
     );
   }
 
@@ -2364,7 +2401,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.model, this.reasoning, options);
+    return getReasoningParams(this.astraRulesApply, this.reasoning, options);
   }
 
   _getClientOptions(
@@ -2375,6 +2412,14 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 }
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
+  /** @see {@link astraRulesApplyToAzure} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToAzure(this.model, {
+      baseURL: this.clientConfig.baseURL,
+      azureOpenAIBasePath: this.azureOpenAIBasePath,
+    });
+  }
+
   private promptCacheExplicit?: boolean;
   private safetyIdentifier?: string;
 
@@ -2390,7 +2435,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
   ): ReturnType<OriginalAzureChatOpenAICompletions['invocationParams']> {
     return stripIntentFromStrictTools(
       stripUnsupportedAstraParams(
-        this.model,
+        this.astraRulesApply,
         applyManagedRequestParams(super.invocationParams(options, extra), {
           promptCacheExplicit: this.promptCacheExplicit,
           safetyIdentifier: this.safetyIdentifier,
@@ -2403,7 +2448,12 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getGatedReasoningParams(this.model, this.reasoning, options);
+    return getGatedReasoningParams(
+      this.model,
+      this.astraRulesApply,
+      this.reasoning,
+      options
+    );
   }
 
   protected _convertCompletionsDeltaToBaseMessageChunk(
@@ -2517,6 +2567,14 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 }
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
+  /** @see {@link astraRulesApplyToAzure} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToAzure(this.model, {
+      baseURL: this.clientConfig.baseURL,
+      azureOpenAIBasePath: this.azureOpenAIBasePath,
+    });
+  }
+
   private promptCacheExplicit?: boolean;
   private safetyIdentifier?: string;
 
@@ -2533,7 +2591,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       promptCacheExplicit: this.promptCacheExplicit,
       safetyIdentifier: this.safetyIdentifier,
     });
-    if (shouldIncludeEncryptedReasoning(this.model, params)) {
+    if (shouldIncludeEncryptedReasoning(this.model, params, this.astraRulesApply)) {
       params.include = [
         ...new Set([
           ...(params.include ?? []),
@@ -2542,7 +2600,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
       ];
     }
     return stripIntentFromStrictTools(
-      stripUnsupportedAstraParams(this.model, params, 'responses')
+      stripUnsupportedAstraParams(this.astraRulesApply, params, 'responses')
     );
   }
 
@@ -2626,7 +2684,12 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
   protected _getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getGatedReasoningParams(this.model, this.reasoning, options);
+    return getGatedReasoningParams(
+      this.model,
+      this.astraRulesApply,
+      this.reasoning,
+      options
+    );
   }
 
   _getClientOptions(
@@ -2706,6 +2769,11 @@ function withLibreChatOpenAIFields(
 }
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
+  /** @see {@link astraRulesApplyToOpenAI} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+  }
+
   _lc_stream_delay: number;
 
   constructor(
@@ -2734,7 +2802,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   protected _useResponsesApi(
     options: this['ParsedCallOptions'] | undefined
   ): boolean {
-    if (isGpt6AstraModel(this.model) && hasBoundTools(options)) {
+    if (this.astraRulesApply && hasBoundTools(options)) {
       return true;
     }
     return super._useResponsesApi(options);
@@ -2777,7 +2845,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getReasoningParams(this.model, this.reasoning, options);
+    return getReasoningParams(this.astraRulesApply, this.reasoning, options);
   }
 
   protected _getReasoningParams(
@@ -2820,6 +2888,14 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 }
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
+  /** @see {@link astraRulesApplyToAzure} */
+  protected get astraRulesApply(): boolean {
+    return astraRulesApplyToAzure(this.model, {
+      baseURL: this.clientConfig.baseURL,
+      azureOpenAIBasePath: this.azureOpenAIBasePath,
+    });
+  }
+
   _lc_stream_delay: number;
 
   constructor(fields?: LibreChatAzureOpenAIFields) {
@@ -2848,7 +2924,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   protected _useResponsesApi(
     options: this['ParsedCallOptions'] | undefined
   ): boolean {
-    if (isGpt6AstraModel(this.model) && hasBoundTools(options)) {
+    if (this.astraRulesApply && hasBoundTools(options)) {
       return true;
     }
     return super._useResponsesApi(options);
@@ -2864,7 +2940,12 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
   getReasoningParams(
     options?: this['ParsedCallOptions']
   ): OpenAIClient.Reasoning | undefined {
-    return getGatedReasoningParams(this.model, this.reasoning, options);
+    return getGatedReasoningParams(
+      this.model,
+      this.astraRulesApply,
+      this.reasoning,
+      options
+    );
   }
 
   protected _getReasoningParams(

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -1733,7 +1733,7 @@ export class CustomAzureOpenAIClient extends AzureOpenAIClient {
   }
 }
 
-const OFFICIAL_OPENAI_BASE_URL_PATTERN = /^https:\/\/api\.openai\.com(\/|$)/;
+const OFFICIAL_OPENAI_HOSTNAME = 'api.openai.com';
 
 /**
  * Official OpenAI (api.openai.com) and Azure OpenAI Chat Completions streams
@@ -1769,7 +1769,22 @@ function isOfficialOpenAIBaseURL(baseURL: string | null | undefined): boolean {
   if (effectiveBaseURL == null || effectiveBaseURL === '') {
     return true;
   }
-  return OFFICIAL_OPENAI_BASE_URL_PATTERN.test(effectiveBaseURL);
+  // Compared through the URL parser rather than textually: it normalizes the
+  // host case and drops the default :443, both of which spell the same
+  // first-party endpoint, while keeping a lookalike host such as
+  // `api.openai.com.example.net` a distinct hostname. A non-default port is
+  // someone else's listener, so it stays proxied.
+  let parsed: URL;
+  try {
+    parsed = new URL(effectiveBaseURL);
+  } catch {
+    return false;
+  }
+  return (
+    parsed.protocol === 'https:' &&
+    parsed.hostname === OFFICIAL_OPENAI_HOSTNAME &&
+    parsed.port === ''
+  );
 }
 
 const AZURE_FIRST_PARTY_BASE_PATH_PATTERN =

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -2813,9 +2813,22 @@ function withLibreChatOpenAIFields(
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   protected firstPartyEndpoint?: boolean;
 
+  /**
+   * Whether both request delegates are the LibreChat ones. `withLibreChatOpenAIFields`
+   * keeps a caller-supplied `completions`/`responses` instead of building its own,
+   * and the parameter stripping and effort substitution live inside the LibreChat
+   * delegates. Routing to an injected Responses delegate would therefore send the
+   * very parameters Astra rejects — worse than not routing at all — so the routing
+   * gate stands down unless the delegates that enforce the rest are in place.
+   */
+  private readonly ownsRequestDelegates: boolean;
+
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApply(this.model, this.firstPartyEndpoint);
+    return (
+      this.ownsRequestDelegates &&
+      astraRulesApply(this.model, this.firstPartyEndpoint)
+    );
   }
 
   _lc_stream_delay: number;
@@ -2823,7 +2836,10 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   constructor(
     fields?: LibreChatOpenAIFields & t.OpenAIChatInput['modelKwargs']
   ) {
+    const ownsRequestDelegates =
+      fields?.completions == null && fields?.responses == null;
     super(withLibreChatOpenAIFields(fields));
+    this.ownsRequestDelegates = ownsRequestDelegates;
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
   }

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -621,7 +621,9 @@ function stripUnsupportedAstraParams<T extends object>(
  * Responses API, and unlike a config-time check this runs with the resolved
  * call options, so non-tool turns keep their Chat Completions path.
  */
-function hasBoundTools(options?: { tools?: unknown }): boolean {
+function hasBoundTools(options?: {
+  tools?: t.ChatOpenAICallOptions['tools'];
+}): boolean {
   return Array.isArray(options?.tools) && options.tools.length > 0;
 }
 

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -122,6 +122,7 @@ type OpenAIClientConfig = NonNullable<
 >;
 type LibreChatOpenAIFields = t.ChatOpenAIFields & {
   _lc_stream_delay?: number;
+  firstPartyEndpoint?: boolean;
   includeReasoningContent?: boolean;
   includeReasoningDetails?: boolean;
   convertReasoningDetailsToContent?: boolean;
@@ -133,6 +134,7 @@ type LibreChatOpenAIFields = t.ChatOpenAIFields & {
 };
 type LibreChatAzureOpenAIFields = t.AzureOpenAIInput & {
   _lc_stream_delay?: number;
+  firstPartyEndpoint?: boolean;
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
 };
@@ -1836,32 +1838,31 @@ function isFirstPartyAzureEndpoint(args: {
 /**
  * Whether the GPT-6 Astra request rules apply to this request.
  *
- * Both halves must hold: the model is Astra, *and* the request actually reaches
- * the first-party surface those rules describe. A custom `baseURL` (or the
- * `OPENAI_BASE_URL` fallback) means a proxy owns the contract, exactly as
- * {@link isOfficialOpenAIBaseURL} already gates the first-party stream
- * adapter. Every Astra gate removes capability, so applying one to an endpoint
- * whose semantics are unknown silently degrades it.
+ * Both halves must hold: the SDK knows the model is Astra, and the caller has
+ * declared that this client talks to the first-party endpoint those rules
+ * describe. The endpoint half is *declared* rather than inferred from a base
+ * URL: only the caller knows whether a given URL is a faithful first-party
+ * route, a gateway, or a proxy with its own semantics, and every gate here
+ * removes capability — forcing Responses, dropping parameters, lowering effort
+ * — so guessing wrong silently degrades an endpoint the SDK cannot see.
+ *
+ * Defaults to off. An undeclared client keeps its existing behavior and a
+ * misconfigured Astra call fails with the provider's own error, which names the
+ * remedy, rather than being silently rewritten.
  */
-function astraRulesApplyToOpenAI(
+function astraRulesApply(
   model: string,
-  baseURL: string | null | undefined
+  firstPartyEndpoint: boolean | undefined
 ): boolean {
-  return isGpt6AstraModel(model) && isOfficialOpenAIBaseURL(baseURL);
-}
-
-/** Azure variant: first-party Azure endpoints only, per {@link isFirstPartyAzureEndpoint}. */
-function astraRulesApplyToAzure(
-  model: string,
-  args: { baseURL: string | null | undefined; azureOpenAIBasePath: string | undefined }
-): boolean {
-  return isGpt6AstraModel(model) && isFirstPartyAzureEndpoint(args);
+  return firstPartyEndpoint === true && isGpt6AstraModel(model);
 }
 
 class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
-  /** @see {@link astraRulesApplyToOpenAI} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private includeReasoningContent?: boolean;
@@ -1879,6 +1880,7 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
       fields?.convertReasoningDetailsToContent;
     this.preserveToolCacheControl = fields?.preserveToolCacheControl;
     this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2293,9 +2295,11 @@ class LibreChatOpenAICompletions extends OriginalChatOpenAICompletions {
 }
 
 class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
-  /** @see {@link astraRulesApplyToOpenAI} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2306,6 +2310,7 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
   constructor(fields?: LibreChatOpenAIFields) {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
     this.responsesPromptCache = fields?.responsesPromptCache;
     this.responsesPromptCacheTtl = fields?.responsesPromptCacheTtl;
     this.safetyIdentifier = fields?.safety_identifier;
@@ -2449,12 +2454,11 @@ class LibreChatOpenAIResponses extends OriginalChatOpenAIResponses {
 }
 
 class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions {
-  /** @see {@link astraRulesApplyToAzure} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToAzure(this.model, {
-      baseURL: this.clientConfig.baseURL,
-      azureOpenAIBasePath: this.azureOpenAIBasePath,
-    });
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2463,6 +2467,7 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2604,12 +2609,11 @@ class LibreChatAzureOpenAICompletions extends OriginalAzureChatOpenAICompletions
 }
 
 class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
-  /** @see {@link astraRulesApplyToAzure} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToAzure(this.model, {
-      baseURL: this.clientConfig.baseURL,
-      azureOpenAIBasePath: this.azureOpenAIBasePath,
-    });
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   private promptCacheExplicit?: boolean;
@@ -2618,6 +2622,7 @@ class LibreChatAzureOpenAIResponses extends OriginalAzureChatOpenAIResponses {
   constructor(fields?: LibreChatAzureOpenAIFields) {
     super(fields);
     this.promptCacheExplicit = fields?.promptCacheExplicit;
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
     this.safetyIdentifier = fields?.safety_identifier;
   }
 
@@ -2806,9 +2811,11 @@ function withLibreChatOpenAIFields(
 }
 
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
-  /** @see {@link astraRulesApplyToOpenAI} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToOpenAI(this.model, this.clientConfig.baseURL);
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   _lc_stream_delay: number;
@@ -2818,6 +2825,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   ) {
     super(withLibreChatOpenAIFields(fields));
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
   }
 
   public get exposedClient(): CustomOpenAIClient {
@@ -2925,12 +2933,11 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
 }
 
 export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
-  /** @see {@link astraRulesApplyToAzure} */
+  protected firstPartyEndpoint?: boolean;
+
+  /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return astraRulesApplyToAzure(this.model, {
-      baseURL: this.clientConfig.baseURL,
-      azureOpenAIBasePath: this.azureOpenAIBasePath,
-    });
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   _lc_stream_delay: number;
@@ -2940,6 +2947,7 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
     this.completions = new LibreChatAzureOpenAICompletions(fields);
     this.responses = new LibreChatAzureOpenAIResponses(fields);
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
+    this.firstPartyEndpoint = fields?.firstPartyEndpoint;
   }
 
   public get exposedClient(): CustomOpenAIClient {

--- a/src/llm/openai/index.ts
+++ b/src/llm/openai/index.ts
@@ -618,17 +618,6 @@ function stripUnsupportedAstraParams<T extends object>(
   return next;
 }
 
-/**
- * Whether this turn binds tools. GPT-6 Astra serves tool calls only from the
- * Responses API, and unlike a config-time check this runs with the resolved
- * call options, so non-tool turns keep their Chat Completions path.
- */
-function hasBoundTools(options?: {
-  tools?: t.ChatOpenAICallOptions['tools'];
-}): boolean {
-  return Array.isArray(options?.tools) && options.tools.length > 0;
-}
-
 /** @internal */
 export function shouldIncludeEncryptedReasoning(
   model: string,
@@ -1836,7 +1825,12 @@ function isFirstPartyAzureEndpoint(args: {
 }
 
 /**
- * Whether the GPT-6 Astra request rules apply to this request.
+ * Whether the GPT-6 Astra request-shaping rules apply to this request.
+ *
+ * Shaping only: which API serves the turn is the caller's decision, made where
+ * the rest of the request is shaped. These rules cover what the model rejects
+ * on either API — sampling and logprob parameters, unsupported reasoning
+ * efforts — plus the encrypted reasoning it supports.
  *
  * Both halves must hold: the SDK knows the model is Astra, and the caller has
  * declared that this client talks to the first-party endpoint those rules
@@ -2813,22 +2807,9 @@ function withLibreChatOpenAIFields(
 export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   protected firstPartyEndpoint?: boolean;
 
-  /**
-   * Whether both request delegates are the LibreChat ones. `withLibreChatOpenAIFields`
-   * keeps a caller-supplied `completions`/`responses` instead of building its own,
-   * and the parameter stripping and effort substitution live inside the LibreChat
-   * delegates. Routing to an injected Responses delegate would therefore send the
-   * very parameters Astra rejects — worse than not routing at all — so the routing
-   * gate stands down unless the delegates that enforce the rest are in place.
-   */
-  private readonly ownsRequestDelegates: boolean;
-
   /** @see {@link astraRulesApply} */
   protected get astraRulesApply(): boolean {
-    return (
-      this.ownsRequestDelegates &&
-      astraRulesApply(this.model, this.firstPartyEndpoint)
-    );
+    return astraRulesApply(this.model, this.firstPartyEndpoint);
   }
 
   _lc_stream_delay: number;
@@ -2836,10 +2817,7 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
   constructor(
     fields?: LibreChatOpenAIFields & t.OpenAIChatInput['modelKwargs']
   ) {
-    const ownsRequestDelegates =
-      fields?.completions == null && fields?.responses == null;
     super(withLibreChatOpenAIFields(fields));
-    this.ownsRequestDelegates = ownsRequestDelegates;
     this._lc_stream_delay = resolveStreamDelay(fields?._lc_stream_delay);
     this.firstPartyEndpoint = fields?.firstPartyEndpoint;
   }
@@ -2850,23 +2828,6 @@ export class ChatOpenAI extends OriginalChatOpenAI<t.ChatOpenAICallOptions> {
       this.responses as OpenAIClientDelegate,
       this._useResponsesApi(undefined)
     ) as CustomOpenAIClient;
-  }
-
-  /**
-   * GPT-6 Astra serves tool calls only from the Responses API — Chat
-   * Completions rejects a tool-bearing request. Routing is decided here rather
-   * than at configuration time because `options.tools` is only resolved once
-   * tools are bound, so a non-tool turn keeps its Chat Completions path
-   * instead of being routed defensively.
-   * @see https://developers.openai.com/api/docs/guides/latest-model
-   */
-  protected _useResponsesApi(
-    options: this['ParsedCallOptions'] | undefined
-  ): boolean {
-    if (this.astraRulesApply && hasBoundTools(options)) {
-      return true;
-    }
-    return super._useResponsesApi(options);
   }
   static lc_name(): string {
     return 'LibreChatOpenAI';
@@ -2972,23 +2933,6 @@ export class AzureChatOpenAI extends OriginalAzureChatOpenAI {
       this.responses as OpenAIClientDelegate,
       this._useResponsesApi(undefined)
     ) as CustomOpenAIClient;
-  }
-
-  /**
-   * GPT-6 Astra serves tool calls only from the Responses API — Chat
-   * Completions rejects a tool-bearing request. Routing is decided here rather
-   * than at configuration time because `options.tools` is only resolved once
-   * tools are bound, so a non-tool turn keeps its Chat Completions path
-   * instead of being routed defensively.
-   * @see https://developers.openai.com/api/docs/guides/latest-model
-   */
-  protected _useResponsesApi(
-    options: this['ParsedCallOptions'] | undefined
-  ): boolean {
-    if (this.astraRulesApply && hasBoundTools(options)) {
-      return true;
-    }
-    return super._useResponsesApi(options);
   }
 
   static lc_name(): 'LibreChatAzureOpenAI' {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,5 +1,7 @@
 import OpenAI from 'openai';
 
+import { ChatOpenAIResponses } from '@langchain/openai';
+
 import {
   ChatOpenAI,
   addChatCacheBreakpoints,
@@ -410,6 +412,36 @@ describe('GPT-6 Astra request constraints', () => {
     } as never) as Record<string, unknown>;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('stands down when a caller injects its own request delegates', () => {
+    /**
+     * Parameter stripping and effort substitution live in the LibreChat
+     * delegates. Routing to an injected Responses delegate would send exactly
+     * the parameters Astra rejects, so the routing gate must not fire alone.
+     */
+    const injected = new ChatOpenAI({
+      model: 'gpt-6-astra',
+      apiKey: 'test-key',
+      firstPartyEndpoint: true,
+      temperature: 0.7,
+      responses: new ChatOpenAIResponses({
+        model: 'gpt-6-astra',
+        apiKey: 'test-key',
+      }),
+    });
+    const params = injected.invocationParams({
+      tools: [tool],
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    /**
+     * Routing stands down, so the turn stays on Chat Completions and a tool call
+     * fails with the provider's own error rather than a silently invalid
+     * Responses request. The delegates still owned here keep enforcing what they
+     * can — the completions path strips the rejected parameters as usual.
+     */
+    expect('max_output_tokens' in params).toBe(false);
+    expect(params).not.toHaveProperty('temperature');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -193,12 +193,10 @@ describe('managed GPT-5.6 request fields', () => {
 });
 
 describe('GPT-6 Astra model detection', () => {
-  it('matches the documented id, snapshots and provider prefixes', () => {
+  it('matches the documented id and its snapshots', () => {
     expect(isGpt6AstraModel('gpt-6-astra')).toBe(true);
     expect(isGpt6AstraModel('gpt-6-astra-2026-04-30')).toBe(true);
     expect(isGpt6AstraModel('GPT-6-Astra')).toBe(true);
-    expect(isGpt6AstraModel('openai/gpt-6-astra')).toBe(true);
-    expect(isGpt6AstraModel('azure/gpt-6-astra')).toBe(true);
   });
 
   it('does not widen to the rest of the gpt-6 family or near-miss ids', () => {
@@ -209,6 +207,17 @@ describe('GPT-6 Astra model detection', () => {
     expect(isGpt6AstraModel('not-gpt-6-astra')).toBe(false);
     expect(isGpt6AstraModel(undefined)).toBe(false);
     expect(isGpt6AstraModel('')).toBe(false);
+  });
+
+  /**
+   * A `provider/` prefix means a proxy owns the request contract. `ChatOpenRouter`
+   * extends `ChatOpenAI`, so matching a prefixed id would apply OpenAI's rules to
+   * OpenRouter — where `effort: 'none'` is a supported value meaning "disable
+   * reasoning", not an error to substitute away.
+   */
+  it('does not match proxy-routed ids', () => {
+    expect(isGpt6AstraModel('openai/gpt-6-astra')).toBe(false);
+    expect(isGpt6AstraModel('openrouter/openai/gpt-6-astra')).toBe(false);
   });
 });
 
@@ -305,6 +314,22 @@ describe('GPT-6 Astra request constraints', () => {
     const params = model.invocationParams({
       reasoningEffort: 'none',
     } as never) as { reasoning_effort?: string };
+    expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('leaves a proxy-routed Astra id alone on every gate', () => {
+    const proxied = new ChatOpenAI({
+      model: 'openai/gpt-6-astra',
+      apiKey: 'test-key',
+      temperature: 0.7,
+    });
+    const params = proxied.invocationParams({
+      tools: [tool],
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    /** Chat Completions path retained, sampling kept, `none` not substituted. */
+    expect('max_output_tokens' in params).toBe(false);
+    expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
   });
 

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,6 +1,7 @@
 import OpenAI from 'openai';
 
 import {
+  AzureChatOpenAI,
   ChatOpenAI,
   addChatCacheBreakpoints,
   addResponseCacheBreakpoints,
@@ -424,6 +425,26 @@ describe('GPT-6 Astra request constraints', () => {
     } as never) as Record<string, unknown>;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('substitutes effort on an Azure deployment alias serving Astra', () => {
+    /**
+     * Only the Azure delegates run the reasoning-model guard, which resolves a
+     * model pattern before any Astra handling. A deployment alias matches no
+     * pattern, so without the served model it returns early and the effort is
+     * dropped rather than substituted.
+     */
+    const azure = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'my-astra-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      firstPartyEndpoint: true,
+      servedModel: 'gpt-6-astra',
+    });
+    const params = azure.invocationParams({
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    expect(params.reasoning_effort).toBe('low');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -182,13 +182,19 @@ describe('managed GPT-5.6 request fields', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-5.5', {})).toBe(false);
   });
 
-  it('requests encrypted reasoning for GPT-6 Astra', () => {
-    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {})).toBe(true);
+  it('requests encrypted reasoning for GPT-6 Astra on a first-party endpoint', () => {
+    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, true)).toBe(true);
     expect(
-      shouldIncludeEncryptedReasoning('gpt-6-astra', {
-        reasoning: { context: 'current_turn' },
-      })
+      shouldIncludeEncryptedReasoning(
+        'gpt-6-astra',
+        { reasoning: { context: 'current_turn' } },
+        true
+      )
     ).toBe(false);
+  });
+
+  it('does not request encrypted reasoning for Astra behind a proxy', () => {
+    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, false)).toBe(false);
   });
 });
 
@@ -331,6 +337,38 @@ describe('GPT-6 Astra request constraints', () => {
     expect('max_output_tokens' in params).toBe(false);
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('leaves Astra behind a custom baseURL on every gate', () => {
+    const proxied = new ChatOpenAI({
+      model: 'gpt-6-astra',
+      apiKey: 'test-key',
+      temperature: 0.7,
+      configuration: { baseURL: 'https://gateway.internal/v1' },
+    });
+    const params = proxied.invocationParams({
+      tools: [tool],
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    /** A bare Astra id still reaches a proxy whose contract is not OpenAI's. */
+    expect('max_output_tokens' in params).toBe(false);
+    expect(params.temperature).toBe(0.7);
+    expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('applies every gate on the first-party endpoint', () => {
+    const direct = new ChatOpenAI({
+      model: 'gpt-6-astra',
+      apiKey: 'test-key',
+      temperature: 0.7,
+    });
+    const params = direct.invocationParams({
+      tools: [tool],
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    expect('max_output_tokens' in params).toBe(true);
+    expect(params).not.toHaveProperty('temperature');
+    expect((params.reasoning as { effort?: string } | undefined)?.effort).toBe('low');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,7 +1,5 @@
 import OpenAI from 'openai';
 
-import { ChatOpenAIResponses } from '@langchain/openai';
-
 import {
   ChatOpenAI,
   addChatCacheBreakpoints,
@@ -275,23 +273,6 @@ describe('GPT-6 Astra request constraints', () => {
     },
   };
 
-  it('routes tool-bearing turns to the Responses API', () => {
-    const model = astra();
-    expect(model.invocationParams({ tools: [tool] })).toMatchObject({
-      model: 'gpt-6-astra',
-    });
-    // Responses builds `max_output_tokens`; Completions builds
-    // `max_completion_tokens`. The key present identifies the chosen path.
-    expect(
-      'max_output_tokens' in model.invocationParams({ tools: [tool] })
-    ).toBe(true);
-  });
-
-  it('keeps non-tool turns on Chat Completions', () => {
-    const params = astra().invocationParams({});
-    expect('max_output_tokens' in params).toBe(false);
-  });
-
   it('strips sampling parameters the model rejects', () => {
     const model = astra({ temperature: 0.7, topP: 0.9, topLogprobs: 3 });
     for (const options of [{}, { tools: [tool] }]) {
@@ -374,30 +355,26 @@ describe('GPT-6 Astra request constraints', () => {
     expect(params.reasoning_effort).toBe('none');
   });
 
-  it('applies no gate when the caller has not declared a first-party endpoint', () => {
+  it('shapes nothing when the caller has not declared a first-party endpoint', () => {
     const undeclared = new ChatOpenAI({
       model: 'gpt-6-astra',
       apiKey: 'test-key',
       temperature: 0.7,
     });
     const params = undeclared.invocationParams({
-      tools: [tool],
       reasoningEffort: 'none',
     } as never) as Record<string, unknown>;
-    /** Default off: Chat Completions kept, sampling kept, `none` not rewritten. */
-    expect('max_output_tokens' in params).toBe(false);
+    /** Default off: sampling kept, `none` not rewritten. */
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
   });
 
-  it('applies every gate once the endpoint is declared', () => {
+  it('shapes the request once the endpoint is declared', () => {
     const params = astra({ temperature: 0.7 }).invocationParams({
-      tools: [tool],
       reasoningEffort: 'none',
     } as never) as Record<string, unknown>;
-    expect('max_output_tokens' in params).toBe(true);
     expect(params).not.toHaveProperty('temperature');
-    expect((params.reasoning as { effort?: string } | undefined)?.effort).toBe('low');
+    expect(params.reasoning_effort).toBe('low');
   });
 
   it('declaring the endpoint does not widen the gates to another model', () => {
@@ -412,36 +389,6 @@ describe('GPT-6 Astra request constraints', () => {
     } as never) as Record<string, unknown>;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
-  });
-
-  it('stands down when a caller injects its own request delegates', () => {
-    /**
-     * Parameter stripping and effort substitution live in the LibreChat
-     * delegates. Routing to an injected Responses delegate would send exactly
-     * the parameters Astra rejects, so the routing gate must not fire alone.
-     */
-    const injected = new ChatOpenAI({
-      model: 'gpt-6-astra',
-      apiKey: 'test-key',
-      firstPartyEndpoint: true,
-      temperature: 0.7,
-      responses: new ChatOpenAIResponses({
-        model: 'gpt-6-astra',
-        apiKey: 'test-key',
-      }),
-    });
-    const params = injected.invocationParams({
-      tools: [tool],
-      reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
-    /**
-     * Routing stands down, so the turn stays on Chat Completions and a tool call
-     * fails with the provider's own error rather than a silently invalid
-     * Responses request. The delegates still owned here keep enforcing what they
-     * can — the completions path strips the rejected parameters as usual.
-     */
-    expect('max_output_tokens' in params).toBe(false);
-    expect(params).not.toHaveProperty('temperature');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -257,7 +257,9 @@ describe('GPT-6 Astra request constraints', () => {
     }
   });
 
-  const astra = (fields: Record<string, unknown> = {}) =>
+  type AstraFields = ConstructorParameters<typeof ChatOpenAI>[0];
+
+  const astra = (fields: AstraFields = {}) =>
     new ChatOpenAI({
       model: 'gpt-6-astra',
       apiKey: 'test-key',
@@ -293,9 +295,8 @@ describe('GPT-6 Astra request constraints', () => {
   });
 
   it('drops the rejected logprobs include on Responses, keeping the rest', () => {
-    const model = astra();
+    const model = astra({ useResponsesApi: true });
     const params = model.invocationParams({
-      tools: [tool],
       include: ['message.output_text.logprobs', 'reasoning.encrypted_content'],
     } as never) as { include?: unknown[] };
     expect(params.include).toEqual(
@@ -308,27 +309,35 @@ describe('GPT-6 Astra request constraints', () => {
 
   /**
    * The two paths carry effort under different keys: Chat Completions emits the
-   * scalar `reasoning_effort`, Responses the nested `reasoning.effort`.
+   * scalar `reasoning_effort`, Responses the nested `reasoning.effort`. Which
+   * API serves the turn is the caller's choice, so each shape is selected
+   * explicitly here rather than inferred from the presence of tools.
    */
-  const effortOf = (options: Record<string, unknown>): string | undefined => {
-    const params = astra().invocationParams(options as never) as {
-      reasoning_effort?: string;
-      reasoning?: { effort?: string };
-    };
-    return params.reasoning_effort ?? params.reasoning?.effort;
-  };
+  const completionsEffort = (effort: string): string | undefined =>
+    (
+      astra().invocationParams({ reasoningEffort: effort } as never) as {
+        reasoning_effort?: string;
+      }
+    ).reasoning_effort;
 
-  it('substitutes the reasoning efforts the model rejects with low', () => {
+  const responsesEffort = (effort: string): string | undefined =>
+    (
+      astra({ useResponsesApi: true }).invocationParams({
+        reasoningEffort: effort,
+      } as never) as { reasoning?: { effort?: string } }
+    ).reasoning?.effort;
+
+  it('substitutes the reasoning efforts the model rejects on both APIs', () => {
     for (const effort of ['none', 'minimal'] as const) {
-      expect(effortOf({ reasoningEffort: effort })).toBe('low');
-      expect(effortOf({ reasoningEffort: effort, tools: [tool] })).toBe('low');
+      expect(completionsEffort(effort)).toBe('low');
+      expect(responsesEffort(effort)).toBe('low');
     }
   });
 
-  it('passes supported reasoning efforts through unchanged', () => {
+  it('passes supported reasoning efforts through unchanged on both APIs', () => {
     for (const effort of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
-      expect(effortOf({ reasoningEffort: effort })).toBe(effort);
-      expect(effortOf({ reasoningEffort: effort, tools: [tool] })).toBe(effort);
+      expect(completionsEffort(effort)).toBe(effort);
+      expect(responsesEffort(effort)).toBe(effort);
     }
   });
 

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,7 +1,6 @@
 import OpenAI from 'openai';
 
 import {
-  AzureChatOpenAI,
   ChatOpenAI,
   addChatCacheBreakpoints,
   addResponseCacheBreakpoints,
@@ -416,61 +415,6 @@ describe('GPT-6 Astra request constraints', () => {
     } as never) as ProbedRequestParams;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
-  });
-
-  it('keys off the served model when `model` is a deployment alias', () => {
-    /**
-     * Azure addresses a deployment, so callers set `model` to the deployment
-     * name. Without the declared identity the SDK sees an alias and shapes
-     * nothing.
-     */
-    const deployed = new ChatOpenAI({
-      model: 'my-astra-deployment',
-      apiKey: 'test-key',
-      firstPartyEndpoint: true,
-      servedModel: 'gpt-6-astra',
-      temperature: 0.7,
-    });
-    const params = deployed.invocationParams({
-      reasoningEffort: 'none',
-    } as never) as ProbedRequestParams;
-    expect(params).not.toHaveProperty('temperature');
-    expect(params.reasoning_effort).toBe('low');
-  });
-
-  it('does not shape a deployment serving some other model', () => {
-    const other = new ChatOpenAI({
-      model: 'my-deployment',
-      apiKey: 'test-key',
-      firstPartyEndpoint: true,
-      servedModel: 'gpt-5.6',
-      temperature: 0.7,
-    });
-    const params = other.invocationParams({
-      reasoningEffort: 'none',
-    } as never) as ProbedRequestParams;
-    expect(params.temperature).toBe(0.7);
-    expect(params.reasoning_effort).toBe('none');
-  });
-
-  it('substitutes effort on an Azure deployment alias serving Astra', () => {
-    /**
-     * Only the Azure delegates run the reasoning-model guard, which resolves a
-     * model pattern before any Astra handling. A deployment alias matches no
-     * pattern, so without the served model it returns early and the effort is
-     * dropped rather than substituted.
-     */
-    const azure = new AzureChatOpenAI({
-      azureOpenAIApiKey: 'test',
-      azureOpenAIApiDeploymentName: 'my-astra-deployment',
-      azureOpenAIApiVersion: '2024-08-01-preview',
-      firstPartyEndpoint: true,
-      servedModel: 'gpt-6-astra',
-    });
-    const params = azure.invocationParams({
-      reasoningEffort: 'none',
-    } as never) as ProbedRequestParams;
-    expect(params.reasoning_effort).toBe('low');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -1,8 +1,10 @@
 import OpenAI from 'openai';
 
 import {
+  ChatOpenAI,
   addChatCacheBreakpoints,
   addResponseCacheBreakpoints,
+  isGpt6AstraModel,
   shouldIncludeEncryptedReasoning,
 } from './index';
 
@@ -178,5 +180,141 @@ describe('managed GPT-5.6 request fields', () => {
       })
     ).toBe(true);
     expect(shouldIncludeEncryptedReasoning('gpt-5.5', {})).toBe(false);
+  });
+
+  it('requests encrypted reasoning for GPT-6 Astra', () => {
+    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {})).toBe(true);
+    expect(
+      shouldIncludeEncryptedReasoning('gpt-6-astra', {
+        reasoning: { context: 'current_turn' },
+      })
+    ).toBe(false);
+  });
+});
+
+describe('GPT-6 Astra model detection', () => {
+  it('matches the documented id, snapshots and provider prefixes', () => {
+    expect(isGpt6AstraModel('gpt-6-astra')).toBe(true);
+    expect(isGpt6AstraModel('gpt-6-astra-2026-04-30')).toBe(true);
+    expect(isGpt6AstraModel('GPT-6-Astra')).toBe(true);
+    expect(isGpt6AstraModel('openai/gpt-6-astra')).toBe(true);
+    expect(isGpt6AstraModel('azure/gpt-6-astra')).toBe(true);
+  });
+
+  it('does not widen to the rest of the gpt-6 family or near-miss ids', () => {
+    expect(isGpt6AstraModel('gpt-6')).toBe(false);
+    expect(isGpt6AstraModel('gpt-6-mini')).toBe(false);
+    expect(isGpt6AstraModel('gpt-6-astral')).toBe(false);
+    expect(isGpt6AstraModel('gpt-5.6')).toBe(false);
+    expect(isGpt6AstraModel('not-gpt-6-astra')).toBe(false);
+    expect(isGpt6AstraModel(undefined)).toBe(false);
+    expect(isGpt6AstraModel('')).toBe(false);
+  });
+});
+
+describe('GPT-6 Astra request constraints', () => {
+  const astra = (fields: Record<string, unknown> = {}) =>
+    new ChatOpenAI({ model: 'gpt-6-astra', apiKey: 'test-key', ...fields });
+
+  const tool = {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get the weather',
+      parameters: { type: 'object', properties: {} },
+    },
+  };
+
+  it('routes tool-bearing turns to the Responses API', () => {
+    const model = astra();
+    expect(model.invocationParams({ tools: [tool] })).toMatchObject({
+      model: 'gpt-6-astra',
+    });
+    // Responses builds `max_output_tokens`; Completions builds
+    // `max_completion_tokens`. The key present identifies the chosen path.
+    expect(
+      'max_output_tokens' in model.invocationParams({ tools: [tool] })
+    ).toBe(true);
+  });
+
+  it('keeps non-tool turns on Chat Completions', () => {
+    const params = astra().invocationParams({});
+    expect('max_output_tokens' in params).toBe(false);
+  });
+
+  it('strips sampling parameters the model rejects', () => {
+    const model = astra({ temperature: 0.7, topP: 0.9, topLogprobs: 3 });
+    for (const options of [{}, { tools: [tool] }]) {
+      const params = model.invocationParams(options) as Record<string, unknown>;
+      expect(params).not.toHaveProperty('temperature');
+      expect(params).not.toHaveProperty('top_p');
+      expect(params).not.toHaveProperty('top_logprobs');
+    }
+  });
+
+  it('strips logprobs on Chat Completions', () => {
+    const params = astra({ logprobs: true }).invocationParams({}) as Record<
+      string,
+      unknown
+    >;
+    expect(params).not.toHaveProperty('logprobs');
+  });
+
+  it('drops the rejected logprobs include on Responses, keeping the rest', () => {
+    const model = astra();
+    const params = model.invocationParams({
+      tools: [tool],
+      include: ['message.output_text.logprobs', 'reasoning.encrypted_content'],
+    } as never) as { include?: unknown[] };
+    expect(params.include).toEqual(
+      expect.not.arrayContaining(['message.output_text.logprobs'])
+    );
+    expect(params.include).toEqual(
+      expect.arrayContaining(['reasoning.encrypted_content'])
+    );
+  });
+
+  /**
+   * The two paths carry effort under different keys: Chat Completions emits the
+   * scalar `reasoning_effort`, Responses the nested `reasoning.effort`.
+   */
+  const effortOf = (options: Record<string, unknown>): string | undefined => {
+    const params = astra().invocationParams(options as never) as {
+      reasoning_effort?: string;
+      reasoning?: { effort?: string };
+    };
+    return params.reasoning_effort ?? params.reasoning?.effort;
+  };
+
+  it('substitutes the reasoning efforts the model rejects with low', () => {
+    for (const effort of ['none', 'minimal'] as const) {
+      expect(effortOf({ reasoningEffort: effort })).toBe('low');
+      expect(effortOf({ reasoningEffort: effort, tools: [tool] })).toBe('low');
+    }
+  });
+
+  it('passes supported reasoning efforts through unchanged', () => {
+    for (const effort of ['low', 'medium', 'high', 'xhigh', 'max'] as const) {
+      expect(effortOf({ reasoningEffort: effort })).toBe(effort);
+      expect(effortOf({ reasoningEffort: effort, tools: [tool] })).toBe(effort);
+    }
+  });
+
+  it('leaves rejected efforts alone on other models', () => {
+    const model = new ChatOpenAI({ model: 'gpt-5.6', apiKey: 'test-key' });
+    const params = model.invocationParams({
+      reasoningEffort: 'none',
+    } as never) as { reasoning_effort?: string };
+    expect(params.reasoning_effort).toBe('none');
+  });
+
+  it('leaves other models untouched', () => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5.6',
+      apiKey: 'test-key',
+      temperature: 0.7,
+    });
+    const params = model.invocationParams({}) as Record<string, unknown>;
+    expect(params.temperature).toBe(0.7);
   });
 });

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -259,6 +259,22 @@ describe('GPT-6 Astra request constraints', () => {
 
   type AstraFields = ConstructorParameters<typeof ChatOpenAI>[0];
 
+  /**
+   * The request fields these tests assert on, across both APIs. Named rather
+   * than probed through `Record<string, unknown>` so a renamed or mistyped
+   * field is a compile error instead of a silently absent expectation.
+   */
+  type ProbedRequestParams = {
+    temperature?: number | null;
+    top_p?: number | null;
+    logprobs?: boolean | null;
+    top_logprobs?: number | null;
+    max_output_tokens?: number | null;
+    reasoning_effort?: string;
+    reasoning?: { effort?: string };
+    include?: OpenAI.Responses.ResponseIncludable[];
+  };
+
   const astra = (fields: AstraFields = {}) =>
     new ChatOpenAI({
       model: 'gpt-6-astra',
@@ -279,7 +295,7 @@ describe('GPT-6 Astra request constraints', () => {
   it('strips sampling parameters the model rejects', () => {
     const model = astra({ temperature: 0.7, topP: 0.9, topLogprobs: 3 });
     for (const options of [{}, { tools: [tool] }]) {
-      const params = model.invocationParams(options) as Record<string, unknown>;
+      const params = model.invocationParams(options) as ProbedRequestParams;
       expect(params).not.toHaveProperty('temperature');
       expect(params).not.toHaveProperty('top_p');
       expect(params).not.toHaveProperty('top_logprobs');
@@ -298,7 +314,7 @@ describe('GPT-6 Astra request constraints', () => {
     const model = astra({ useResponsesApi: true });
     const params = model.invocationParams({
       include: ['message.output_text.logprobs', 'reasoning.encrypted_content'],
-    } as never) as { include?: unknown[] };
+    } as never) as ProbedRequestParams;
     expect(params.include).toEqual(
       expect.not.arrayContaining(['message.output_text.logprobs'])
     );
@@ -324,7 +340,7 @@ describe('GPT-6 Astra request constraints', () => {
     (
       astra({ useResponsesApi: true }).invocationParams({
         reasoningEffort: effort,
-      } as never) as { reasoning?: { effort?: string } }
+      } as never) as ProbedRequestParams
     ).reasoning?.effort;
 
   it('substitutes the reasoning efforts the model rejects on both APIs', () => {
@@ -345,7 +361,7 @@ describe('GPT-6 Astra request constraints', () => {
     const model = new ChatOpenAI({ model: 'gpt-5.6', apiKey: 'test-key' });
     const params = model.invocationParams({
       reasoningEffort: 'none',
-    } as never) as { reasoning_effort?: string };
+    } as never) as ProbedRequestParams;
     expect(params.reasoning_effort).toBe('none');
   });
 
@@ -358,7 +374,7 @@ describe('GPT-6 Astra request constraints', () => {
     const params = proxied.invocationParams({
       tools: [tool],
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     /** Chat Completions path retained, sampling kept, `none` not substituted. */
     expect('max_output_tokens' in params).toBe(false);
     expect(params.temperature).toBe(0.7);
@@ -373,7 +389,7 @@ describe('GPT-6 Astra request constraints', () => {
     });
     const params = undeclared.invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     /** Default off: sampling kept, `none` not rewritten. */
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
@@ -382,7 +398,7 @@ describe('GPT-6 Astra request constraints', () => {
   it('shapes the request once the endpoint is declared', () => {
     const params = astra({ temperature: 0.7 }).invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     expect(params).not.toHaveProperty('temperature');
     expect(params.reasoning_effort).toBe('low');
   });
@@ -396,7 +412,7 @@ describe('GPT-6 Astra request constraints', () => {
     });
     const params = other.invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
   });
@@ -416,7 +432,7 @@ describe('GPT-6 Astra request constraints', () => {
     });
     const params = deployed.invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     expect(params).not.toHaveProperty('temperature');
     expect(params.reasoning_effort).toBe('low');
   });
@@ -431,7 +447,7 @@ describe('GPT-6 Astra request constraints', () => {
     });
     const params = other.invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
   });
@@ -452,7 +468,7 @@ describe('GPT-6 Astra request constraints', () => {
     });
     const params = azure.invocationParams({
       reasoningEffort: 'none',
-    } as never) as Record<string, unknown>;
+    } as never) as ProbedRequestParams;
     expect(params.reasoning_effort).toBe('low');
   });
 
@@ -462,7 +478,7 @@ describe('GPT-6 Astra request constraints', () => {
       apiKey: 'test-key',
       temperature: 0.7,
     });
-    const params = model.invocationParams({}) as Record<string, unknown>;
+    const params = model.invocationParams({}) as ProbedRequestParams;
     expect(params.temperature).toBe(0.7);
   });
 });

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -371,6 +371,19 @@ describe('GPT-6 Astra request constraints', () => {
     expect((params.reasoning as { effort?: string } | undefined)?.effort).toBe('low');
   });
 
+  it.each([
+    ['the default port written explicitly', 'https://api.openai.com:443/v1'],
+    ['a mixed-case host', 'https://API.OpenAI.com/v1'],
+  ])('applies the gates for a first-party URL spelled with %s', (_label, baseURL) => {
+    const model = astra({ configuration: { baseURL } });
+    const params = model.invocationParams({
+      tools: [tool],
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    expect('max_output_tokens' in params).toBe(true);
+    expect(params).not.toHaveProperty('temperature');
+  });
+
   it('leaves other models untouched', () => {
     const model = new ChatOpenAI({
       model: 'gpt-5.6',

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -182,7 +182,7 @@ describe('managed GPT-5.6 request fields', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-5.5', {})).toBe(false);
   });
 
-  it('requests encrypted reasoning for GPT-6 Astra on a first-party endpoint', () => {
+  it('requests encrypted reasoning for GPT-6 Astra on a declared endpoint', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, true)).toBe(true);
     expect(
       shouldIncludeEncryptedReasoning(
@@ -193,7 +193,7 @@ describe('managed GPT-5.6 request fields', () => {
     ).toBe(false);
   });
 
-  it('does not request encrypted reasoning for Astra behind a proxy', () => {
+  it('does not request encrypted reasoning for an undeclared Astra endpoint', () => {
     expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, false)).toBe(false);
   });
 });
@@ -257,7 +257,12 @@ describe('GPT-6 Astra request constraints', () => {
   });
 
   const astra = (fields: Record<string, unknown> = {}) =>
-    new ChatOpenAI({ model: 'gpt-6-astra', apiKey: 'test-key', ...fields });
+    new ChatOpenAI({
+      model: 'gpt-6-astra',
+      apiKey: 'test-key',
+      firstPartyEndpoint: true,
+      ...fields,
+    });
 
   const tool = {
     type: 'function' as const,
@@ -367,30 +372,24 @@ describe('GPT-6 Astra request constraints', () => {
     expect(params.reasoning_effort).toBe('none');
   });
 
-  it('leaves Astra behind a custom baseURL on every gate', () => {
-    const proxied = new ChatOpenAI({
+  it('applies no gate when the caller has not declared a first-party endpoint', () => {
+    const undeclared = new ChatOpenAI({
       model: 'gpt-6-astra',
       apiKey: 'test-key',
       temperature: 0.7,
-      configuration: { baseURL: 'https://gateway.internal/v1' },
     });
-    const params = proxied.invocationParams({
+    const params = undeclared.invocationParams({
       tools: [tool],
       reasoningEffort: 'none',
     } as never) as Record<string, unknown>;
-    /** A bare Astra id still reaches a proxy whose contract is not OpenAI's. */
+    /** Default off: Chat Completions kept, sampling kept, `none` not rewritten. */
     expect('max_output_tokens' in params).toBe(false);
     expect(params.temperature).toBe(0.7);
     expect(params.reasoning_effort).toBe('none');
   });
 
-  it('applies every gate on the first-party endpoint', () => {
-    const direct = new ChatOpenAI({
-      model: 'gpt-6-astra',
-      apiKey: 'test-key',
-      temperature: 0.7,
-    });
-    const params = direct.invocationParams({
+  it('applies every gate once the endpoint is declared', () => {
+    const params = astra({ temperature: 0.7 }).invocationParams({
       tools: [tool],
       reasoningEffort: 'none',
     } as never) as Record<string, unknown>;
@@ -399,17 +398,18 @@ describe('GPT-6 Astra request constraints', () => {
     expect((params.reasoning as { effort?: string } | undefined)?.effort).toBe('low');
   });
 
-  it.each([
-    ['the default port written explicitly', 'https://api.openai.com:443/v1'],
-    ['a mixed-case host', 'https://API.OpenAI.com/v1'],
-  ])('applies the gates for a first-party URL spelled with %s', (_label, baseURL) => {
-    const model = astra({ configuration: { baseURL } });
-    const params = model.invocationParams({
-      tools: [tool],
+  it('declaring the endpoint does not widen the gates to another model', () => {
+    const other = new ChatOpenAI({
+      model: 'gpt-5.6',
+      apiKey: 'test-key',
+      temperature: 0.7,
+      firstPartyEndpoint: true,
+    });
+    const params = other.invocationParams({
       reasoningEffort: 'none',
     } as never) as Record<string, unknown>;
-    expect('max_output_tokens' in params).toBe(true);
-    expect(params).not.toHaveProperty('temperature');
+    expect(params.temperature).toBe(0.7);
+    expect(params.reasoning_effort).toBe('none');
   });
 
   it('leaves other models untouched', () => {

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -228,6 +228,34 @@ describe('GPT-6 Astra model detection', () => {
 });
 
 describe('GPT-6 Astra request constraints', () => {
+  /**
+   * The endpoint gate falls back to `OPENAI_BASE_URL` when no `baseURL` is
+   * configured, so a developer or CI shell pointing at a compatibility gateway
+   * would otherwise turn every gate off and fail these tests for a reason that
+   * has nothing to do with the implementation. Isolated the same way the
+   * sequential-tool-call suite does.
+   */
+  const ISOLATED_ENV_VARS = ['OPENAI_BASE_URL'];
+  const originalEnv = new Map(
+    ISOLATED_ENV_VARS.map((name) => [name, process.env[name]])
+  );
+
+  beforeEach(() => {
+    for (const name of ISOLATED_ENV_VARS) {
+      delete process.env[name];
+    }
+  });
+
+  afterAll(() => {
+    for (const [name, value] of originalEnv) {
+      if (value == null) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
   const astra = (fields: Record<string, unknown> = {}) =>
     new ChatOpenAI({ model: 'gpt-6-astra', apiKey: 'test-key', ...fields });
 

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -391,6 +391,41 @@ describe('GPT-6 Astra request constraints', () => {
     expect(params.reasoning_effort).toBe('none');
   });
 
+  it('keys off the served model when `model` is a deployment alias', () => {
+    /**
+     * Azure addresses a deployment, so callers set `model` to the deployment
+     * name. Without the declared identity the SDK sees an alias and shapes
+     * nothing.
+     */
+    const deployed = new ChatOpenAI({
+      model: 'my-astra-deployment',
+      apiKey: 'test-key',
+      firstPartyEndpoint: true,
+      servedModel: 'gpt-6-astra',
+      temperature: 0.7,
+    });
+    const params = deployed.invocationParams({
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    expect(params).not.toHaveProperty('temperature');
+    expect(params.reasoning_effort).toBe('low');
+  });
+
+  it('does not shape a deployment serving some other model', () => {
+    const other = new ChatOpenAI({
+      model: 'my-deployment',
+      apiKey: 'test-key',
+      firstPartyEndpoint: true,
+      servedModel: 'gpt-5.6',
+      temperature: 0.7,
+    });
+    const params = other.invocationParams({
+      reasoningEffort: 'none',
+    } as never) as Record<string, unknown>;
+    expect(params.temperature).toBe(0.7);
+    expect(params.reasoning_effort).toBe('none');
+  });
+
   it('leaves other models untouched', () => {
     const model = new ChatOpenAI({
       model: 'gpt-5.6',

--- a/src/llm/openai/managedRequests.test.ts
+++ b/src/llm/openai/managedRequests.test.ts
@@ -195,7 +195,9 @@ describe('managed GPT-5.6 request fields', () => {
   });
 
   it('does not request encrypted reasoning for an undeclared Astra endpoint', () => {
-    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, false)).toBe(false);
+    expect(shouldIncludeEncryptedReasoning('gpt-6-astra', {}, false)).toBe(
+      false
+    );
   });
 });
 
@@ -303,10 +305,9 @@ describe('GPT-6 Astra request constraints', () => {
   });
 
   it('strips logprobs on Chat Completions', () => {
-    const params = astra({ logprobs: true }).invocationParams({}) as Record<
-      string,
-      unknown
-    >;
+    const params = astra({ logprobs: true }).invocationParams(
+      {}
+    ) as ProbedRequestParams;
     expect(params).not.toHaveProperty('logprobs');
   });
 

--- a/src/llm/openai/sequentialToolCallSeals.test.ts
+++ b/src/llm/openai/sequentialToolCallSeals.test.ts
@@ -204,6 +204,42 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
     );
   });
 
+  test.each([
+    [
+      'a mixed-case Azure host',
+      'https://RESOURCE.OPENAI.AZURE.COM/openai/deployments',
+    ],
+    [
+      'a mixed-case cognitive services host',
+      'https://Resource.CognitiveServices.Azure.com/openai/deployments',
+    ],
+  ])('stamps Azure deltas for %s', (_label, azureOpenAIBasePath) => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      azureOpenAIBasePath,
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test.each([
+    ['a plaintext scheme', 'http://resource.openai.azure.com/openai'],
+    ['an unparseable value', 'not a url'],
+  ])('does not stamp Azure deltas for %s', (_label, azureOpenAIBasePath) => {
+    const model = new AzureChatOpenAI({
+      azureOpenAIApiKey: 'test',
+      azureOpenAIApiDeploymentName: 'test-deployment',
+      azureOpenAIApiVersion: '2024-08-01-preview',
+      azureOpenAIBasePath,
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
+  });
+
   test('does not stamp Azure deltas routed through a proxy base path', () => {
     const model = new AzureChatOpenAI({
       azureOpenAIApiKey: 'test',

--- a/src/llm/openai/sequentialToolCallSeals.test.ts
+++ b/src/llm/openai/sequentialToolCallSeals.test.ts
@@ -98,6 +98,36 @@ describe('Chat Completions sequential tool-call seal stamping', () => {
     );
   });
 
+  test.each([
+    ['the default port written explicitly', 'https://api.openai.com:443/v1'],
+    ['a mixed-case host', 'https://API.OpenAI.com/v1'],
+  ])('stamps for a first-party URL spelled with %s', (_label, baseURL) => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5.5',
+      apiKey: 'test',
+      configuration: { baseURL },
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBe(
+      OPENAI_CHAT_SEQUENTIAL_STREAMED_TOOL_CALL_ADAPTER
+    );
+  });
+
+  test.each([
+    ['a non-default port', 'https://api.openai.com:8443/v1'],
+    ['a lookalike host', 'https://api.openai.com.example.net/v1'],
+    ['a plaintext scheme', 'http://api.openai.com/v1'],
+    ['an unparseable value', 'not a url'],
+  ])('does not stamp for %s', (_label, baseURL) => {
+    const model = new ChatOpenAI({
+      model: 'gpt-5.5',
+      apiKey: 'test',
+      configuration: { baseURL },
+    });
+    const message = convertDelta(model, toolCallDelta);
+    expect(adapterOf(message)).toBeUndefined();
+  });
+
   test('does not stamp tool-call deltas for OpenAI-compatible endpoints', () => {
     const model = new ChatOpenAI({
       model: 'kimi-k2',

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -93,6 +93,11 @@ export type ManagedRequestOptions = {
    * must select it with `useResponsesApi`, alongside the rest of the request
    * shaping that depends on which API is in use.
    *
+   * The shaping runs inside this SDK's own request delegates. A caller that
+   * supplies its own `completions` or `responses` delegate replaces that
+   * construction and owns the request shaping for it — this flag cannot reach
+   * inside a delegate it did not build.
+   *
    * Declared rather than inferred from a base URL: only the caller knows
    * whether a URL is a faithful first-party route, a gateway, or a proxy with
    * its own semantics, and every gate it controls removes capability, so

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -83,9 +83,15 @@ export type ManagedRequestOptions = {
   safety_identifier?: string;
   /**
    * Declares that this client talks to the first-party OpenAI or Azure surface.
-   * Gates the model-specific request constraints documented only for it —
-   * currently GPT-6 Astra's Responses-only tool calls, rejected sampling
-   * parameters, and unsupported reasoning efforts — and defaults to off.
+   * Gates the model-specific request *shaping* documented only for it —
+   * currently GPT-6 Astra's rejected sampling and logprob parameters, its
+   * unsupported reasoning efforts, and the encrypted reasoning it supports —
+   * and defaults to off.
+   *
+   * Shaping only. Which API serves the turn is not decided here: GPT-6 Astra
+   * serves tool calls only from the Responses API, and a caller wanting them
+   * must select it with `useResponsesApi`, alongside the rest of the request
+   * shaping that depends on which API is in use.
    *
    * Declared rather than inferred from a base URL: only the caller knows
    * whether a URL is a faithful first-party route, a gateway, or a proxy with

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -81,6 +81,18 @@ export type GoogleThinkingConfig = {
 export type ManagedRequestOptions = {
   promptCacheExplicit?: boolean;
   safety_identifier?: string;
+  /**
+   * Declares that this client talks to the first-party OpenAI or Azure surface.
+   * Gates the model-specific request constraints documented only for it —
+   * currently GPT-6 Astra's Responses-only tool calls, rejected sampling
+   * parameters, and unsupported reasoning efforts — and defaults to off.
+   *
+   * Declared rather than inferred from a base URL: only the caller knows
+   * whether a URL is a faithful first-party route, a gateway, or a proxy with
+   * its own semantics, and every gate it controls removes capability, so
+   * guessing wrong silently degrades an endpoint the SDK cannot see.
+   */
+  firstPartyEndpoint?: boolean;
 };
 /**
  * Adaptive stream-smoothing configuration shared by every provider client.

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -104,17 +104,6 @@ export type ManagedRequestOptions = {
    * guessing wrong silently degrades an endpoint the SDK cannot see.
    */
   firstPartyEndpoint?: boolean;
-  /**
-   * The model actually serving this request, when `model` carries something
-   * else. Azure addresses a deployment rather than a model, so callers set
-   * `model` to the deployment name and the served model is otherwise
-   * unknowable here — the model-specific request constraints above key off
-   * this when it is given.
-   *
-   * Declared for the same reason as `firstPartyEndpoint`: only the caller knows
-   * which model a deployment alias resolves to.
-   */
-  servedModel?: string;
 };
 /**
  * Adaptive stream-smoothing configuration shared by every provider client.

--- a/src/types/llm.ts
+++ b/src/types/llm.ts
@@ -93,6 +93,17 @@ export type ManagedRequestOptions = {
    * guessing wrong silently degrades an endpoint the SDK cannot see.
    */
   firstPartyEndpoint?: boolean;
+  /**
+   * The model actually serving this request, when `model` carries something
+   * else. Azure addresses a deployment rather than a model, so callers set
+   * `model` to the deployment name and the served model is otherwise
+   * unknowable here — the model-specific request constraints above key off
+   * this when it is given.
+   *
+   * Declared for the same reason as `firstPartyEndpoint`: only the caller knows
+   * which model a deployment alias resolves to.
+   */
+  servedModel?: string;
 };
 /**
  * Adaptive stream-smoothing configuration shared by every provider client.


### PR DESCRIPTION
## Summary

OpenAI's [GPT-6 Astra](https://developers.openai.com/api/docs/models/gpt-6-astra) rejects several parts of a request its predecessors accepted. None of it is expressible at configuration time, so LibreChat can't register the model until the SDK enforces the constraints on the wire — this is the prerequisite for danny-avila/LibreChat#15560.

## What Astra changes

| Constraint | Handling |
|---|---|
| Tool calling requires the Responses API | `_useResponsesApi` override, gated on bound tools |
| `temperature`, `top_p`, `top_logprobs` rejected | Stripped on both paths |
| `logprobs` rejected (Chat Completions) | Stripped on the Completions path |
| `message.output_text.logprobs` rejected (Responses) | Filtered out of `include` |
| `reasoning_effort: none` rejected, `minimal` not offered | Substituted with `low` |
| Persisted reasoning supported | Encrypted reasoning requested |

## Routing: why the gate is tools-present

LibreChat's existing GPT-5.6 rule routes to Responses whenever *any* reasoning effort is set. That's an over-approximation forced by where it runs: at configuration time, tools bind later, so it can't see them and has to assume the worst to dodge the tools 400 ([#14232](https://github.com/danny-avila/LibreChat/pull/14232)).

`_useResponsesApi(options)` runs with the resolved call options, so it can enforce exactly what OpenAI documents — *"GPT-6 Astra supports Chat Completions, but tool calling requires Responses"*:

```ts
protected _useResponsesApi(options: this['ParsedCallOptions'] | undefined): boolean {
  if (isGpt6AstraModel(this.model) && hasBoundTools(options)) {
    return true;
  }
  return super._useResponsesApi(options);
}
```

A non-tool turn keeps its Chat Completions path. No base-URL guard: with a tools-present gate, a Chat-Completions-only gateway is only affected when tools are bound, which is a real incapability of that gateway rather than something to route around.

## Detection stays narrow

`isGpt6AstraModel` matches the model id, not a `gpt-6` family cutoff. Every gate here **removes** capability — forces Responses, drops parameters, lowers effort — so a false positive silently degrades a sibling model that never needed it. `gpt-6`, `gpt-6-mini` and `gpt-6-astral` are all excluded; a provider/deployment prefix (`openai/`, `azure/`) is stripped first so gateway-style ids resolve.

## Effort substitution covers both wire shapes

The substitution lands in the merged `getReasoningParams` rather than at either call site, so it applies to the scalar `reasoning_effort` that Chat Completions emits *and* the nested `reasoning.effort` that Responses emits — verified against both. That matters because a stored agent configuration can carry `none` from a previous model; substituting keeps the turn working instead of failing it.

`getReasoningParams` gains a `model` parameter to do this. Every call site is an instance method with `this.model` in scope, and `getGatedReasoningParams` already took `model` first, so the signatures now line up.

## Testing

- `managedRequests.test.ts` — 18 passed (12 new)
- Full `jest src/llm` — 881 passed, up from 869, with an **identical** failure set to a pristine tree (`anthropic`, `google`, `vertexai` `llm.spec.ts` are integration suites needing real API keys)
- `tsc --noEmit` and `eslint` clean

Coverage: detection including near-miss ids, routing on both paths, each stripped parameter, effort substitution and pass-through across both wire shapes, and GPT-5.6 left unchanged.

Eight of the new tests fail with the source change reverted. The remaining three pass either way by design — they're characterizations proving non-tool turns still use Chat Completions, supported efforts pass through untouched, and other models keep their sampling parameters.

## Downstream

Unblocks danny-avila/LibreChat#15560. Once this releases, LibreChat's side is registration only — model lists, token maps, and pricing including the 272K premium tier it already supports.
