### PR TITLE
🎈 fix: Pass Through Search Chunks Without a Reranker

### DIFF
--- a/src/tools/search/no-reranker.test.ts
+++ b/src/tools/search/no-reranker.test.ts
@@ -1,0 +1,193 @@
+/**
+ * `rerankerType: 'none'` is a schema-valid opt-out, but it used to make the
+ * web search useless: `createReranker` returns `undefined` for it, so
+ * `getHighlights` returned `undefined`, so `expandHighlights` found a source
+ * with content but no highlights and stripped the content. The model received
+ * links and no text.
+ *
+ * The scraped chunks now pass through unscored via `getDefaultRanking` — the
+ * same ranking every reranker already falls back to when it fails.
+ */
+import type * as t from './types';
+import { createSourceProcessor } from './search';
+import { expandHighlights } from './highlights';
+import { createSearchMetrics } from './metrics';
+import { BaseReranker, getDefaultRanking } from './rerankers';
+
+const noopLog = (..._args: unknown[]): void => {};
+const silentLogger = {
+  error: noopLog,
+  warn: noopLog,
+  info: noopLog,
+  debug: noopLog,
+} as t.Logger;
+
+const link = 'https://example.com/article';
+const MARKER = 'THE ANSWER THE USER ASKED FOR IS FORTY-TWO.';
+const FILLER = 'lorem ipsum dolor sit amet consectetur adipiscing elit\n';
+
+/** Marker at the very top, inside the first few chunks. */
+const makeContent = (): string => `${MARKER}\n${FILLER.repeat(40)}`;
+
+/** Marker far past `topResults * chunkSize` — used to pin down the cap. */
+const makeContentWithDeepMarker = (): string =>
+  `${FILLER.repeat(40)}${MARKER}\n${FILLER.repeat(40)}`;
+
+const createFakeScraper = (content: string): t.BaseScraper => ({
+  scrapeUrl: async (url: string): Promise<[string, t.AnyScraperResponse]> => [
+    url,
+    { success: true, data: { markdown: content } },
+  ],
+  extractContent: (
+    response: t.AnyScraperResponse
+  ): [string, undefined | t.References] => [
+    (response as t.FirecrawlScrapeResponse).data?.markdown ?? '',
+    undefined,
+  ],
+  extractMetadata: (): t.GenericScrapeMetadata => ({}),
+});
+
+const makeOrganic = (l: string): t.ProcessedOrganic => ({
+  link: l,
+  title: `Title for ${l}`,
+  snippet: `Snippet for ${l}`,
+});
+
+const runSearch = async (
+  reranker: BaseReranker | undefined,
+  content = makeContent()
+): Promise<t.SearchResultData> => {
+  const processor = createSourceProcessor(
+    { reranker, topResults: 5, logger: silentLogger },
+    createFakeScraper(content)
+  );
+  return processor.processSources({
+    query: 'what is the answer',
+    proMode: true,
+    onGetHighlights: undefined,
+    news: false,
+    numElements: 5,
+    result: { success: true, data: { organic: [makeOrganic(link)] } },
+  });
+};
+
+/** Stands in for a configured reranker that returns nothing usable — the case
+ * the stripping rule exists for, and which must keep stripping. */
+class EmptyReranker extends BaseReranker {
+  readonly provider = 'empty';
+  constructor() {
+    super(silentLogger);
+  }
+  async rerank(): Promise<t.Highlight[]> {
+    return [];
+  }
+}
+
+describe('getHighlights when no reranker is configured', () => {
+  test('passes the scraped text through instead of dropping it', async () => {
+    const data = await runSearch(undefined);
+    const expanded = expandHighlights(data);
+    const source = expanded.organic?.[0];
+
+    expect(source?.highlights?.length).toBeGreaterThan(0);
+    /** The point of the fix: the scraped text reaches the model. */
+    expect(source?.highlights?.map((h) => h.text).join('\n')).toContain(MARKER);
+  });
+
+  test('still strips the raw content itself, only highlights leave', async () => {
+    const data = await runSearch(undefined);
+    const expanded = expandHighlights(data);
+
+    expect(expanded.organic?.[0].content).toBeUndefined();
+    expect(expanded.organic?.[0].references).toBeUndefined();
+  });
+
+  test('keeps stripping when a reranker is configured but yields nothing', async () => {
+    const data = await runSearch(new EmptyReranker());
+    const expanded = expandHighlights(data);
+
+    /** The guarantee the rule protects is unchanged for every other case. */
+    expect(expanded.organic?.[0].content).toBeUndefined();
+    expect(expanded.organic?.[0].highlights ?? []).toHaveLength(0);
+  });
+
+  /** ⚠️ Pass-through is not the whole page. `getDefaultRanking` keeps the
+   * first `topK` candidates, so a source contributes about
+   * `topResults * chunkSize` characters — with the defaults (5 x 150) roughly
+   * 750, however long the article is. That is the same amount a failing
+   * reranker delivers today through its fallback, and it is deliberate: the
+   * chunk budget is what keeps a search from flooding the context. Anything
+   * beyond it needs a reranker to decide *which* chunks are worth sending. */
+  test('delivers the first chunks only, not the whole document', async () => {
+    const data = await runSearch(undefined, makeContentWithDeepMarker());
+    const expanded = expandHighlights(data);
+    const delivered = expanded.organic?.[0].highlights
+      ?.map((h) => h.text)
+      .join('\n');
+
+    expect(delivered).toBeDefined();
+    expect(delivered).not.toContain(MARKER);
+  });
+
+  test('honors topResults, like every reranker fallback does', async () => {
+    const processor = createSourceProcessor(
+      { reranker: undefined, topResults: 2, logger: silentLogger },
+      createFakeScraper(makeContent())
+    );
+    const data = await processor.processSources({
+      query: 'what is the answer',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 5,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+    });
+
+    expect(data.organic?.[0].highlights?.length).toBeLessThanOrEqual(2);
+  });
+
+  test('records the pass-through in metrics without marking it a failure', async () => {
+    const recorded: t.RerankObservation[] = [];
+    const metrics = createSearchMetrics(silentLogger);
+    const original = metrics.recordRerank.bind(metrics);
+    metrics.recordRerank = (observation: t.RerankObservation): void => {
+      recorded.push(observation);
+      original(observation);
+    };
+
+    const processor = createSourceProcessor(
+      { reranker: undefined, topResults: 5, logger: silentLogger },
+      createFakeScraper(makeContent())
+    );
+    await processor.processSources({
+      query: 'what is the answer',
+      proMode: true,
+      onGetHighlights: undefined,
+      news: false,
+      numElements: 5,
+      result: { success: true, data: { organic: [makeOrganic(link)] } },
+      metrics,
+    });
+
+    const passThrough = recorded.find((o) => o.provider === 'none');
+    expect(passThrough).toBeDefined();
+    /** Nothing failed — a `reason` here would show up as a fallback in the
+     * search summary and hide real reranker problems. */
+    expect(passThrough?.reason).toBeUndefined();
+    expect(passThrough?.results).toBeGreaterThan(0);
+  });
+});
+
+describe('getDefaultRanking', () => {
+  test('keeps candidate order and caps at topK', () => {
+    const docs = ['a', 'b', 'c', 'd'];
+    expect(getDefaultRanking(docs, 2)).toEqual([
+      { text: 'a', score: 0 },
+      { text: 'b', score: 0 },
+    ]);
+  });
+
+  test('never returns more than it was given', () => {
+    expect(getDefaultRanking(['a'], 10)).toHaveLength(1);
+  });
+});

--- a/src/tools/search/rerankers.ts
+++ b/src/tools/search/rerankers.ts
@@ -21,6 +21,23 @@ const getDefaultCohereApiUrl = (): string =>
     ? process.env.COHERE_API_URL
     : DEFAULT_COHERE_API_URL;
 
+/**
+ * Ranking used whenever no reranker scores the chunks: the candidates' own
+ * order, capped at `topK`, with a neutral score.
+ *
+ * Exported because it is not only a *fallback*. With `rerankerType: 'none'`
+ * there is no reranker to fall back from, and the search pipeline needs the
+ * same ranking to hand the scraped text downstream — see `getHighlights` in
+ * `./search`.
+ */
+export const getDefaultRanking = (
+  documents: string[],
+  topK: number
+): t.Highlight[] =>
+  documents
+    .slice(0, Math.min(topK, documents.length))
+    .map((doc) => ({ text: doc, score: 0 }));
+
 export abstract class BaseReranker {
   protected apiKey: string | undefined;
   protected logger: t.Logger;
@@ -51,9 +68,7 @@ export abstract class BaseReranker {
     documents: string[],
     topK: number
   ): t.Highlight[] {
-    return documents
-      .slice(0, Math.min(topK, documents.length))
-      .map((doc) => ({ text: doc, score: 0 }));
+    return getDefaultRanking(documents, topK);
   }
 
   /** A direct caller has no enclosing search to fold into, so one

--- a/src/tools/search/search.ts
+++ b/src/tools/search/search.ts
@@ -10,7 +10,7 @@ import { createKeenableAPI } from './keenable-search';
 import { createTavilyAPI } from './tavily-search';
 import { createSearchMetrics } from './metrics';
 import { createCrwAPI } from './crw-search';
-import { BaseReranker } from './rerankers';
+import { BaseReranker, getDefaultRanking } from './rerankers';
 
 /** Engines queried when `searxngSearchOptions.engines` is not configured. */
 const DEFAULT_SEARXNG_ENGINES = 'google,bing,duckduckgo';
@@ -144,9 +144,20 @@ function createSourceUpdateCallback(sourceMap: Map<string, t.ValidSource>) {
   };
 }
 
+/** Provider label for the metrics summary when reranking is switched off.
+ * `undefined` would be indistinguishable from a reranker that never ran. */
+const NO_RERANKER_PROVIDER = 'none';
+
 /** Returns undefined without logging when there is nothing to rank: an empty
- * scrape is already counted by the scrape summary, and a missing reranker is
- * reported once at tool construction rather than once per source. */
+ * scrape is already counted by the scrape summary.
+ *
+ * A *missing* reranker is not the same as nothing to rank. `rerankerType:
+ * 'none'` is a schema-valid opt-out, and `createReranker` returns `undefined`
+ * for it by design. Returning `undefined` here as well would leave the source
+ * without highlights, and `expandHighlights` then strips its content — the
+ * search would answer with links and no text at all. So the chunks are handed
+ * on in their original order via `getDefaultRanking`, exactly what every
+ * reranker's own failure path already does. */
 const getHighlights = async ({
   query,
   content,
@@ -164,7 +175,7 @@ const getHighlights = async ({
   maxContentLength?: number;
   chunkOptions?: { chunkSize: number; chunkOverlap: number };
 }): Promise<t.Highlight[] | undefined> => {
-  if (!content || !reranker) {
+  if (!content) {
     return;
   }
 
@@ -181,7 +192,7 @@ const getHighlights = async ({
     );
   } catch (error) {
     metrics.recordRerank({
-      provider: reranker.provider,
+      provider: reranker?.provider ?? NO_RERANKER_PROVIDER,
       chunks: 0,
       results: 0,
       durationMs: Date.now() - chunkStartedAt,
@@ -189,6 +200,20 @@ const getHighlights = async ({
       error: formatErrorForLog(error),
     });
     return;
+  }
+
+  /** Reranking is switched off, so the chunks pass through unscored. Recorded
+   * like any other rerank so the search summary still accounts for the source;
+   * it carries no `reason`, because nothing failed. */
+  if (!reranker) {
+    const highlights = getDefaultRanking(documents, topResults);
+    metrics.recordRerank({
+      provider: NO_RERANKER_PROVIDER,
+      chunks: documents.length,
+      results: highlights.length,
+      durationMs: Date.now() - chunkStartedAt,
+    });
+    return highlights;
   }
 
   const rerankStartedAt = Date.now();


### PR DESCRIPTION
`rerankerType: 'none'` is a schema-valid option, but it made web search answer with links and no text at all.

The chain: `createReranker` returns `undefined` for 'none' by design, so `getHighlights` bailed out on `!reranker` and returned `undefined`, so the source reached `expandHighlights` with content but no highlights -- and that function strips raw content it cannot expand. Every scraped page was discarded on the way to the model.

`getHighlights` now separates "nothing to rank" from "no reranker configured". Without a reranker the chunks pass through in their original order via `getDefaultRanking` -- the very ranking each reranker already falls back to when it fails, which is why `tool.ts` already logs "Using default ranking" for this case.

`getDefaultRanking` moves out of `BaseReranker` into an exported function so the pipeline can use it without instantiating a reranker; the protected method stays and delegates, so no subclass changes.

`highlights.ts` is deliberately untouched. "Raw scraped content must never leave this function" still holds for every other case: a source that truly has no highlights is still stripped, and even on the pass-through path the `content` field itself is still removed -- only highlights travel onward.

Note the size of what passes through: `getDefaultRanking` keeps the first `topK` candidates, so a source contributes roughly `topResults * chunkSize` characters (5 x 150 by default), not the whole page. That matches the existing fallback behaviour and keeps the chunk budget that stops a search from flooding the context. A test pins this down so the limit is visible rather than surprising.

Tests: 8 new in src/tools/search/no-reranker.test.ts; the full src/tools/search suite passes (250/250).