### PR TITLE
v3.7.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.19",
+  "version": "3.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@librechat/agents",
-      "version": "3.7.19",
+      "version": "3.7.20",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.115.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@librechat/agents",
-  "version": "3.7.19",
+  "version": "3.7.20",
   "reova": {
     "enabled": true,
     "endpoint": "https://telemetry.reo.dev/data"


### PR DESCRIPTION
Releases the four PRs merged since `v3.7.19`:

- #503 — test: Cover Provider Migration Recovery
- #504 — fix: Tell the Model When a Web Search Failed
- #505 — fix: Guard Nullish Search Results
- #506 — feat: Enforce GPT-6 Astra Request Constraints

`#506` unblocks [LibreChat#15567](https://github.com/danny-avila/LibreChat/pull/15567), which pins this version to pick up the Astra request-shaping rules.
