### PR TITLE
🔦 fix: Log the Cause Behind the Sanitized Code API Authorization Error

### DIFF
--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -119,8 +119,7 @@ export const CodeExecutionToolSchema = {
   required: ['lang', 'code'],
 } as const;
 
-export const CODE_API_EXPECTED_PROFILE_HEADER =
-  'X-CodeAPI-Expected-Profile';
+export const CODE_API_EXPECTED_PROFILE_HEADER = 'X-CodeAPI-Expected-Profile';
 
 type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
@@ -149,10 +148,28 @@ const SAFE_CODE_API_EXECUTION_ERROR_DETAILS: Readonly<
 };
 
 export class CodeApiRequestError extends Error {
-  constructor(message = CODE_API_UNAVAILABLE_ERROR_MESSAGE) {
+  constructor(
+    message = CODE_API_UNAVAILABLE_ERROR_MESSAGE,
+    options?: { cause?: unknown }
+  ) {
     super(message);
     this.name = 'CodeApiRequestError';
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
   }
+}
+
+const MAX_LOGGED_RESPONSE_BODY_CHARS = 512;
+
+/** Keeps a pathological error body from dominating the log line. */
+function truncateCodeApiResponseBody(responseBody: string): string {
+  if (responseBody === '') {
+    return '<empty body>';
+  }
+  return responseBody.length <= MAX_LOGGED_RESPONSE_BODY_CHARS
+    ? responseBody
+    : `${responseBody.slice(0, MAX_LOGGED_RESPONSE_BODY_CHARS)}... [truncated]`;
 }
 
 function getRetryAfterSeconds(responseBody: string): number | undefined {
@@ -230,8 +247,20 @@ export async function resolveCodeApiAuthHeaders(
     try {
       const resolvedHeaders = await authHeaders();
       return resolvedHeaders;
-    } catch {
-      throw new CodeApiRequestError(CODE_API_AUTHORIZATION_ERROR_MESSAGE);
+    } catch (error) {
+      /* The model-facing message stays credential-free by design, so this is
+       * the only place the real reason survives. Discarding it made the two
+       * paths that share that message — a callback that threw before any
+       * request was sent, and a Code API that answered 401/403 — impossible
+       * to tell apart from production data. */
+      // eslint-disable-next-line no-console
+      console.error(
+        '[CodeExecutor] Code API auth-header resolution failed; no request was sent',
+        error
+      );
+      throw new CodeApiRequestError(CODE_API_AUTHORIZATION_ERROR_MESSAGE, {
+        cause: error,
+      });
     }
   }
   return authHeaders;
@@ -251,8 +280,8 @@ export function addCodeApiExecutionProfileHeader(
 }
 
 export async function buildCodeApiHttpErrorMessage(
-  _method: string,
-  _endpoint: string,
+  method: string,
+  endpoint: string,
   response: { status: number; text: () => Promise<string> }
 ): Promise<string> {
   let responseBody = '';
@@ -261,6 +290,16 @@ export async function buildCodeApiHttpErrorMessage(
   } catch {
     responseBody = '';
   }
+  /* Everything below collapses a status and a body into one of five fixed
+   * sentences the model is allowed to see. The operator needs what the model
+   * must not, and this is the last frame that still holds it. Rate limiting
+   * is the one routine rejection here, so it stays a warning. */
+  // eslint-disable-next-line no-console
+  const log = response.status === 429 ? console.warn : console.error;
+  log(
+    `[CodeExecutor] Code API rejected ${method} ${endpoint} with ${response.status}: ` +
+      truncateCodeApiResponseBody(responseBody)
+  );
   if (response.status === 429) {
     const retryAfterSeconds = getRetryAfterSeconds(responseBody);
     return retryAfterSeconds != null

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -1,8 +1,21 @@
 import fetch from 'node-fetch';
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { RequestInit } from 'node-fetch';
 import type * as t from '@/types';
+import {
+  createCodeExecutionTool,
+  resolveCodeApiAuthHeaders,
+  buildCodeApiHttpErrorMessage,
+  CODE_API_AUTHORIZATION_ERROR_MESSAGE,
+} from '../CodeExecutor';
 import {
   createLocalProgrammaticToolCallingTool,
   createLocalBashProgrammaticToolCallingTool,
@@ -18,10 +31,6 @@ import {
   makeRequest,
 } from '../ProgrammaticToolCalling';
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
-import {
-  createCodeExecutionTool,
-  resolveCodeApiAuthHeaders,
-} from '../CodeExecutor';
 import { createBashExecutionTool } from '../BashExecutor';
 
 jest.mock('node-fetch', () => ({
@@ -224,18 +233,12 @@ describe('CodeAPI auth header injection', () => {
       statefulSessions: true,
     });
 
-    await defaultTool.invoke(
-      { lang: 'py', code: 'print(1)' },
-      {
-        toolCall: { _runtime_session_hint: 'graph-wide-hint' },
-      } as unknown as RunnableConfig
-    );
-    await statefulTool.invoke(
-      { lang: 'py', code: 'print(1)' },
-      {
-        toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
-      } as unknown as RunnableConfig
-    );
+    await defaultTool.invoke({ lang: 'py', code: 'print(1)' }, {
+      toolCall: { _runtime_session_hint: 'graph-wide-hint' },
+    } as unknown as RunnableConfig);
+    await statefulTool.invoke({ lang: 'py', code: 'print(1)' }, {
+      toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
+    } as unknown as RunnableConfig);
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       'https://code-default.example.com/exec'
@@ -329,12 +332,9 @@ describe('CodeAPI auth header injection', () => {
       statefulSessions: true,
     });
 
-    await tool.invoke(
-      { command: 'echo 1' },
-      {
-        toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
-      } as unknown as RunnableConfig
-    );
+    await tool.invoke({ command: 'echo 1' }, {
+      toolCall: { _runtime_session_hint: 'wrong-agent-hint' },
+    } as unknown as RunnableConfig);
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       'https://code-stateful.example.com/exec'
@@ -1022,6 +1022,95 @@ describe('CodeAPI auth header injection', () => {
         }),
       })
     );
+  });
+
+  describe('the cause behind the sanitized authorization error', () => {
+    /**
+     * Two unrelated situations answer the model with one sentence: an
+     * auth-header callback that threw before any request was sent, and a Code
+     * API that answered 401/403. The sentence must stay credential-free, so
+     * the log and the thrown error's `cause` are the only places the real
+     * reason can survive. Without both, a recurring production failure has no
+     * attributable root cause — an upstream service logging nothing is equally
+     * consistent with either path.
+     */
+    let errorSpy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      errorSpy.mockRestore();
+    });
+
+    it('logs and preserves the auth-header failure it replaces', async () => {
+      const underlying = new Error(
+        'credential helper failed for secret codeapi-signing-key in namespace internal-auth'
+      );
+
+      const error = await resolveCodeApiAuthHeaders(async () => {
+        throw underlying;
+      }).catch((caught: unknown) => caught);
+
+      expect((error as Error).message).toBe(
+        CODE_API_AUTHORIZATION_ERROR_MESSAGE
+      );
+      expect((error as Error).cause).toBe(underlying);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('auth-header resolution failed'),
+        underlying
+      );
+    });
+
+    it('logs the status, route and body behind an HTTP rejection', async () => {
+      const message = await buildCodeApiHttpErrorMessage(
+        'POST',
+        'https://code.example.com/exec',
+        {
+          status: 403,
+          text: async () => '{"error":"Unauthorized"}',
+        }
+      );
+
+      expect(message).toBe(CODE_API_AUTHORIZATION_ERROR_MESSAGE);
+      const logged = String(errorSpy.mock.calls[0]?.[0]);
+      expect(logged).toContain('403');
+      expect(logged).toContain('POST https://code.example.com/exec');
+      expect(logged).toContain('Unauthorized');
+    });
+
+    it('reports a rate limit as a warning, not an error', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await buildCodeApiHttpErrorMessage(
+        'POST',
+        'https://code.example.com/exec',
+        {
+          status: 429,
+          text: async () => '{"error":"rate_limited","retry_after_seconds":5}',
+        }
+      );
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain('429');
+      warnSpy.mockRestore();
+    });
+
+    it('truncates a pathological error body instead of logging all of it', async () => {
+      await buildCodeApiHttpErrorMessage(
+        'POST',
+        'https://code.example.com/exec',
+        {
+          status: 500,
+          text: async () => 'x'.repeat(4096),
+        }
+      );
+
+      const logged = String(errorSpy.mock.calls[0]?.[0]);
+      expect(logged).toContain('[truncated]');
+      expect(logged.length).toBeLessThan(1024);
+    });
   });
 
   it('preserves the legacy fetchSessionFiles proxy/auth argument order', async () => {


### PR DESCRIPTION
## The problem

`Code execution is not authorized. Verify access before trying again.` is produced by two entirely unrelated situations, and until now neither left a trace anywhere:

```ts
// the dynamic auth-header callback threw; the HTTP request is never sent
if (typeof authHeaders === 'function') {
  try { return await authHeaders(); }
  catch { throw new CodeApiRequestError(CODE_API_AUTHORIZATION_ERROR_MESSAGE); }
}

// the Code API answered with a real HTTP status
if (response.status === 401 || response.status === 403) {
  return CODE_API_AUTHORIZATION_ERROR_MESSAGE;
}
```

The bare `catch {}` discards the caught error entirely — not logged, not counted, not attached to the thrown error. Because it has no binding, this repo's own `preserve-caught-error` rule had nothing to bind to and stayed quiet, which is part of why it survived. The 401/403 branch likewise recorded neither the status it saw nor the body; `buildCodeApiHttpErrorMessage`'s `_method` and `_endpoint` parameters were unused, underscore-prefixed to say so. Downstream, `src/stream.ts` renders whatever survives as `Error: ${result.errorMessage}\n Please fix your mistakes.`, so the operator and the model see the same detail-free sentence.

## Why it matters

A production LibreChat instance hit this four times in a 1h45m window, in a tight cluster — both executions following each `create_file` call, zero failures anywhere else — and **it could not be attributed to either branch.** The upstream Code API logged nothing at any of the four timestamps. That is exactly what the callback path predicts, since in that branch no request is sent (this repo's own test asserts `expect(fetchMock).not.toHaveBeenCalled()`), and it is equally what a service that simply does not log rejected requests looks like. There is no way to tell from production data, so a recurring, user-visible failure has no root cause available without adding instrumentation and waiting for it to recur.

The failure is also actively misdirecting: the message points at credentials, so the agent's own recovery attempts — retrying, simplifying the script, switching tools — were all aimed at the wrong thing, and it lost code execution for the remainder of the turn immediately after producing a file it wanted to validate.

## What this changes

**Not the model-facing strings.** Every sentence the model can see is byte-identical, and the test asserting that neither the secret name nor the namespace reaches the model still passes. The sanitization is correct and stays. What changes is that the operator now gets what the model must not:

- `resolveCodeApiAuthHeaders` logs the callback failure with the original error, and re-throws `CodeApiRequestError` carrying it as `cause`. A host that wants to route it through its own logger now can.
- `buildCodeApiHttpErrorMessage` logs method, route, status, and the response body truncated to 512 chars. Its two parameters lose their underscores because they are finally used.
- 429 is the one routine rejection on this path, so it logs at `warn`; everything else at `error`.

`console.error` / `console.warn` follows what `CodeExecutor.ts` already does for its no-injected-files notice — these are free functions with six call sites across three modules and no logger in scope, and threading one through would be a far larger change for a diagnostic line.

## Tests

Four added under `the cause behind the sanitized authorization error`, all failing on `main`:

- the auth-header failure is logged and preserved as `cause`, while the message stays the sanitized one;
- an HTTP rejection logs its status, route and body while still returning the sanitized string;
- a 429 logs at warn, not error;
- a 4096-char error body is truncated rather than logged whole.

`npx jest src/tools/__tests__/` — 1115 passed, 23 skipped. `tsc -p tsconfig.json --noEmit` clean, `eslint` clean (the 3 warnings on `CodeExecutor.ts` are pre-existing on `main`), `check:circular-deps` clean. A few unrelated reflows in the diff are the repo's own pre-commit `prettier --write` acting on the touched files.

## Follow-up, not fixed here

The clustered failure that prompted this is still unattributed by design — that is the point of the change. Two adjacent LibreChat-side defects found in the same investigation are fixed in danny-avila/LibreChat#15593. Once this ships, one recurrence carries enough signal to close the original report.