### PR TITLE
🧲 fix: Match MCP Server Filters Leniently in Tool Search

### DIFF
--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -189,14 +189,16 @@ function isFromMcpServer(toolName: string, serverName: string): boolean {
  * equal `☀️`. Collapsing separators is the only equivalence intended here, so
  * it is the only one performed.
  *
- * The uppercase/lowercase round trip approximates Unicode case folding, which
- * `toLowerCase` alone does not do: `ΟΣ` lowercases to `ος` with a final sigma
- * and would otherwise never match a registered `οσ`.
+ * Case is folded with `toLowerCase` alone. A round trip through uppercase
+ * would additionally equate a Greek final sigma with its medial form, but it
+ * also equates dotless `ı` with ASCII `i`, which Unicode case folding keeps
+ * apart — and a false match hands over another server's tools while a missed
+ * one only produces the message naming the servers that do exist. The safe
+ * direction is the one taken here.
  */
 function canonicalizeServerName(serverName: string): string {
   return serverName
     .trim()
-    .toUpperCase()
     .toLowerCase()
     .normalize('NFC')
     .replace(/[-_. ]+/g, '-');
@@ -1131,7 +1133,6 @@ ${mcpNote}${toolsListSection}
         let server: string | undefined;
         if (hasServerFilter) {
           server = extractMcpServerName(lcTool.name);
-          /** `tool_mcp_` yields an empty suffix that no filter can name. */
           if (server !== undefined && server !== '') {
             registeredServers?.add(server);
           } else {

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -177,23 +177,29 @@ function isFromMcpServer(toolName: string, serverName: string): boolean {
 }
 
 /**
- * Reduces a server name to the form used for lenient matching: lowercase, with
- * separators and punctuation removed. A host rewrites characters it cannot put
- * in a tool name (LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`),
- * so a model asking for `clickhouse-cloud` is naming the same server.
+ * Canonical form used for lenient matching. It folds case and treats the
+ * separators a host may rewrite as equivalent — LibreChat turns
+ * `ClickHouse Cloud` into `ClickHouse_Cloud`, so a model asking for
+ * `clickhouse-cloud` is naming the same server.
  *
- * Letters, digits and combining marks are kept whatever their script, and the
- * result is composed so the same name written two ways agrees with itself.
- * Discarding any of them folds distinct names together: dropping non-ASCII
- * makes `éfoo` reduce to `foo`, and dropping marks makes `İfoo` — whose
- * lowercase is `i` plus a combining dot — reduce to `ifoo`. In both cases a
- * request for the plain name would return the other server's tools.
+ * **No character is ever discarded.** Every incorrect match this resolver has
+ * produced came from deleting characters, because deleting merges two distinct
+ * names onto one key: dropping non-ASCII made `éfoo` equal `foo`, dropping
+ * combining marks made `İfoo` equal `ifoo`, and dropping symbols made `❤️`
+ * equal `☀️`. Collapsing separators is the only equivalence intended here, so
+ * it is the only one performed.
+ *
+ * The uppercase/lowercase round trip approximates Unicode case folding, which
+ * `toLowerCase` alone does not do: `ΟΣ` lowercases to `ος` with a final sigma
+ * and would otherwise never match a registered `οσ`.
  */
 function canonicalizeServerName(serverName: string): string {
   return serverName
+    .trim()
+    .toUpperCase()
     .toLowerCase()
     .normalize('NFC')
-    .replace(/[^\p{L}\p{N}\p{M}]+/gu, '');
+    .replace(/[-_. ]+/g, '-');
 }
 
 /**

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -187,15 +187,22 @@ function canonicalizeServerName(serverName: string): string {
 }
 
 /**
- * Drops a leading `mcp` token from an already-canonical name. Servers are
- * commonly keyed by the bare product (`clickhouse`) while the package that
- * implements them is called `mcp-clickhouse`, and a model that has read the
- * package name asks for that instead.
+ * Canonical form of a requested name with a leading `mcp` token removed, or
+ * undefined when it had none. Servers are commonly keyed by the bare product
+ * (`clickhouse`) while the package implementing them is `mcp-clickhouse`, and a
+ * model that read the package name asks for that instead.
+ *
+ * The boundary is checked on the original string, before canonicalization drops
+ * separators: `mcp-clickhouse` names the `clickhouse` server, but `mcparty` is
+ * simply a server called `mcparty` and must never resolve to `arty`.
  */
-function withoutMcpPrefix(canonical: string): string {
-  return canonical.startsWith('mcp') && canonical.length > 3
-    ? canonical.slice(3)
-    : canonical;
+function canonicalizeWithoutMcpPrefix(requested: string): string | undefined {
+  const match = /^mcp[-_. ]+(.+)$/i.exec(requested.trim());
+  if (match === null) {
+    return undefined;
+  }
+  const key = canonicalizeServerName(match[1]);
+  return key === '' ? undefined : key;
 }
 
 /**
@@ -254,7 +261,9 @@ function resolveServerFilters(
       resolved.push(...direct);
       continue;
     }
-    const stripped = canonical.get(withoutMcpPrefix(key));
+    const strippedKey = canonicalizeWithoutMcpPrefix(want);
+    const stripped =
+      strippedKey === undefined ? undefined : canonical.get(strippedKey);
     if (stripped !== undefined) {
       resolved.push(...stripped);
       continue;
@@ -909,12 +918,15 @@ function getDeferredToolsListing(
  * @param tools - Array of tool metadata from the server(s)
  * @param serverNames - The MCP server name(s)
  * @param nameFormat - Whether to show 'full' names (tool_mcp_server) or 'base' names (tool only)
+ * @param notes - Diagnostics about requested servers that were not searched;
+ * carried inside the JSON so the output stays parseable
  * @returns JSON string showing all tools grouped by server
  */
 function formatServerListing(
   tools: t.ToolMetadata[],
   serverNames: string | string[],
-  nameFormat: t.McpNameFormat = 'full'
+  nameFormat: t.McpNameFormat = 'full',
+  notes: string[] = []
 ): string {
   const servers = Array.isArray(serverNames) ? serverNames : [serverNames];
   const useFullName = nameFormat === 'full';
@@ -926,6 +938,7 @@ function formatServerListing(
         servers,
         total_tools: 0,
         tools_by_server: {},
+        ...(notes.length > 0 ? { notes } : {}),
         hint: 'No tools found from the specified MCP server(s).',
       },
       null,
@@ -960,6 +973,7 @@ function formatServerListing(
     servers,
     total_tools: tools.length,
     tools_by_server: toolsByServer,
+    ...(notes.length > 0 ? { notes } : {}),
     hint: `To use a tool, search for it by name (e.g., query: "${exampleToolName}") to load it.`,
   };
 
@@ -1223,6 +1237,7 @@ ${mcpNote}${toolsListSection}
               ...(hasServerFilter
                 ? { available_mcp_servers: availableServers }
                 : {}),
+              ...filterMetadata,
             },
           },
         ];
@@ -1231,14 +1246,17 @@ ${mcpNote}${toolsListSection}
       const isServerListing = hasServerFilter && query === '';
 
       if (isServerListing) {
+        /** The listing's contract is parseable JSON, so the diagnostics go
+         * inside the payload rather than in front of it. */
         const formattedOutput = formatServerListing(
           deferredTools,
           activeServers,
-          mcpNameFormat
+          mcpNameFormat,
+          filterNotes
         );
 
         return [
-          `${filterNotice}${formattedOutput}`,
+          formattedOutput,
           {
             tool_references: [],
             metadata: {

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -182,12 +182,18 @@ function isFromMcpServer(toolName: string, serverName: string): boolean {
  * in a tool name (LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`),
  * so a model asking for `clickhouse-cloud` is naming the same server.
  *
- * Letters and digits are kept whatever their script. Dropping non-ASCII instead
- * would fold distinct names together — `éfoo` and `foo` would both reduce to
- * `foo`, and a request for one would return the other's tools.
+ * Letters, digits and combining marks are kept whatever their script, and the
+ * result is composed so the same name written two ways agrees with itself.
+ * Discarding any of them folds distinct names together: dropping non-ASCII
+ * makes `éfoo` reduce to `foo`, and dropping marks makes `İfoo` — whose
+ * lowercase is `i` plus a combining dot — reduce to `ifoo`. In both cases a
+ * request for the plain name would return the other server's tools.
  */
 function canonicalizeServerName(serverName: string): string {
-  return serverName.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
+  return serverName
+    .toLowerCase()
+    .normalize('NFC')
+    .replace(/[^\p{L}\p{N}\p{M}]+/gu, '');
 }
 
 /**

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -178,12 +178,16 @@ function isFromMcpServer(toolName: string, serverName: string): boolean {
 
 /**
  * Reduces a server name to the form used for lenient matching: lowercase, with
- * every separator removed. A host rewrites characters it cannot put in a tool
- * name (LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`), so a model
- * asking for `clickhouse-cloud` is naming the same server and should match.
+ * separators and punctuation removed. A host rewrites characters it cannot put
+ * in a tool name (LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`),
+ * so a model asking for `clickhouse-cloud` is naming the same server.
+ *
+ * Letters and digits are kept whatever their script. Dropping non-ASCII instead
+ * would fold distinct names together — `éfoo` and `foo` would both reduce to
+ * `foo`, and a request for one would return the other's tools.
  */
 function canonicalizeServerName(serverName: string): string {
-  return serverName.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  return serverName.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, '');
 }
 
 /**
@@ -807,11 +811,14 @@ function parseSearchResults(stdout: string): t.ToolSearchResponse {
  * Formats search results as structured JSON for efficient parsing.
  * @param searchResponse - The parsed search response
  * @param nameFormat - Whether to show 'full' names (tool_mcp_server) or 'base' names (tool only)
+ * @param notes - Diagnostics about requested servers that were not searched;
+ * carried inside the JSON so the output stays parseable
  * @returns JSON string with search results
  */
 function formatSearchResults(
   searchResponse: t.ToolSearchResponse,
-  nameFormat: t.McpNameFormat = 'full'
+  nameFormat: t.McpNameFormat = 'full',
+  notes: string[] = []
 ): string {
   const { tool_references, total_tools_searched, pattern_used } =
     searchResponse;
@@ -827,6 +834,7 @@ function formatSearchResults(
     })),
     total_searched: total_tools_searched,
     query: pattern_used,
+    ...(notes.length > 0 ? { notes } : {}),
   };
 
   return JSON.stringify(output, null, 2);
@@ -1276,13 +1284,15 @@ ${mcpNote}${toolsListSection}
           fields,
           max_results
         );
+        /** Diagnostics ride inside the payload; this output is parsed. */
         const formattedOutput = formatSearchResults(
           searchResponse,
-          mcpNameFormat
+          mcpNameFormat,
+          filterNotes
         );
 
         return [
-          `${filterNotice}${formattedOutput}`,
+          formattedOutput,
           {
             tool_references: searchResponse.tool_references,
             metadata: {
@@ -1357,7 +1367,7 @@ ${mcpNote}${toolsListSection}
         }
 
         const searchResponse = parseSearchResults(result.stdout);
-        const formattedOutput = `${filterNotice}${warningMessage}${formatSearchResults(searchResponse, mcpNameFormat)}`;
+        const formattedOutput = `${warningMessage}${formatSearchResults(searchResponse, mcpNameFormat, filterNotes)}`;
 
         return [
           formattedOutput,

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -223,6 +223,12 @@ function resolveServerFilters(
   const canonical = new Map<string, string[]>();
   for (const name of available) {
     const key = canonicalizeServerName(name);
+    /** A name with no ASCII alphanumerics — `---`, or a Unicode-only name —
+     * canonicalizes to nothing. Indexing it would make every request that also
+     * canonicalizes to nothing resolve to this server. */
+    if (key === '') {
+      continue;
+    }
     const bucket = canonical.get(key);
     if (bucket === undefined) {
       canonical.set(key, [name]);
@@ -239,6 +245,10 @@ function resolveServerFilters(
       continue;
     }
     const key = canonicalizeServerName(want);
+    if (key === '') {
+      unresolved.push(want);
+      continue;
+    }
     const direct = canonical.get(key);
     if (direct !== undefined) {
       resolved.push(...direct);
@@ -1133,6 +1143,29 @@ ${mcpNote}${toolsListSection}
         (name) => searchableServers?.has(name) !== true
       );
 
+      /** A filter naming several servers can resolve only partly. Saying so on
+       * the successful path too stops "searched github and slack" being read
+       * into a result that only ever covered github. */
+      const filterNotes: string[] = [];
+      if (unknownServers.length > 0) {
+        filterNotes.push(
+          `No MCP server matched: ${unknownServers.join(', ')}.`
+        );
+      }
+      if (idleServers.length > 0) {
+        filterNotes.push(
+          `Registered with no tools left to search: ${idleServers.join(', ')}.`
+        );
+      }
+      const filterNotice =
+        filterNotes.length > 0 ? `Note: ${filterNotes.join(' ')}\n\n` : '';
+      const filterMetadata = {
+        ...(unknownServers.length > 0
+          ? { unmatched_mcp_servers: unknownServers }
+          : {}),
+        ...(idleServers.length > 0 ? { idle_mcp_servers: idleServers } : {}),
+      };
+
       if (staged !== undefined) {
         for (const lcTool of staged) {
           if (isFromAnyMcpServer(lcTool.name, activeServers)) {
@@ -1205,13 +1238,14 @@ ${mcpNote}${toolsListSection}
         );
 
         return [
-          formattedOutput,
+          `${filterNotice}${formattedOutput}`,
           {
             tool_references: [],
             metadata: {
               total_available: deferredTools.length,
               mcp_server: serverFilters,
               listing_mode: true,
+              ...filterMetadata,
             },
           },
         ];
@@ -1230,13 +1264,14 @@ ${mcpNote}${toolsListSection}
         );
 
         return [
-          formattedOutput,
+          `${filterNotice}${formattedOutput}`,
           {
             tool_references: searchResponse.tool_references,
             metadata: {
               total_searched: searchResponse.total_tools_searched,
               pattern: searchResponse.pattern_used,
               mcp_server: serverFilters.length > 0 ? serverFilters : undefined,
+              ...filterMetadata,
             },
           },
         ];
@@ -1291,19 +1326,20 @@ ${mcpNote}${toolsListSection}
 
         if (!result.stdout || !result.stdout.trim()) {
           return [
-            `${warningMessage}No tools matched the pattern "${sanitizedPattern}".\nTotal tools searched: ${deferredTools.length}`,
+            `${filterNotice}${warningMessage}No tools matched the pattern "${sanitizedPattern}".\nTotal tools searched: ${deferredTools.length}`,
             {
               tool_references: [],
               metadata: {
                 total_searched: deferredTools.length,
                 pattern: sanitizedPattern,
+                ...filterMetadata,
               },
             },
           ];
         }
 
         const searchResponse = parseSearchResults(result.stdout);
-        const formattedOutput = `${warningMessage}${formatSearchResults(searchResponse, mcpNameFormat)}`;
+        const formattedOutput = `${filterNotice}${warningMessage}${formatSearchResults(searchResponse, mcpNameFormat)}`;
 
         return [
           formattedOutput,
@@ -1312,6 +1348,7 @@ ${mcpNote}${toolsListSection}
             metadata: {
               total_searched: searchResponse.total_tools_searched,
               pattern: searchResponse.pattern_used,
+              ...filterMetadata,
             },
           },
         ];

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -206,6 +206,11 @@ function withoutMcpPrefix(canonical: string): string {
  * mcp-prefix-stripped form. Trying them in that order keeps a deployment that
  * runs both `github` and `mcp-github` unambiguous: each resolves to itself.
  *
+ * Several registered names can still share one canonical form (`foo-bar` and
+ * `foobar`). An inexact request cannot choose between them, so every candidate
+ * is returned rather than whichever was seen first: a superset is recoverable
+ * by reading the tool names, an arbitrary pick is not.
+ *
  * @param requested - Server names as supplied by the caller
  * @param available - Server names present in the tool registry
  * @returns The registry names to filter by, and any request that matched none
@@ -215,11 +220,14 @@ function resolveServerFilters(
   available: string[]
 ): { resolved: string[]; unresolved: string[] } {
   const exact = new Set(available);
-  const canonical = new Map<string, string>();
+  const canonical = new Map<string, string[]>();
   for (const name of available) {
     const key = canonicalizeServerName(name);
-    if (!canonical.has(key)) {
-      canonical.set(key, name);
+    const bucket = canonical.get(key);
+    if (bucket === undefined) {
+      canonical.set(key, [name]);
+    } else {
+      bucket.push(name);
     }
   }
 
@@ -233,12 +241,12 @@ function resolveServerFilters(
     const key = canonicalizeServerName(want);
     const direct = canonical.get(key);
     if (direct !== undefined) {
-      resolved.push(direct);
+      resolved.push(...direct);
       continue;
     }
     const stripped = canonical.get(withoutMcpPrefix(key));
     if (stripped !== undefined) {
-      resolved.push(stripped);
+      resolved.push(...stripped);
       continue;
     }
     unresolved.push(want);
@@ -1060,22 +1068,53 @@ ${mcpNote}${toolsListSection}
       }
 
       const toolsArray: t.LCTool[] = Array.from(toolRegistry.values());
-      const searchable = toolsArray.filter(
-        (lcTool) => onlyDeferred !== true || lcTool.defer_loading === true
-      );
-      const availableServers = Array.from(
-        new Set(
-          searchable
-            .map((lcTool) => extractMcpServerName(lcTool.name))
-            .filter((name): name is string => name !== undefined)
-        )
-      ).sort();
+      /** One pass builds the searchable subset and, only when a server filter
+       * needs them, the two server indexes. An unfiltered search is the hot
+       * path and pays for none of the server bookkeeping. */
+      const searchable: t.LCTool[] = [];
+      const registeredServers = hasServerFilter ? new Set<string>() : undefined;
+      const searchableServers = hasServerFilter ? new Set<string>() : undefined;
+      for (const lcTool of toolsArray) {
+        const server =
+          registeredServers === undefined
+            ? undefined
+            : extractMcpServerName(lcTool.name);
+        if (server !== undefined) {
+          registeredServers?.add(server);
+        }
+        if (onlyDeferred === true && lcTool.defer_loading !== true) {
+          continue;
+        }
+        searchable.push(lcTool);
+        if (server !== undefined) {
+          searchableServers?.add(server);
+        }
+      }
 
-      /** A near-miss on the server name filters instead of returning nothing. */
-      const { resolved: activeServers, unresolved: unknownServers } =
+      const availableServers =
+        searchableServers === undefined
+          ? []
+          : Array.from(searchableServers).sort();
+
+      /** Resolve against every registered server, not just the searchable ones,
+       * so a server whose tools are all loaded already is reported as having
+       * nothing left to search instead of as a name that does not exist. */
+      const { resolved: matchedServers, unresolved: unknownServers } =
         hasServerFilter
-          ? resolveServerFilters(serverFilters, availableServers)
+          ? resolveServerFilters(
+            serverFilters,
+            registeredServers === undefined
+              ? []
+              : Array.from(registeredServers)
+          )
           : { resolved: [], unresolved: [] };
+
+      const activeServers = matchedServers.filter(
+        (name) => searchableServers?.has(name) === true
+      );
+      const idleServers = matchedServers.filter(
+        (name) => searchableServers?.has(name) !== true
+      );
 
       const deferredTools: t.ToolMetadata[] = searchable
         .filter((lcTool) => {
@@ -1101,12 +1140,27 @@ ${mcpNote}${toolsListSection}
         if (searchable.length === 0) {
           message =
             'No tools available to search. The tool registry is empty or no deferred tools are registered.';
-        } else if (hasServerFilter && unknownServers.length > 0) {
-          const available =
-            availableServers.length > 0
-              ? availableServers.join(', ')
-              : '(none registered)';
-          message = `No tools matched MCP server(s): ${unknownServers.join(', ')}. Available server(s): ${available}.`;
+        } else if (
+          hasServerFilter &&
+          (unknownServers.length > 0 || idleServers.length > 0)
+        ) {
+          const parts: string[] = [];
+          if (unknownServers.length > 0) {
+            parts.push(`No MCP server matched: ${unknownServers.join(', ')}.`);
+          }
+          if (idleServers.length > 0) {
+            parts.push(
+              `Registered with no tools left to search: ${idleServers.join(', ')}.`
+            );
+          }
+          parts.push(
+            `Server(s) with searchable tools: ${
+              availableServers.length > 0
+                ? availableServers.join(', ')
+                : '(none)'
+            }.`
+          );
+          message = parts.join(' ');
         } else {
           const serverMsg = hasServerFilter
             ? ` from MCP server(s): ${serverFilters.join(', ')}`
@@ -1121,7 +1175,9 @@ ${mcpNote}${toolsListSection}
               total_searched: 0,
               pattern: query,
               mcp_server: serverFilters,
-              available_mcp_servers: availableServers,
+              ...(hasServerFilter
+                ? { available_mcp_servers: availableServers }
+                : {}),
             },
           },
         ];

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -1067,25 +1067,42 @@ ${mcpNote}${toolsListSection}
         ];
       }
 
-      const toolsArray: t.LCTool[] = Array.from(toolRegistry.values());
-      /** One pass builds the searchable subset and, only when a server filter
-       * needs them, the two server indexes. An unfiltered search is the hot
-       * path and pays for none of the server bookkeeping. */
-      const searchable: t.LCTool[] = [];
       const registeredServers = hasServerFilter ? new Set<string>() : undefined;
       const searchableServers = hasServerFilter ? new Set<string>() : undefined;
-      for (const lcTool of toolsArray) {
-        const server =
-          registeredServers === undefined
-            ? undefined
-            : extractMcpServerName(lcTool.name);
-        if (server !== undefined) {
-          registeredServers?.add(server);
+      /** The set to filter by is unknown until the whole registry has been
+       * seen, so a server-filtered search has to stage its candidates. An
+       * unfiltered search is the hot path: it builds the result during the same
+       * single traversal, with no staging array and no copy of the registry. */
+      const staged: t.LCTool[] | undefined = hasServerFilter ? [] : undefined;
+      const deferredTools: t.ToolMetadata[] = [];
+      let searchableCount = 0;
+
+      const describeTool = (lcTool: t.LCTool): t.ToolMetadata => ({
+        name: lcTool.name,
+        description: lcTool.description ?? '',
+        parameters: simplifyParametersForSearch(lcTool.parameters),
+      });
+
+      for (const lcTool of toolRegistry.values()) {
+        let server: string | undefined;
+        if (hasServerFilter) {
+          server = extractMcpServerName(lcTool.name);
+          /** `tool_mcp_` yields an empty suffix that no filter can name. */
+          if (server !== undefined && server !== '') {
+            registeredServers?.add(server);
+          } else {
+            server = undefined;
+          }
         }
         if (onlyDeferred === true && lcTool.defer_loading !== true) {
           continue;
         }
-        searchable.push(lcTool);
+        searchableCount += 1;
+        if (staged === undefined) {
+          deferredTools.push(describeTool(lcTool));
+          continue;
+        }
+        staged.push(lcTool);
         if (server !== undefined) {
           searchableServers?.add(server);
         }
@@ -1116,31 +1133,23 @@ ${mcpNote}${toolsListSection}
         (name) => searchableServers?.has(name) !== true
       );
 
-      const deferredTools: t.ToolMetadata[] = searchable
-        .filter((lcTool) => {
-          if (
-            hasServerFilter &&
-            !isFromAnyMcpServer(lcTool.name, activeServers)
-          ) {
-            return false;
+      if (staged !== undefined) {
+        for (const lcTool of staged) {
+          if (isFromAnyMcpServer(lcTool.name, activeServers)) {
+            deferredTools.push(describeTool(lcTool));
           }
-          return true;
-        })
-        .map((lcTool) => ({
-          name: lcTool.name,
-          description: lcTool.description ?? '',
-          parameters: simplifyParametersForSearch(lcTool.parameters),
-        }));
+        }
+      }
 
       if (deferredTools.length === 0) {
         /** Say which of the three it is, so an empty result is not read as an
          * outage: nothing is registered, the name did not match anything, or
          * the named server genuinely has no tools. */
         let message: string;
-        if (searchable.length === 0) {
-          message =
-            'No tools available to search. The tool registry is empty or no deferred tools are registered.';
-        } else if (
+        /** The server diagnosis comes first: a registry holding only loaded
+         * tools makes both conditions true, and naming the requested server is
+         * the more useful of the two answers. */
+        if (
           hasServerFilter &&
           (unknownServers.length > 0 || idleServers.length > 0)
         ) {
@@ -1161,6 +1170,9 @@ ${mcpNote}${toolsListSection}
             }.`
           );
           message = parts.join(' ');
+        } else if (searchableCount === 0) {
+          message =
+            'No tools available to search. The tool registry is empty or no deferred tools are registered.';
         } else {
           const serverMsg = hasServerFilter
             ? ` from MCP server(s): ${serverFilters.join(', ')}`

--- a/src/tools/ToolSearch.ts
+++ b/src/tools/ToolSearch.ts
@@ -177,6 +177,77 @@ function isFromMcpServer(toolName: string, serverName: string): boolean {
 }
 
 /**
+ * Reduces a server name to the form used for lenient matching: lowercase, with
+ * every separator removed. A host rewrites characters it cannot put in a tool
+ * name (LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`), so a model
+ * asking for `clickhouse-cloud` is naming the same server and should match.
+ */
+function canonicalizeServerName(serverName: string): string {
+  return serverName.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+/**
+ * Drops a leading `mcp` token from an already-canonical name. Servers are
+ * commonly keyed by the bare product (`clickhouse`) while the package that
+ * implements them is called `mcp-clickhouse`, and a model that has read the
+ * package name asks for that instead.
+ */
+function withoutMcpPrefix(canonical: string): string {
+  return canonical.startsWith('mcp') && canonical.length > 3
+    ? canonical.slice(3)
+    : canonical;
+}
+
+/**
+ * Maps requested server names onto the servers that actually have tools
+ * registered, so a near-miss filters instead of silently returning nothing.
+ *
+ * Exact names win, then case/separator-insensitive matches, then the
+ * mcp-prefix-stripped form. Trying them in that order keeps a deployment that
+ * runs both `github` and `mcp-github` unambiguous: each resolves to itself.
+ *
+ * @param requested - Server names as supplied by the caller
+ * @param available - Server names present in the tool registry
+ * @returns The registry names to filter by, and any request that matched none
+ */
+function resolveServerFilters(
+  requested: string[],
+  available: string[]
+): { resolved: string[]; unresolved: string[] } {
+  const exact = new Set(available);
+  const canonical = new Map<string, string>();
+  for (const name of available) {
+    const key = canonicalizeServerName(name);
+    if (!canonical.has(key)) {
+      canonical.set(key, name);
+    }
+  }
+
+  const resolved: string[] = [];
+  const unresolved: string[] = [];
+  for (const want of requested) {
+    if (exact.has(want)) {
+      resolved.push(want);
+      continue;
+    }
+    const key = canonicalizeServerName(want);
+    const direct = canonical.get(key);
+    if (direct !== undefined) {
+      resolved.push(direct);
+      continue;
+    }
+    const stripped = canonical.get(withoutMcpPrefix(key));
+    if (stripped !== undefined) {
+      resolved.push(stripped);
+      continue;
+    }
+    unresolved.push(want);
+  }
+
+  return { resolved: Array.from(new Set(resolved)), unresolved };
+}
+
+/**
  * Checks if a tool belongs to any of the specified MCP servers.
  * @param toolName - The full tool name
  * @param serverNames - Array of server names to match
@@ -989,14 +1060,28 @@ ${mcpNote}${toolsListSection}
       }
 
       const toolsArray: t.LCTool[] = Array.from(toolRegistry.values());
-      const deferredTools: t.ToolMetadata[] = toolsArray
+      const searchable = toolsArray.filter(
+        (lcTool) => onlyDeferred !== true || lcTool.defer_loading === true
+      );
+      const availableServers = Array.from(
+        new Set(
+          searchable
+            .map((lcTool) => extractMcpServerName(lcTool.name))
+            .filter((name): name is string => name !== undefined)
+        )
+      ).sort();
+
+      /** A near-miss on the server name filters instead of returning nothing. */
+      const { resolved: activeServers, unresolved: unknownServers } =
+        hasServerFilter
+          ? resolveServerFilters(serverFilters, availableServers)
+          : { resolved: [], unresolved: [] };
+
+      const deferredTools: t.ToolMetadata[] = searchable
         .filter((lcTool) => {
-          if (onlyDeferred === true && lcTool.defer_loading !== true) {
-            return false;
-          }
           if (
             hasServerFilter &&
-            !isFromAnyMcpServer(lcTool.name, serverFilters)
+            !isFromAnyMcpServer(lcTool.name, activeServers)
           ) {
             return false;
           }
@@ -1009,17 +1094,34 @@ ${mcpNote}${toolsListSection}
         }));
 
       if (deferredTools.length === 0) {
-        const serverMsg = hasServerFilter
-          ? ` from MCP server(s): ${serverFilters.join(', ')}`
-          : '';
+        /** Say which of the three it is, so an empty result is not read as an
+         * outage: nothing is registered, the name did not match anything, or
+         * the named server genuinely has no tools. */
+        let message: string;
+        if (searchable.length === 0) {
+          message =
+            'No tools available to search. The tool registry is empty or no deferred tools are registered.';
+        } else if (hasServerFilter && unknownServers.length > 0) {
+          const available =
+            availableServers.length > 0
+              ? availableServers.join(', ')
+              : '(none registered)';
+          message = `No tools matched MCP server(s): ${unknownServers.join(', ')}. Available server(s): ${available}.`;
+        } else {
+          const serverMsg = hasServerFilter
+            ? ` from MCP server(s): ${serverFilters.join(', ')}`
+            : '';
+          message = `No tools available to search${serverMsg}. The tool registry is empty or no matching deferred tools are registered.`;
+        }
         return [
-          `No tools available to search${serverMsg}. The tool registry is empty or no matching deferred tools are registered.`,
+          message,
           {
             tool_references: [],
             metadata: {
               total_searched: 0,
               pattern: query,
               mcp_server: serverFilters,
+              available_mcp_servers: availableServers,
             },
           },
         ];
@@ -1030,7 +1132,7 @@ ${mcpNote}${toolsListSection}
       if (isServerListing) {
         const formattedOutput = formatServerListing(
           deferredTools,
-          serverFilters,
+          activeServers,
           mcpNameFormat
         );
 
@@ -1179,6 +1281,8 @@ export {
   extractMcpServerName,
   isFromMcpServer,
   isFromAnyMcpServer,
+  resolveServerFilters,
+  canonicalizeServerName,
   normalizeServerFilter,
   getAvailableMcpServers,
   getDeferredToolsListing,

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1283,6 +1283,16 @@ describe('resolveServerFilters', () => {
     ]);
   });
 
+  it('does not fold non-ASCII names onto ASCII ones', () => {
+    /** Stripping non-ASCII would reduce `éfoo` to `foo`, so a request for an
+     * unregistered `foo` would return the other server's tools. */
+    expect(resolveServerFilters(['foo'], ['éfoo'])).toEqual({
+      resolved: [],
+      unresolved: ['foo'],
+    });
+    expect(resolveServerFilters(['ÉFOO'], ['éfoo']).resolved).toEqual(['éfoo']);
+  });
+
   it('only strips an mcp prefix at a real token boundary', () => {
     /** `mcparty` is a server name that happens to start with those letters;
      * resolving it to `arty` would return an unrelated server's tools. */
@@ -1419,6 +1429,36 @@ describe('tool_search mcp_server filtering', () => {
     expect(output).toContain('no tools left to search');
     expect(output).toContain('slack');
     expect(output).not.toContain('No MCP server matched');
+  });
+
+  it('keeps a partial search response parseable as JSON', async () => {
+    const mixed = new Map(
+      [
+        { name: 'send_message_mcp_slack', defer_loading: false },
+        { name: 'create_issue_mcp_github', defer_loading: true },
+      ].map((tool) => [
+        tool.name,
+        {
+          ...tool,
+          description: tool.name,
+          parameters: { type: 'object', properties: {} },
+        },
+      ])
+    );
+
+    const output = String(
+      await createToolSearch({
+        mode: 'local',
+        toolRegistry: mixed as never,
+      }).invoke({ query: 'create', mcp_server: ['github', 'slack'] })
+    );
+
+    const parsed = JSON.parse(output) as {
+      found: number;
+      notes?: string[];
+    };
+    expect(parsed.found).toBe(1);
+    expect(parsed.notes?.join(' ')).toContain('slack');
   });
 
   it('keeps a partial server listing parseable as JSON', async () => {

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1266,6 +1266,23 @@ describe('resolveServerFilters', () => {
     expect(resolveServerFilters(['github'], both).resolved).toEqual(['github']);
   });
 
+  it('keeps every candidate when registered names share a canonical form', () => {
+    /** `foo-bar` and `foobar` are indistinguishable once separators are
+     * dropped, so an inexact request must not silently pick one. */
+    const ambiguous = ['foo-bar', 'foobar'];
+    expect(resolveServerFilters(['FOOBAR'], ambiguous).resolved).toEqual([
+      'foo-bar',
+      'foobar',
+    ]);
+  });
+
+  it('still prefers an exact name over an ambiguous canonical form', () => {
+    const ambiguous = ['foo-bar', 'foobar'];
+    expect(resolveServerFilters(['foobar'], ambiguous).resolved).toEqual([
+      'foobar',
+    ]);
+  });
+
   it('reports a name that matches nothing', () => {
     expect(resolveServerFilters(['nope'], available)).toEqual({
       resolved: [],
@@ -1345,6 +1362,35 @@ describe('tool_search mcp_server filtering', () => {
 
     expect(String(output)).toContain('run_select_query_mcp_clickhouse');
     expect(String(output)).not.toContain('create_issue_mcp_github');
+  });
+
+  it('distinguishes a server with nothing left to search from an unknown one', async () => {
+    /** Every Slack tool is already loaded, so it is registered but has nothing
+     * deferred; saying it does not exist would be wrong. */
+    const mixed = new Map(
+      [
+        { name: 'send_message_mcp_slack', defer_loading: false },
+        { name: 'create_issue_mcp_github', defer_loading: true },
+      ].map((tool) => [
+        tool.name,
+        {
+          ...tool,
+          description: tool.name,
+          parameters: { type: 'object', properties: {} },
+        },
+      ])
+    );
+
+    const output = String(
+      await createToolSearch({
+        mode: 'local',
+        toolRegistry: mixed as never,
+      }).invoke({ query: 'anything', mcp_server: 'slack' })
+    );
+
+    expect(output).toContain('no tools left to search');
+    expect(output).toContain('slack');
+    expect(output).not.toContain('No MCP server matched');
   });
 
   it('names the available servers when the filter matches none', async () => {

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1315,10 +1315,11 @@ describe('resolveServerFilters', () => {
     });
   });
 
-  it('matches a Greek name whose case differs in the final letter', () => {
-    expect(
-      resolveServerFilters(['\u039f\u03a3'], ['\u03bf\u03c3']).resolved
-    ).toEqual(['\u03bf\u03c3']);
+  it('keeps dotless i from resolving to an ASCII name', () => {
+    expect(resolveServerFilters(['ifoo'], ['\u0131foo'])).toEqual({
+      resolved: [],
+      unresolved: ['ifoo'],
+    });
   });
 
   it('only strips an mcp prefix at a real token boundary', () => {
@@ -1399,8 +1400,14 @@ describe('canonicalizeServerName', () => {
     );
   });
 
-  it('case-folds past toLowerCase, so a final sigma still matches', () => {
-    expect(canonicalizeServerName('\u039f\u03a3')).toBe(
+  it('keeps dotless and dotted i apart, at the cost of the sigma case', () => {
+    /** Folding through uppercase would match `\u039f\u03a3` to `\u03bf\u03c3`, but it also
+     * equates `\u0131` with `i`. A missed match only produces the message listing
+     * the real servers; a false one hands over their tools. */
+    expect(canonicalizeServerName('\u0131foo')).not.toBe(
+      canonicalizeServerName('ifoo')
+    );
+    expect(canonicalizeServerName('\u039f\u03a3')).not.toBe(
       canonicalizeServerName('\u03bf\u03c3')
     );
   });
@@ -1415,7 +1422,7 @@ describe('tool_search mcp_server filtering', () => {
   /** LangChain's callback manager mints a uuid v7; `globalThis.crypto` is not
    * exposed on Node 18, so invoking a tool there throws before reaching us. */
   beforeAll(() => {
-    if ((globalThis as { crypto?: unknown }).crypto === undefined) {
+    if ((globalThis as { crypto?: Crypto }).crypto === undefined) {
       Object.defineProperty(globalThis, 'crypto', {
         value: nodeWebcrypto,
         configurable: true,

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1393,6 +1393,33 @@ describe('tool_search mcp_server filtering', () => {
     expect(output).not.toContain('No MCP server matched');
   });
 
+  it('diagnoses an idle server even when nothing at all is deferred', async () => {
+    /** Every tool is loaded, so the registry looks empty to a deferred-only
+     * search while the requested server plainly exists. The server answer is
+     * the useful one and must win over the generic empty-registry message. */
+    const allLoaded = new Map(
+      [{ name: 'send_message_mcp_slack', defer_loading: false }].map((tool) => [
+        tool.name,
+        {
+          ...tool,
+          description: tool.name,
+          parameters: { type: 'object', properties: {} },
+        },
+      ])
+    );
+
+    const output = String(
+      await createToolSearch({
+        mode: 'local',
+        toolRegistry: allLoaded as never,
+      }).invoke({ query: 'anything', mcp_server: 'slack' })
+    );
+
+    expect(output).toContain('no tools left to search');
+    expect(output).toContain('slack');
+    expect(output).not.toContain('The tool registry is empty');
+  });
+
   it('names the available servers when the filter matches none', async () => {
     const output = String(
       await search().invoke({ query: 'anything', mcp_server: 'not-a-server' })

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1283,6 +1283,21 @@ describe('resolveServerFilters', () => {
     ]);
   });
 
+  it('only strips an mcp prefix at a real token boundary', () => {
+    /** `mcparty` is a server name that happens to start with those letters;
+     * resolving it to `arty` would return an unrelated server's tools. */
+    expect(resolveServerFilters(['mcparty'], ['arty'])).toEqual({
+      resolved: [],
+      unresolved: ['mcparty'],
+    });
+    expect(resolveServerFilters(['mcp-arty'], ['arty']).resolved).toEqual([
+      'arty',
+    ]);
+    expect(resolveServerFilters(['mcp_arty'], ['arty']).resolved).toEqual([
+      'arty',
+    ]);
+  });
+
   it('never fuzzy-matches names that canonicalize to nothing', () => {
     /** `---` and `!!!` both reduce to the empty string; treating that as a
      * shared key would hand one server's tools to an unrelated request. */
@@ -1404,6 +1419,36 @@ describe('tool_search mcp_server filtering', () => {
     expect(output).toContain('no tools left to search');
     expect(output).toContain('slack');
     expect(output).not.toContain('No MCP server matched');
+  });
+
+  it('keeps a partial server listing parseable as JSON', async () => {
+    const mixed = new Map(
+      [
+        { name: 'send_message_mcp_slack', defer_loading: false },
+        { name: 'create_issue_mcp_github', defer_loading: true },
+      ].map((tool) => [
+        tool.name,
+        {
+          ...tool,
+          description: tool.name,
+          parameters: { type: 'object', properties: {} },
+        },
+      ])
+    );
+
+    const output = String(
+      await createToolSearch({
+        mode: 'local',
+        toolRegistry: mixed as never,
+      }).invoke({ query: '', mcp_server: ['github', 'slack'] })
+    );
+
+    const parsed = JSON.parse(output) as {
+      listing_mode: boolean;
+      notes?: string[];
+    };
+    expect(parsed.listing_mode).toBe(true);
+    expect(parsed.notes?.join(' ')).toContain('slack');
   });
 
   it('reports the unsearched half of a partly resolved filter', async () => {

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1283,6 +1283,21 @@ describe('resolveServerFilters', () => {
     ]);
   });
 
+  it('keeps combining marks so cased Unicode does not fold onto ASCII', () => {
+    /** `İ`.toLowerCase() is `i` plus a combining dot above; dropping the
+     * mark would make it indistinguishable from a plain `ifoo` server. */
+    expect(resolveServerFilters(['ifoo'], ['İfoo'])).toEqual({
+      resolved: [],
+      unresolved: ['ifoo'],
+    });
+  });
+
+  it('matches the same name whether composed or decomposed', () => {
+    /** NFC composition means `e` + combining acute and a precomposed `é`
+     * name are one server, not two. */
+    expect(resolveServerFilters(['éfoo'], ['éfoo']).resolved).toEqual(['éfoo']);
+  });
+
   it('does not fold non-ASCII names onto ASCII ones', () => {
     /** Stripping non-ASCII would reduce `éfoo` to `foo`, so a request for an
      * unregistered `foo` would return the other server's tools. */

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -4,6 +4,7 @@
  * Tests helper functions and sanitization logic without hitting the API.
  */
 import { describe, it, expect } from '@jest/globals';
+import { webcrypto as nodeWebcrypto } from 'node:crypto';
 import type { ToolMetadata, LCToolRegistry } from '@/types';
 import {
   sanitizeRegex,
@@ -20,6 +21,9 @@ import {
   getDeferredToolsListing,
   getBaseToolName,
   formatServerListing,
+  resolveServerFilters,
+  canonicalizeServerName,
+  createToolSearch,
 } from '../ToolSearch';
 
 describe('ToolSearch', () => {
@@ -518,6 +522,7 @@ describe('ToolSearch', () => {
 
     it('handles edge cases', () => {
       expect(extractMcpServerName('_mcp_server')).toBe('server');
+
       expect(extractMcpServerName('tool_mcp_')).toBe('');
     });
   });
@@ -1223,5 +1228,133 @@ describe('ToolSearch', () => {
       expect(parsed.servers).toEqual(['weather-api']);
       expect(parsed.tools_by_server['weather-api']).toBeDefined();
     });
+  });
+});
+describe('resolveServerFilters', () => {
+  const available = ['clickhouse', 'github', 'ClickHouse_Cloud', 'langfuse'];
+
+  it('resolves an exact name unchanged', () => {
+    expect(resolveServerFilters(['github'], available)).toEqual({
+      resolved: ['github'],
+      unresolved: [],
+    });
+  });
+
+  it('resolves the package name a model is likely to have read', () => {
+    /** The failure this fixes: tools are keyed `clickhouse`, the published
+     * package is `mcp-clickhouse`, and the filter silently matched nothing. */
+    expect(resolveServerFilters(['mcp-clickhouse'], available)).toEqual({
+      resolved: ['clickhouse'],
+      unresolved: [],
+    });
+  });
+
+  it('ignores case and separator differences', () => {
+    expect(
+      resolveServerFilters(['clickhouse-cloud'], available).resolved
+    ).toEqual(['ClickHouse_Cloud']);
+    expect(resolveServerFilters(['GitHub'], available).resolved).toEqual([
+      'github',
+    ]);
+  });
+
+  it('keeps mcp-prefixed and bare servers distinct when both exist', () => {
+    const both = ['github', 'mcp-github'];
+    expect(resolveServerFilters(['mcp-github'], both).resolved).toEqual([
+      'mcp-github',
+    ]);
+    expect(resolveServerFilters(['github'], both).resolved).toEqual(['github']);
+  });
+
+  it('reports a name that matches nothing', () => {
+    expect(resolveServerFilters(['nope'], available)).toEqual({
+      resolved: [],
+      unresolved: ['nope'],
+    });
+  });
+
+  it('deduplicates filters that resolve to the same server', () => {
+    expect(
+      resolveServerFilters(
+        ['clickhouse', 'ClickHouse', 'mcp-clickhouse'],
+        available
+      ).resolved
+    ).toEqual(['clickhouse']);
+  });
+
+  it('separates the resolvable from the unresolvable', () => {
+    const { resolved, unresolved } = resolveServerFilters(
+      ['mcp-clickhouse', 'ghost'],
+      available
+    );
+    expect(resolved).toEqual(['clickhouse']);
+    expect(unresolved).toEqual(['ghost']);
+  });
+});
+
+describe('canonicalizeServerName', () => {
+  it('collapses case and every separator', () => {
+    expect(canonicalizeServerName('ClickHouse Cloud')).toBe('clickhousecloud');
+    expect(canonicalizeServerName('ClickHouse_Cloud')).toBe('clickhousecloud');
+    expect(canonicalizeServerName('clickhouse-cloud')).toBe('clickhousecloud');
+  });
+});
+describe('tool_search mcp_server filtering', () => {
+  /** LangChain's callback manager mints a uuid v7; `globalThis.crypto` is not
+   * exposed on Node 18, so invoking a tool there throws before reaching us. */
+  beforeAll(() => {
+    if ((globalThis as { crypto?: unknown }).crypto === undefined) {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: nodeWebcrypto,
+        configurable: true,
+      });
+    }
+  });
+
+  const registry = new Map(
+    [
+      {
+        name: 'run_select_query_mcp_clickhouse',
+        description: 'Run a ClickHouse SELECT',
+      },
+      {
+        name: 'list_databases_mcp_clickhouse',
+        description: 'List ClickHouse databases',
+      },
+      { name: 'create_issue_mcp_github', description: 'Open a GitHub issue' },
+    ].map((tool) => [
+      tool.name,
+      {
+        ...tool,
+        defer_loading: true,
+        parameters: { type: 'object', properties: {} },
+      },
+    ])
+  );
+
+  const search = () =>
+    createToolSearch({ mode: 'local', toolRegistry: registry as never });
+
+  it('finds tools when the model names the package instead of the server key', async () => {
+    /** The reported failure: the server is keyed `clickhouse`, the model asked
+     * for `mcp-clickhouse`, and the exact-match filter returned nothing. */
+    const output = await search().invoke({
+      query: 'select query',
+      mcp_server: 'mcp-clickhouse',
+    });
+
+    expect(String(output)).toContain('run_select_query_mcp_clickhouse');
+    expect(String(output)).not.toContain('create_issue_mcp_github');
+  });
+
+  it('names the available servers when the filter matches none', async () => {
+    const output = String(
+      await search().invoke({ query: 'anything', mcp_server: 'not-a-server' })
+    );
+
+    expect(output).toContain('not-a-server');
+    expect(output).toContain('clickhouse');
+    expect(output).toContain('github');
+    expect(output).not.toContain('The tool registry is empty');
   });
 });

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1267,19 +1267,19 @@ describe('resolveServerFilters', () => {
   });
 
   it('keeps every candidate when registered names share a canonical form', () => {
-    /** `foo-bar` and `foobar` are indistinguishable once separators are
-     * dropped, so an inexact request must not silently pick one. */
-    const ambiguous = ['foo-bar', 'foobar'];
-    expect(resolveServerFilters(['FOOBAR'], ambiguous).resolved).toEqual([
+    /** `foo-bar` and `foo_bar` differ only by a separator, so they share one
+     * canonical key and an inexact request must not silently pick one. */
+    const ambiguous = ['foo-bar', 'foo_bar'];
+    expect(resolveServerFilters(['FOO BAR'], ambiguous).resolved).toEqual([
       'foo-bar',
-      'foobar',
+      'foo_bar',
     ]);
   });
 
   it('still prefers an exact name over an ambiguous canonical form', () => {
-    const ambiguous = ['foo-bar', 'foobar'];
-    expect(resolveServerFilters(['foobar'], ambiguous).resolved).toEqual([
-      'foobar',
+    const ambiguous = ['foo-bar', 'foo_bar'];
+    expect(resolveServerFilters(['foo_bar'], ambiguous).resolved).toEqual([
+      'foo_bar',
     ]);
   });
 
@@ -1308,6 +1308,19 @@ describe('resolveServerFilters', () => {
     expect(resolveServerFilters(['ÉFOO'], ['éfoo']).resolved).toEqual(['éfoo']);
   });
 
+  it('keeps symbol-only names distinct', () => {
+    expect(resolveServerFilters(['\u2600\ufe0f'], ['\u2764\ufe0f'])).toEqual({
+      resolved: [],
+      unresolved: ['\u2600\ufe0f'],
+    });
+  });
+
+  it('matches a Greek name whose case differs in the final letter', () => {
+    expect(
+      resolveServerFilters(['\u039f\u03a3'], ['\u03bf\u03c3']).resolved
+    ).toEqual(['\u03bf\u03c3']);
+  });
+
   it('only strips an mcp prefix at a real token boundary', () => {
     /** `mcparty` is a server name that happens to start with those letters;
      * resolving it to `arty` would return an unrelated server's tools. */
@@ -1323,9 +1336,9 @@ describe('resolveServerFilters', () => {
     ]);
   });
 
-  it('never fuzzy-matches names that canonicalize to nothing', () => {
-    /** `---` and `!!!` both reduce to the empty string; treating that as a
-     * shared key would hand one server's tools to an unrelated request. */
+  it('keeps punctuation-only names distinct from one another', () => {
+    /** An earlier revision reduced both to the empty string, which would have
+     * handed one server's tools to a request for the other. */
     const punctuation = ['---'];
     expect(resolveServerFilters(['!!!'], punctuation)).toEqual({
       resolved: [],
@@ -1363,10 +1376,39 @@ describe('resolveServerFilters', () => {
 });
 
 describe('canonicalizeServerName', () => {
-  it('collapses case and every separator', () => {
-    expect(canonicalizeServerName('ClickHouse Cloud')).toBe('clickhousecloud');
-    expect(canonicalizeServerName('ClickHouse_Cloud')).toBe('clickhousecloud');
-    expect(canonicalizeServerName('clickhouse-cloud')).toBe('clickhousecloud');
+  it('folds case and treats separators as equivalent', () => {
+    expect(canonicalizeServerName('ClickHouse Cloud')).toBe('clickhouse-cloud');
+    expect(canonicalizeServerName('ClickHouse_Cloud')).toBe('clickhouse-cloud');
+    expect(canonicalizeServerName('clickhouse-cloud')).toBe('clickhouse-cloud');
+  });
+
+  it('discards no character, so distinct names keep distinct keys', () => {
+    /** Each pair below was merged by an earlier revision of this function, and
+     * each merge handed one server's tools to a request for the other. */
+    expect(canonicalizeServerName('\u00e9foo')).not.toBe(
+      canonicalizeServerName('foo')
+    );
+    expect(canonicalizeServerName('\u0130foo')).not.toBe(
+      canonicalizeServerName('ifoo')
+    );
+    expect(canonicalizeServerName('\u2764\ufe0f')).not.toBe(
+      canonicalizeServerName('\u2600\ufe0f')
+    );
+    expect(canonicalizeServerName('---')).not.toBe(
+      canonicalizeServerName('!!!')
+    );
+  });
+
+  it('case-folds past toLowerCase, so a final sigma still matches', () => {
+    expect(canonicalizeServerName('\u039f\u03a3')).toBe(
+      canonicalizeServerName('\u03bf\u03c3')
+    );
+  });
+
+  it('composes, so one name written two ways agrees with itself', () => {
+    expect(canonicalizeServerName('e\u0301foo')).toBe(
+      canonicalizeServerName('\u00e9foo')
+    );
   });
 });
 describe('tool_search mcp_server filtering', () => {

--- a/src/tools/__tests__/ToolSearch.test.ts
+++ b/src/tools/__tests__/ToolSearch.test.ts
@@ -1283,6 +1283,19 @@ describe('resolveServerFilters', () => {
     ]);
   });
 
+  it('never fuzzy-matches names that canonicalize to nothing', () => {
+    /** `---` and `!!!` both reduce to the empty string; treating that as a
+     * shared key would hand one server's tools to an unrelated request. */
+    const punctuation = ['---'];
+    expect(resolveServerFilters(['!!!'], punctuation)).toEqual({
+      resolved: [],
+      unresolved: ['!!!'],
+    });
+    expect(resolveServerFilters(['---'], punctuation).resolved).toEqual([
+      '---',
+    ]);
+  });
+
   it('reports a name that matches nothing', () => {
     expect(resolveServerFilters(['nope'], available)).toEqual({
       resolved: [],
@@ -1391,6 +1404,35 @@ describe('tool_search mcp_server filtering', () => {
     expect(output).toContain('no tools left to search');
     expect(output).toContain('slack');
     expect(output).not.toContain('No MCP server matched');
+  });
+
+  it('reports the unsearched half of a partly resolved filter', async () => {
+    /** GitHub answers, Slack has nothing deferred. Returning only GitHub
+     * results without saying so would read as though both were searched. */
+    const mixed = new Map(
+      [
+        { name: 'send_message_mcp_slack', defer_loading: false },
+        { name: 'create_issue_mcp_github', defer_loading: true },
+      ].map((tool) => [
+        tool.name,
+        {
+          ...tool,
+          description: tool.name,
+          parameters: { type: 'object', properties: {} },
+        },
+      ])
+    );
+
+    const output = String(
+      await createToolSearch({
+        mode: 'local',
+        toolRegistry: mixed as never,
+      }).invoke({ query: 'create', mcp_server: ['github', 'slack'] })
+    );
+
+    expect(output).toContain('create_issue_mcp_github');
+    expect(output).toContain('no tools left to search');
+    expect(output).toContain('slack');
   });
 
   it('diagnoses an idle server even when nothing at all is deferred', async () => {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1262,6 +1262,10 @@ export type ToolSearchArtifact = {
     /** Servers that had tools to search, emitted when a server filter matched
      * nothing so the caller can see what it could have asked for. */
     available_mcp_servers?: string[];
+    /** Requested servers that matched no registered server. */
+    unmatched_mcp_servers?: string[];
+    /** Requested servers that exist but had no tools left to search. */
+    idle_mcp_servers?: string[];
   };
 };
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1259,6 +1259,9 @@ export type ToolSearchArtifact = {
     total_searched: number;
     pattern: string;
     error?: string;
+    /** Servers that had tools to search, emitted when a server filter matched
+     * nothing so the caller can see what it could have asked for. */
+    available_mcp_servers?: string[];
   };
 };
 


### PR DESCRIPTION
## Summary

`tool_search`'s `mcp_server` filter compared the requested name against the tool's suffix with `===`, so a near-miss filtered everything out and reported it as an empty registry.

**The failure that prompted this.** An agent with 18 ClickHouse tools attached searched with:

```jsonc
tool_search { "query": "ClickHouse run select query", "mcp_server": "mcp-clickhouse" }
```

The server is keyed `clickhouse`, so its tools are named `run_select_query_mcp_clickhouse`; `mcp-clickhouse` is the *published package* name, which is what the model had read. Nothing matched, and the tool answered:

> `No tools available to search from MCP server(s): mcp-clickhouse. The tool registry is empty or no matching deferred tools are registered.`

The agent concluded the service was unavailable and hedged the answer it had been asked for, closing with "The ClickHouse code graph service was not available in this session." Its 18 ClickHouse tools were in the registry the whole time.

Two things were wrong: the filter had no tolerance for a name that means the same server, and the message conflated "registry is empty" with "your filter matched nothing" while never naming the servers that do exist.

## Changes

- **`resolveServerFilters`** maps requested names onto servers that actually have tools registered: exact match first, then case- and separator-insensitive, then with a leading `mcp` token dropped.
  - Separator leniency matters because a host rewrites characters it cannot put in a tool name — LibreChat turns `ClickHouse Cloud` into `ClickHouse_Cloud`, so a model asking for `clickhouse-cloud` is naming the same server.
  - Trying the three in that order keeps a deployment running both `github` and `mcp-github` unambiguous: each resolves to itself, never to the other.
- **The empty-result message now distinguishes three cases** it used to collapse into one: nothing is registered, the requested name matched nothing (and here are the servers that exist), or the named server genuinely has no tools. `available_mcp_servers` is added to the result metadata.
- Server listings (`mcp_server` with an empty query) format against the resolved names, so a lenient match lists the right server.
- `resolveServerFilters` and `canonicalizeServerName` are exported alongside the existing `isFromAnyMcpServer`, which is unchanged.

## Testing

`src/tools/__tests__/ToolSearch.test.ts` — **108 passed**.

Unit coverage for the resolver: exact names, the package-name case, case/separator differences, the `github` vs `mcp-github` disambiguation, unresolvable names, deduplication of filters that resolve to the same server, and mixed resolvable/unresolvable input.

Flow-level coverage driving `createToolSearch({ mode: 'local' })` against a small registry, which is what actually reproduces the bug:

- `mcp_server: 'mcp-clickhouse'` now returns the `clickhouse` tools and excludes the GitHub one.
- An unknown server name reports the available servers and no longer claims the registry is empty.

Those two polyfill `globalThis.crypto`, which Node 18 does not expose and LangChain's callback manager needs to mint a uuid before the tool body runs.

`npx tsc --noEmit` clean. ESLint reports 0 errors on the touched files (1 warning, also present on `main`).

## Note

Committed without a GPG signature at the author's request — the signing key could not be unlocked in the environment this was prepared in.
