### PR TITLE
🔐 chore: Pin `@langchain/langgraph-checkpoint` to the Patched Serializer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@anthropic-ai/sandbox-runtime": "^0.0.67",
         "@anthropic-ai/vertex-sdk": "^0.12.0",
         "@eslint/js": "^10.0.1",
-        "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
+        "@langchain/langgraph-checkpoint-mongodb": "^1.4.1",
         "@swc/core": "^1.6.13",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.13.1",
@@ -2679,9 +2679,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
-      "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+      "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2691,9 +2691,9 @@
       }
     },
     "node_modules/@langchain/langgraph-checkpoint-mongodb": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint-mongodb/-/langgraph-checkpoint-mongodb-1.4.0.tgz",
-      "integrity": "sha512-CFTrK7LrhyjotGn2YEyqYQIT1YDnw8rGC3ZTApkPvLHAW1BpVwC5N2WhA/StGOCqbCNx1HZkskLtBFhjkcKGwA==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint-mongodb/-/langgraph-checkpoint-mongodb-1.4.1.tgz",
+      "integrity": "sha512-bAjOijeERW0dKV0x43AbuYO9HUjwM2i1JQFuKF2HmaZgHWBNtUQwKzHuQWeepPfbP82xYEzmLcz9zAe6suCYxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2704,7 +2704,7 @@
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.44",
-        "@langchain/langgraph-checkpoint": "^1.0.0"
+        "@langchain/langgraph-checkpoint": "^1.1.4"
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
@@ -4734,9 +4734,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4754,9 +4751,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4774,9 +4768,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4794,9 +4785,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4814,9 +4802,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4834,9 +4819,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5838,9 +5820,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5855,9 +5834,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5872,9 +5848,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5889,9 +5862,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5906,9 +5876,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5923,9 +5890,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5940,9 +5904,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5957,9 +5918,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5974,9 +5932,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5991,9 +5946,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -280,6 +280,7 @@
   },
   "overrides": {
     "@langchain/openai": "$@langchain/openai",
+    "@langchain/langgraph-checkpoint": "^1.1.5",
     "@browserbasehq/stagehand": {
       "openai": "$openai"
     },
@@ -339,7 +340,7 @@
     "@anthropic-ai/sandbox-runtime": "^0.0.67",
     "@anthropic-ai/vertex-sdk": "^0.12.0",
     "@eslint/js": "^10.0.1",
-    "@langchain/langgraph-checkpoint-mongodb": "^1.4.0",
+    "@langchain/langgraph-checkpoint-mongodb": "^1.4.1",
     "@swc/core": "^1.6.13",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.13.1",


### PR DESCRIPTION
## What

Lifts the transitive `@langchain/langgraph-checkpoint` floor from **1.1.3 → 1.1.5** via an `overrides` entry, and moves the dev-only `@langchain/langgraph-checkpoint-mongodb` to `^1.4.1`.

`@langchain/langgraph` stays at **1.4.8** — see [Why not the runtime bump](#why-not-the-runtime-bump).

```
@langchain/langgraph                  1.4.8   (unchanged)
@langchain/langgraph-sdk              1.9.28  (unchanged)
@langchain/langgraph-checkpoint       1.1.3 → 1.1.5
@langchain/langgraph-checkpoint-mongodb  1.4.0 → 1.4.1  (dev)
```

## Why

`JsonPlusSerializer` up to 1.1.3 resolved an `lc:2` constructor record by matching the *trailing* segment of a payload-supplied `id`, then invoked a payload-supplied static `method` with payload-supplied `args`:

```js
const constructorName = revivedObj.id[revivedObj.id.length - 1];
// ...switch to Set | Map | RegExp | Error | Uint8Array...
if (revivedObj.method) return constructor[revivedObj.method](...revivedObj.args || []);
```

Checkpoint blobs are data, not instructions — and for any host running a durable checkpointer they are reachable by whoever can write to that store. 1.1.4/1.1.5 replace the name lookup with a validated allowlist and keep everything else inert.

Reproduced against both versions with a record carrying `id: ['not','real','Uint8Array'], method: 'of'`:

```
1.1.3  INVOKED Uint8Array.of() from the payload -> [1,2,3]
1.1.5  inert, returned as plain data
```

Legitimate values still round-trip on 1.1.5 — `Set`, `Map`, `RegExp`, `Uint8Array` and `Error` all reconstruct with values intact.

There is **no published npm advisory** for this (the registry's bulk advisories endpoint returns `{}` for all three packages), so this is hardening rather than a CVE fix. The equivalent Python-side issues do carry advisories.

## Why an override rather than a bump

`@langchain/langgraph@1.4.8` already declares `@langchain/langgraph-checkpoint: ^1.1.3`, so 1.1.5 satisfies its range untouched — this is a lockfile lift with no change to the graph runtime. The `overrides` block is where the other transitive floors here are held (`@opentelemetry/core`, `js-yaml`, `minimatch`), so it follows the existing convention and states the requirement explicitly rather than leaving it to resolution order.

Note that consumers installing `@librechat/agents` were already resolving the caret to 1.1.5 themselves; the stale pin only affected our own installs and CI. `@langchain/langgraph-checkpoint-mongodb@1.4.1` is byte-identical to 1.4.0 apart from raising its peer to `^1.1.4` — upstream's own way of requiring the patched serializer.

## Why not the runtime bump

`@langchain/langgraph` 1.4.13 is available and carries two fixes we'd want — `mergeCallbacks` deduping handlers by identity (1.4.11), and `context` values kept out of tracer metadata (1.4.10, inert for us since we don't use the runtime `context` API).

It is being held back deliberately. **1.4.9 changes the `Topic` checkpoint shape** to a flat values list for non-unique topics. Restore reads the legacy `[seen, values]` form, so upgrading is safe forward — but the reverse does not hold:

```
1.4.13 reads a 1.4.8 checkpoint   -> ok
1.4.8  reads a 1.4.13 checkpoint  -> TypeError: object is not iterable
1.4.8  reads a 1.4.13 EMPTY one   -> values undefined, isAvailable() throws
```

Empty checkpoints break too, so once a host writes on 1.4.9+ every persisted thread becomes unreadable on rollback. With `durability: 'exit'` and a Mongo checkpointer those checkpoints exist. That bump is a one-way door for persisted threads and needs its own migration plan, so it is out of scope here.

Verified the format is untouched by this PR — `Topic` still checkpoints `[[], [...]]`.

Worth noting for whenever the runtime bump does happen: the 1.4.11 `mergeCallbacks` fix only dedupes the CallbackManager+CallbackManager branch. The array branches still `concat` without deduping, so the existing duplicate-callback guards in `run.ts` should stay.

## Testing

| Check | Result |
| --- | --- |
| `jest` (full suite) | 5046 passed, identical to the pre-change baseline |
| `tsc --noEmit` | clean |
| `npm run build` | clean |

The 4 failing suites (`llm/anthropic`, `llm/google`, `llm/vertexai`, `durability-checkpoint.integration`) fail identically before and after — they need live provider credentials and a downloadable mongod binary, neither available in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmCVzbegmucsDzY7TGK3Hc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WmCVzbegmucsDzY7TGK3Hc)_