### PR TITLE
⏩ feat: Start Foreground Subagents During Parent Streaming

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -297,3 +297,12 @@ cancellation, output, and command results remain invocation-scoped.
 
 See [ADR 0002](docs/adr/0002-stable-execution-worlds.md) for the adapter
 identity and compatibility boundary.
+
+## Prepared Subagent Invocations
+
+A **Prepared Subagent Invocation** is a foreground built-in subagent invocation
+started after its provider seals the arguments but before the parent model
+attempt completes. It is owned by that attempt and the executing agent, bound
+to the tool-call ID and canonical arguments, and adopted once by ToolNode for
+normal result processing. It is process-local and is not a Durable Subagent
+Execution replay mechanism. See [ADR 0009](docs/adr/0009-prepare-sealed-subagent-invocations.md).

--- a/docs/adr/0009-prepare-sealed-subagent-invocations.md
+++ b/docs/adr/0009-prepare-sealed-subagent-invocations.md
@@ -1,0 +1,73 @@
+# ADR 0009: Prepare Sealed Foreground Subagent Invocations in ToolNode
+
+## Status
+
+Accepted
+
+## Context
+
+Event-driven tools already start from provider stream completion signals, but
+all direct graph tools are excluded. A parent therefore finishes generating
+every subagent prompt before any child starts. The graph-tool exclusion also
+preserves a real ordering guarantee: direct tools can interrupt or redirect
+the batch before event-driven tools reach the host.
+
+Starting SubagentExecutor directly from the stream would duplicate ToolNode's
+runtime setup and bypass its hooks, replay, output limits and reference
+registration. Its Execution Record only deduplicates pending child work; it
+is not a replacement for the complete tool lifecycle. Durable Subagent
+Execution additionally requires the finalized parent checkpoint/batch identity.
+
+## Decision
+
+A **Prepared Subagent Invocation** is the raw invocation of a built-in
+foreground subagent started by ToolNode during one explicitly open model
+attempt. It is bound to its owning agent, tool-call ID and canonical arguments.
+A graph-owned module reserves bounded work, adopts the raw result once, and
+cancels abandoned work. The stream uses the existing provider sealing and
+canonical-argument parsing implementation; it never infers completion from a
+closing JSON brace alone.
+
+The first adapter is the built-in subagent wrapper. It invokes the existing
+SubagentExecutor through the same runtime construction as normal tools. Normal
+ToolNode execution adopts its raw output, then applies existing output limits,
+references and completion handling. Ordinary event tools retain the existing
+direct-before-event ordering. There is no generic eager-direct-tool interface
+or second subagent scheduler.
+
+Early starts require event-driven execution with eager execution enabled, a
+single built-in subagent graph tool, no checkpointer, no human-in-the-loop
+mode, no interrupting tool names, and no parent tool lifecycle hooks. Background
+calls, continued child threads, output-reference arguments and excluded tools
+retain normal execution. Child lifecycle hooks still execute in the child.
+An observation-only PostToolBatch registry remains compatible.
+
+The provider-attempt scope opens admission and closes it before retry or
+fallback. Completion reconciles reservations with the final tool calls. Late
+buffered stream events cannot reopen a closed attempt. If an attempt fails,
+discards or changes a call after delegation begins, the run fails closed rather
+than automatically retrying work whose effects cannot be undone. Reset and
+terminal cleanup cancel unadopted and still-running adopted invocations.
+
+`eagerEventToolExecution.maxPendingSubagents` bounds outstanding early work
+and retained raw results per graph; the default is four and zero disables this
+path. Excess calls execute normally with the completed batch. Cancellation-
+ignoring work keeps its admission slot until it settles. This is an early-work
+limit, not a new process-wide limit for all foreground subagents.
+
+## Consequences
+
+- Long sibling prompts overlap with the first child's execution.
+- ToolNode remains the module owning tool runtime and result processing;
+  streaming does not acquire graph lifecycle responsibilities.
+- The reservation interface concentrates identity, cancellation, admission,
+  failure containment and result adoption in one testable module.
+- Checkpointed/HITL runs keep their established replay semantics and do not
+  receive the latency improvement in this first pass.
+- Earlier child side effects are possible before the parent response commits.
+  Cancellation is best effort, never rollback. Automatic provider fallback is
+  deliberately unavailable after an early child invocation starts.
+- Normal result order, references and completion events remain batch-owned;
+  child activity can appear before the parent finishes generating sibling calls.
+- Tests exercise actual streamed model and child graphs, plus cancellation,
+  argument changes, duplicate admission, capacity and ToolNode adoption.

--- a/docs/adr/0009-prepare-sealed-subagent-invocations.md
+++ b/docs/adr/0009-prepare-sealed-subagent-invocations.md
@@ -51,8 +51,7 @@ terminal cleanup cancel unadopted and still-running adopted invocations.
 
 `eagerEventToolExecution.maxPendingSubagents` bounds outstanding early work
 and retained raw results per graph; the default is four and zero disables this
-path. Excess calls execute normally with the completed batch. Cancellation-
-ignoring work keeps its admission slot until it settles. This is an early-work
+path. Excess calls execute normally with the completed batch. An unsettled tool invocation keeps its admission slot until it settles. This is an early-work
 limit, not a new process-wide limit for all foreground subagents.
 
 ## Consequences
@@ -75,3 +74,7 @@ limit, not a new process-wide limit for all foreground subagents.
 ### Trace ownership
 
 Each early invocation opens a singleton tool-dispatch chain before starting its tool and child graph. The normal completed batch collects that result and dispatches deferred calls. This represents the actual streaming timeline without reparenting spans or transferring ownership of a future graph-node span. The dispatch uses the attempt-owned callbacks and the executing agent’s tracing scope, and its input contains only that call.
+
+The early dispatch chain emits only completion status. Raw results stay in the preparation closure and tool observation, preserving tool-specific output redaction even for scalar results that cannot be recursively identified as tool messages.
+
+Capacity tracks outstanding tool invocation promises. Cancellation is still governed by the existing tool and executor contracts: a provider request that outlives a settled cancellation response is not a physical resource this process-local registry can account for. The tracing wrapper must not add an earlier settlement race of its own.

--- a/docs/adr/0009-prepare-sealed-subagent-invocations.md
+++ b/docs/adr/0009-prepare-sealed-subagent-invocations.md
@@ -71,3 +71,7 @@ limit, not a new process-wide limit for all foreground subagents.
   child activity can appear before the parent finishes generating sibling calls.
 - Tests exercise actual streamed model and child graphs, plus cancellation,
   argument changes, duplicate admission, capacity and ToolNode adoption.
+
+### Trace ownership
+
+Each early invocation opens a singleton tool-dispatch chain before starting its tool and child graph. The normal completed batch collects that result and dispatches deferred calls. This represents the actual streaming timeline without reparenting spans or transferring ownership of a future graph-node span. The dispatch uses the attempt-owned callbacks and the executing agent’s tracing scope, and its input contains only that call.

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -146,6 +146,7 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
+import { PreparedSubagents, PreparedSubagentError } from '@/tools/preparedSubagents';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
@@ -898,6 +899,7 @@ export abstract class Graph<
    * Call after a run completes and content has been extracted.
    */
   clearHeavyState(): void {
+    this.preparedSubagents.clear();
     this.config = undefined;
     this.signal = undefined;
     this.callerSignal = undefined;
@@ -1239,6 +1241,8 @@ export abstract class Graph<
     restoreSubagentResumeState(state: SubagentToolNodeResumeState): void;
   }> = new Set();
   private _subagentExecutors = new Set<SubagentExecutor>();
+  readonly preparedSubagents = new PreparedSubagents();
+  protected readonly subagentToolNodes = new Map<string, CustomToolNode<t.BaseGraphState>>();
   public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
     // Return the cached instance unconditionally if one exists. The
     // toolExecution check below decides whether to *create* a new
@@ -1397,16 +1401,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    * paths must not run in that state. */
   protected resolveTrippedBreakerReason(
     breakerSignal: AbortSignal = this.breakerAbort.signal
-  ): StreamLimitExceededError | undefined {
+  ): StreamLimitExceededError | PreparedSubagentError | undefined {
     if (
       breakerSignal.aborted &&
-      breakerSignal.reason instanceof StreamLimitExceededError
+      (breakerSignal.reason instanceof StreamLimitExceededError || breakerSignal.reason instanceof PreparedSubagentError)
     ) {
       return breakerSignal.reason;
     }
     if (
       this.signal?.aborted === true &&
-      this.signal.reason instanceof StreamLimitExceededError
+      (this.signal.reason instanceof StreamLimitExceededError || this.signal.reason instanceof PreparedSubagentError)
     ) {
       return this.signal.reason;
     }
@@ -1581,6 +1585,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /* Init */
 
   resetValues(keepContent?: boolean, checkpointScope?: string): void {
+    this.preparedSubagents.clear();
     this.resetSubagentCheckpointThreadIds();
     this.messages = [];
     this.hasRestoredCheckpointMessages = false;
@@ -2717,6 +2722,48 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
 
   /* Graph */
 
+  canPrestartSubagents(agentContext?: AgentContext): boolean {
+    if (
+      this.eagerEventToolExecution?.enabled !== true ||
+      (this.eagerEventToolExecution.maxPendingSubagents ?? 4) <= 0 ||
+      this.compileOptions?.checkpointer != null ||
+      this.humanInTheLoop?.enabled === true ||
+      (this.interruptingToolNames?.length ?? 0) > 0 ||
+      agentContext == null ||
+      !this.subagentToolNodes.has(agentContext.agentId)
+    ) {
+      return false;
+    }
+    const graphTools = agentContext.graphTools as t.GenericTool[] | undefined;
+    return (
+      graphTools?.length === 1 &&
+      graphTools[0].name === Constants.SUBAGENT &&
+      SUBAGENT_REPLAY_CONTROLLER in graphTools[0]
+    );
+  }
+
+  prestartSubagent(
+    call: ToolCall,
+    attempt: string,
+    agentContext?: AgentContext
+  ): void {
+    if (
+      !this.canPrestartSubagents(agentContext) ||
+      this.config == null ||
+      agentContext == null
+    ) {
+      return;
+    }
+    this.subagentToolNodes
+      .get(agentContext.agentId)
+      ?.prestartSubagent(
+        call,
+        attempt,
+        this.config,
+        this.eagerEventToolExecution?.maxPendingSubagents ?? 4
+      );
+  }
+
   initializeTools({
     currentTools,
     currentToolMap,
@@ -2791,6 +2838,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         hookRegistry: this.hookRegistry,
         humanInTheLoop: this.humanInTheLoop,
         eagerEventToolExecution: this.eagerEventToolExecution,
+        preparedSubagents: this.preparedSubagents,
         codeSessionToolNames: this.codeSessionToolNames,
         eagerEventToolExecutions: this.eagerEventToolExecutions,
         eagerEventToolUsageCount: this.getEagerEventToolUsageCount(
@@ -2816,6 +2864,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           StandardGraph.handleToolCallErrorStatic(this, data, metadata),
       });
       this.registerCompiledToolNode(node);
+      if (agentContext != null) {
+        this.subagentToolNodes.set(agentContext.agentId, node);
+      }
       return node;
     }
 
@@ -4092,7 +4143,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * succeeding fallback would resolve a run the public contract says
          * must reject. Rethrow before any recovery path.
          */
-        if (primaryError instanceof StreamLimitExceededError) {
+        if (
+          primaryError instanceof StreamLimitExceededError ||
+          primaryError instanceof PreparedSubagentError
+        ) {
           /** Tripped before rethrowing so parallel agent nodes' in-flight
            * model calls and subagents stop while the rejection propagates. */
           attemptBreaker.abort(primaryError);
@@ -4342,7 +4396,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               })
           );
         } catch (fallbackError) {
-          if (fallbackError instanceof StreamLimitExceededError) {
+          if (
+            fallbackError instanceof StreamLimitExceededError ||
+            fallbackError instanceof PreparedSubagentError
+          ) {
             /** Same treatment as the primary path: a fallback stream that
              * trips the breaker must stop parallel agent nodes' model calls
              * and subagents before the rejection propagates. */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -2747,9 +2747,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     attempt: string,
     agentContext?: AgentContext
   ): void {
+    const config = this.preparedSubagents.getConfig(attempt);
     if (
       !this.canPrestartSubagents(agentContext) ||
-      this.config == null ||
+      config == null ||
       agentContext == null
     ) {
       return;
@@ -2759,7 +2760,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       ?.prestartSubagent(
         call,
         attempt,
-        this.config,
+        config,
         this.eagerEventToolExecution?.maxPendingSubagents ?? 4
       );
   }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -51,6 +51,7 @@ import {
 } from '@/llm/providers';
 import { ChatModelStreamHandler, dispatchesChatModelStream } from '@/stream';
 import { Constants, ContentTypes, GraphEvents, Providers } from '@/common';
+import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { assertNotTruncatedToolCall } from '@/llm/truncation';
 import { resolveClientOptionsModel } from '@/llm/request';
 import { safeDispatchCustomEvent } from '@/utils/events';
@@ -702,9 +703,8 @@ export async function attemptInvoke(
     },
   };
   const request = resolveAttemptRequest(params, providerStampedConfig);
-  const configuredModel = providerStampedConfig.metadata?.[
-    Constants.INVOKED_MODEL
-  ];
+  const configuredModel =
+    providerStampedConfig.metadata?.[Constants.INVOKED_MODEL];
   const modelId =
     request.modelId ??
     (typeof configuredModel === 'string' ? configuredModel : undefined);
@@ -745,8 +745,14 @@ export async function attemptInvoke(
   if (leaseTarget != null && generationKey != null) {
     registerActiveStreamLimitGeneration(leaseTarget, generationKey);
   }
+  const prepared =
+    params.context?.eagerEventToolExecution?.enabled === true
+      ? params.context.preparedSubagents
+      : undefined;
+  const preparedAttempt = resolveGenerationKey(stampedConfig.metadata);
+  prepared?.begin(preparedAttempt);
   try {
-    return await attemptInvokeBody(
+    const result = await attemptInvokeBody(
       {
         request,
         context: params.context,
@@ -755,7 +761,27 @@ export async function attemptInvoke(
       },
       stampedConfig
     );
+    const calls =
+      result.messages?.flatMap((message) =>
+        'tool_calls' in message
+          ? ((message.tool_calls as ToolCall[] | undefined) ?? [])
+          : []
+      ) ?? [];
+    prepared?.finish(preparedAttempt, calls);
+    return result;
+  } catch (error) {
+    prepared?.finish(preparedAttempt, undefined, error);
+    throw error;
   } finally {
+    const chunks = params.context?.eagerEventToolCallChunks;
+    if (prepared != null && chunks != null) {
+      const prefix = `prepared:${preparedAttempt}\u0000`;
+      for (const key of chunks.keys()) {
+        if (key.startsWith(prefix)) {
+          chunks.delete(key);
+        }
+      }
+    }
     if (leaseTarget != null && generationKey != null) {
       releaseStreamLimitGeneration(leaseTarget, generationKey);
     }
@@ -1053,7 +1079,7 @@ async function attemptInvokeBody(
       const signal = config.signal;
       if (
         signal?.aborted === true &&
-        signal.reason instanceof StreamLimitExceededError
+        (signal.reason instanceof StreamLimitExceededError || signal.reason instanceof PreparedSubagentError)
       ) {
         throw signal.reason;
       }
@@ -1290,6 +1316,7 @@ async function attemptInvokeBody(
       const ownAbort =
         restartRoute === 'aborted' &&
         !(error instanceof StreamLimitExceededError) &&
+        !(error instanceof PreparedSubagentError) &&
         config.signal?.aborted !== true;
       if (!ownAbort) {
         throw error;
@@ -1639,7 +1666,7 @@ export async function tryFallbackProviders({
        * a run that must reject. Check before every fallback invocation. */
       if (
         config?.signal?.aborted === true &&
-        config.signal.reason instanceof StreamLimitExceededError
+        (config.signal.reason instanceof StreamLimitExceededError || config.signal.reason instanceof PreparedSubagentError)
       ) {
         throw config.signal.reason;
       }
@@ -1673,7 +1700,7 @@ export async function tryFallbackProviders({
        * provider failure. Continuing would try the remaining fallbacks and a
        * succeeding one would resolve a run that must reject.
        */
-      if (e instanceof StreamLimitExceededError) {
+      if (e instanceof StreamLimitExceededError || e instanceof PreparedSubagentError) {
         throw e;
       }
       /** A parallel sibling's trip aborts this branch's composed signal, and
@@ -1682,7 +1709,7 @@ export async function tryFallbackProviders({
        * abort. Rethrow the breaker's own reason instead. */
       if (
         config?.signal?.aborted === true &&
-        config.signal.reason instanceof StreamLimitExceededError
+        (config.signal.reason instanceof StreamLimitExceededError || config.signal.reason instanceof PreparedSubagentError)
       ) {
         throw config.signal.reason;
       }

--- a/src/llm/invoke.ts
+++ b/src/llm/invoke.ts
@@ -750,7 +750,7 @@ export async function attemptInvoke(
       ? params.context.preparedSubagents
       : undefined;
   const preparedAttempt = resolveGenerationKey(stampedConfig.metadata);
-  prepared?.begin(preparedAttempt);
+  prepared?.begin(preparedAttempt, stampedConfig);
   try {
     const result = await attemptInvokeBody(
       {

--- a/src/specs/eager-subagents.test.ts
+++ b/src/specs/eager-subagents.test.ts
@@ -1,0 +1,235 @@
+import { MemorySaver } from '@langchain/langgraph';
+import { HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { BaseMessage } from '@langchain/core/messages';
+import {
+  STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY,
+  STREAMED_TOOL_CALL_SEAL_METADATA_KEY,
+  OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+  BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+  GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+} from '@/tools/streamedToolCallSeals';
+import { PreparedSubagentError } from '@/tools/preparedSubagents';
+import { Constants, Providers } from '@/common';
+import { StandardGraph } from '@/graphs/Graph';
+import { FakeChatModel } from '@/llm/fake';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const calls: ToolCall[] = ['first', 'second'].map((id) => ({
+  id,
+  name: Constants.SUBAGENT,
+  args: { description: `Research ${id}`, subagent_type: 'researcher' },
+}));
+
+class ParentModel extends FakeChatModel {
+  private invoked = false;
+  readonly observed: BaseMessage[][] = [];
+  constructor(
+    private readonly started: Promise<void>,
+    private readonly fail: boolean,
+    private readonly sealStyle: 'responses' | 'bedrock' | 'google'
+  ) {
+    super({ responses: ['unused'] });
+  }
+  override async *_streamResponseChunks(
+    messages: BaseMessage[]
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.observed.push(messages);
+    if (this.invoked) {
+      yield this._createResponseChunk('Both results received.');
+      return;
+    }
+    this.invoked = true;
+    for (let index = 0; index < calls.length; index++) {
+      const call = calls[index];
+      const adapter = {
+        bedrock: BEDROCK_CONVERSE_STREAMED_TOOL_CALL_ADAPTER,
+        google: GOOGLE_STREAMED_TOOL_CALL_ADAPTER,
+        responses: OPENAI_RESPONSES_STREAMED_TOOL_CALL_ADAPTER,
+      }[this.sealStyle];
+      const seal =
+        this.sealStyle === 'google'
+          ? { kind: 'all' }
+          : { kind: 'single', index };
+      yield this._createResponseChunk(
+        '',
+        [
+          {
+            id: call.id,
+            name: call.name,
+            args: JSON.stringify(call.args),
+            index,
+          },
+        ],
+        {
+          [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]: adapter,
+          ...(this.sealStyle === 'bedrock'
+            ? {}
+            : { [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: seal }),
+        }
+      );
+      if (this.sealStyle === 'bedrock') {
+        yield this._createResponseChunk('', [{ index, args: '' }], {
+          [STREAMED_TOOL_CALL_ADAPTER_METADATA_KEY]: adapter,
+          [STREAMED_TOOL_CALL_SEAL_METADATA_KEY]: seal,
+        });
+      }
+      if (index === 0) {
+        let timeout!: ReturnType<typeof setTimeout>;
+        try {
+          await Promise.race([
+            this.started,
+            new Promise<never>((_, reject) => {
+              timeout = setTimeout(
+                () =>
+                  reject(
+                    new Error('Child did not start before sibling prompt')
+                  ),
+                3000
+              );
+            }),
+          ]);
+        } finally {
+          clearTimeout(timeout);
+        }
+        if (this.fail) {
+          throw new Error('provider disconnected');
+        }
+      }
+    }
+  }
+}
+
+class ChildModel extends FakeChatModel {
+  starts = 0;
+  constructor(private readonly started: () => void) {
+    super({ responses: ['unused'] });
+  }
+  override async *_streamResponseChunks(): AsyncGenerator<ChatGenerationChunk> {
+    this.starts++;
+    this.started();
+    yield this._createResponseChunk('Research result.');
+  }
+}
+
+function fixture(
+  fail = false,
+  sealStyle: 'responses' | 'bedrock' | 'google' = 'responses'
+) {
+  const started = deferred();
+  const parent = new ParentModel(started.promise, fail, sealStyle);
+  const child = new ChildModel(started.resolve);
+  const parentOptions = {
+    model: 'fake-parent',
+    fallbacks: [
+      {
+        provider: Providers.OPENAI,
+        clientOptions: { model: 'unused-fallback' },
+      },
+    ],
+  };
+  const graph = new StandardGraph({
+    runId: 'eager-subagent-integration',
+    agents: [
+      {
+        agentId: 'parent',
+        provider: Providers.OPENAI,
+        instructions: 'Delegate work.',
+        clientOptions: parentOptions,
+        toolDefinitions: [
+          {
+            name: 'unused',
+            description: 'unused',
+            parameters: { type: 'object', properties: {} },
+          },
+        ],
+        subagentConfigs: [
+          {
+            type: 'researcher',
+            name: 'Researcher',
+            description: 'Research tasks',
+            agentInputs: {
+              agentId: 'researcher',
+              provider: Providers.OPENAI,
+              instructions: 'Research.',
+            },
+          },
+        ],
+      },
+    ],
+  });
+  graph.eagerEventToolExecution = { enabled: true };
+  graph.overrideModel = parent;
+  graph.setSubagentModelOverride(child);
+  return { graph, parent, child };
+}
+
+describe('Eager subagents through the real graph and provider stream', () => {
+  it.each(['responses', 'bedrock', 'google'] as const)(
+    'starts the first child before the second prompt using %s seals',
+    async (style) => {
+      const { graph, parent, child } = fixture(false, style);
+      try {
+        const result = await graph.createWorkflow().invoke(
+          { messages: [new HumanMessage('Research two things')] },
+          {
+            configurable: { thread_id: 'thread', run_id: 'run' },
+          }
+        );
+        expect(child.starts).toBe(2);
+        expect(parent.observed).toHaveLength(2);
+        expect(
+          result.messages.filter((message) => message instanceof ToolMessage)
+        ).toHaveLength(2);
+      } finally {
+        graph.clearHeavyState();
+      }
+    }
+  );
+
+  it('fails closed instead of retrying a provider after the first child starts', async () => {
+    const { graph, child } = fixture(true);
+    try {
+      await expect(
+        graph.createWorkflow().invoke(
+          { messages: [new HumanMessage('Research two things')] },
+          {
+            configurable: { thread_id: 'thread', run_id: 'run' },
+          }
+        )
+      ).rejects.toBeInstanceOf(PreparedSubagentError);
+      expect(child.starts).toBe(1);
+    } finally {
+      graph.clearHeavyState();
+    }
+  });
+  it('keeps durable checkpoint execution on the normal path', () => {
+    const { graph } = fixture();
+    graph.createWorkflow();
+    const agent = graph.agentContexts.get('parent');
+    expect(graph.canPrestartSubagents(agent)).toBe(true);
+    graph.compileOptions = { checkpointer: new MemorySaver() };
+    expect(graph.canPrestartSubagents(agent)).toBe(false);
+    graph.clearHeavyState();
+  });
+
+  it('keeps interrupting or disabled configurations on the normal path', () => {
+    const { graph } = fixture();
+    graph.createWorkflow();
+    const agent = graph.agentContexts.get('parent');
+    graph.interruptingToolNames = ['ask_user_question'];
+    expect(graph.canPrestartSubagents(agent)).toBe(false);
+    graph.interruptingToolNames = undefined;
+    graph.eagerEventToolExecution = { enabled: true, maxPendingSubagents: 0 };
+    expect(graph.canPrestartSubagents(agent)).toBe(false);
+    graph.clearHeavyState();
+  });
+});

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1333,7 +1333,9 @@ function startPreparedSubagents(
     (graph as Partial<StandardGraph>).canPrestartSubagents?.(agentContext) !==
       true ||
     graph.preparedSubagents.isOpen(attempt) !== true ||
-    isBatchSensitiveToolExecution(graph, metadata)
+    graph.hookRegistry?.hasResultAlteringHooks(
+      graph.preparedSubagents.getConfig(attempt)?.configurable?.run_id
+    ) === true
   ) {
     return;
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -15,6 +15,7 @@ import {
   requiresStreamLimitAccounting,
   StreamLimitExceededError,
   STREAM_LIMIT_EPOCH_KEY,
+  resolveGenerationKey,
 } from '@/llm/streamLimits';
 import {
   getStreamedToolCallSeal,
@@ -56,6 +57,7 @@ import {
 } from '@/utils/truncation';
 import { resolveToolOutcome, outcomeFieldsFromResult } from '@/tools/intentArg';
 import { TOOL_OUTPUT_REF_PATTERN } from '@/tools/toolOutputReferences';
+import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { isReasoningContentBlock } from '@/messages/core';
 import { safeDispatchCustomEvent } from '@/utils/events';
 import { composeAbortSignals } from '@/utils/misc';
@@ -1319,6 +1321,63 @@ function startReadyStreamedEagerToolExecutions(args: {
   });
 }
 
+/** Shares provider sealing/parsing with event tools, but never relaxes their batch guard. */
+function startPreparedSubagents(
+  graph: StandardGraph,
+  agentContext: AgentContext | undefined,
+  chunk: Partial<AIMessageChunk>,
+  metadata?: Record<string, unknown>
+): void {
+  const attempt = resolveGenerationKey(metadata);
+  if (
+    (graph as Partial<StandardGraph>).canPrestartSubagents?.(agentContext) !==
+      true ||
+    graph.preparedSubagents.isOpen(attempt) !== true ||
+    isBatchSensitiveToolExecution(graph, metadata)
+  ) {
+    return;
+  }
+  let calls: ToolCall[];
+  if (hasOnArrivalToolCallSeal(chunk) && (chunk.tool_calls?.length ?? 0) > 0) {
+    calls = chunk.tool_calls!;
+  } else {
+    const seal = getStreamedToolCallSeal(chunk.response_metadata);
+    const allowSequentialSeal =
+      canPrestartSequentialStreamedToolChunks(agentContext) ||
+      streamedToolCallAdapterAllowsSequentialSeal(chunk.response_metadata);
+    if (!hasExplicitStreamedToolCallSeals(chunk) && !allowSequentialSeal) {
+      return;
+    }
+    const stepKey = `prepared:${attempt}`;
+    recordEagerToolCallChunks({
+      graph,
+      stepKey,
+      toolCallChunks: chunk.tool_call_chunks ?? [],
+      seal,
+    });
+    calls = getStreamedReadyToolCalls({
+      graph,
+      stepKey,
+      toolCallChunks: chunk.tool_call_chunks,
+      seal,
+      allowSequentialSeal,
+    });
+    pruneEagerToolCallChunkStates({
+      graph,
+      stepKey,
+      toolCallIds: new Set(calls.map((call) => call.id!)),
+    });
+  }
+  for (const call of calls) {
+    if (
+      call.name === Constants.SUBAGENT &&
+      !hasToolOutputReference(call.args)
+    ) {
+      graph.prestartSubagent(call, attempt, agentContext);
+    }
+  }
+}
+
 export function getChunkContent({
   chunk,
   provider,
@@ -1597,7 +1656,7 @@ export class ChatModelStreamHandler implements t.EventHandler {
       if (
         eventBreaker != null &&
         eventBreaker.signal.aborted &&
-        eventBreaker.signal.reason instanceof StreamLimitExceededError
+        (eventBreaker.signal.reason instanceof StreamLimitExceededError || eventBreaker.signal.reason instanceof PreparedSubagentError)
       ) {
         throw eventBreaker.signal.reason;
       }
@@ -1743,6 +1802,9 @@ export class ChatModelStreamHandler implements t.EventHandler {
         return;
       }
       throwIfRunBreakerTripped();
+      if (hasOnArrivalToolCallSeal(chunk)) {
+        startPreparedSubagents(graph, agentContext, chunk, metadata);
+      }
       if (hasFinalToolCallSignal(chunk)) {
         startEagerToolExecutions({
           graph,
@@ -1837,6 +1899,11 @@ export class ChatModelStreamHandler implements t.EventHandler {
           sealAll: hasFinalToolCallSignal(chunk),
         });
       }
+    }
+
+    if (!hasOnArrivalToolCallSeal(chunk) && !runScopeInvalidated()) {
+      throwIfRunBreakerTripped();
+      startPreparedSubagents(graph, agentContext, chunk, metadata);
     }
 
     if (isEmptyContent) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import { ToolCall } from '@langchain/core/messages/tool';
+import { RunnableLambda } from '@langchain/core/runnables';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import {
   AIMessage,
@@ -1367,23 +1368,31 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const turn = this.toolUsageCount.get(call.name) ?? 0;
         this.toolUsageCount.set(call.name, turn + 1);
         this.directPathTurns.set(call.id!, turn);
+        // An early call is its own dispatch, before the completed batch exists.
+        // Give it a real chain parent instead of borrowing the model's callback
+        // parent or attempting to reparent already-exported observations later.
         return this.withToolScope(capturedConfig, (scopedConfig) =>
-          this.invokeWithRuntime(
-            tool,
-            {
-              ...preparedCall,
-              type: 'tool_call',
-              turn,
-              stepId: this.toolCallStepIds?.get(call.id!),
-            },
-            preparedCall,
-            {
-              ...scopedConfig,
-              signal: composeAbortSignals(
-                signal,
-                composeAbortSignals(config.signal, scope?.controller.signal)
-              ),
-            }
+          RunnableLambda.from(async (_input, dispatchConfig) =>
+            this.invokeWithRuntime(
+              tool,
+              {
+                ...preparedCall,
+                type: 'tool_call',
+                turn,
+                stepId: this.toolCallStepIds?.get(call.id!),
+              },
+              preparedCall,
+              {
+                ...dispatchConfig,
+                signal: composeAbortSignals(
+                  signal,
+                  composeAbortSignals(config.signal, scope?.controller.signal)
+                ),
+              }
+            )
+          ).invoke(
+            { messages: [new AIMessage({ content: '', tool_calls: [preparedCall] })] },
+            { ...scopedConfig, runId: undefined, runName: `tools=${this.executingAgentId ?? ''}` }
           )
         );
       }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -46,8 +46,17 @@ import type {
   PostToolBatchEntry,
   ToolApprovalReplayKey,
 } from '@/hooks';
+import type { PreparedSubagents } from '@/tools/preparedSubagents';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
+import {
+  type CallerCapabilityProjection,
+  createCallerCapabilityProjectionSnapshot,
+  isToolDefinitionActive,
+  isProgrammaticControlTool,
+  mergeCallerCapabilityDefinitions,
+  resolveCallerCapabilityProjection,
+} from '@/tools/CallerCapabilities';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
@@ -57,6 +66,13 @@ import {
   serializeStructuredValueBounded,
   serializeToolContentBounded,
 } from '@/utils/toolContent';
+import {
+  buildToolExecutionRequestPlan,
+  coerceArgsForSchema,
+  coerceRecordArgs,
+  resolveRuntimeSessionHint,
+  recordArgsEqual,
+} from '@/tools/eagerEventExecution';
 import {
   attachSubagentResumeManifest,
   SUBAGENT_PARENT_BATCH_CONFIG_KEY,
@@ -69,13 +85,6 @@ import {
   isIntentLabelProperty,
   outcomeFieldsFromResult,
 } from '@/tools/intentArg';
-import {
-  buildToolExecutionRequestPlan,
-  coerceArgsForSchema,
-  coerceRecordArgs,
-  resolveRuntimeSessionHint,
-  recordArgsEqual,
-} from '@/tools/eagerEventExecution';
 import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
@@ -96,16 +105,9 @@ import {
   resolveLocalToolRegistry,
   resolveLocalExecutionTools,
 } from '@/tools/local';
-import {
-  type CallerCapabilityProjection,
-  createCallerCapabilityProjectionSnapshot,
-  isToolDefinitionActive,
-  isProgrammaticControlTool,
-  mergeCallerCapabilityDefinitions,
-  resolveCallerCapabilityProjection,
-} from '@/tools/CallerCapabilities';
 import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
+import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { attachRunStepResumeState } from '@/tools/runStepResume';
 
 /** Host-facing batch requests must not carry the batch's breaker scope —
@@ -793,6 +795,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private getBreakerSignal?: () => AbortSignal | undefined;
   /** Owning graph's immutable run scope; captured once per batch. */
   private getRunScope?: () => RunBreakerScope;
+  private preparedSubagents?: PreparedSubagents;
   /**
    * Monotonic counter used to mint a unique scope id for anonymous
    * batches (ones invoked without a `run_id` in
@@ -842,6 +845,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     fileCheckpointer,
     getBreakerSignal,
     getRunScope,
+    preparedSubagents,
     restoreRunStepResumeState,
     createRunStepResumeState,
   }: t.ToolNodeConstructorParams) {
@@ -927,6 +931,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     this.toolExecution = toolExecution;
     this.getBreakerSignal = getBreakerSignal;
     this.getRunScope = getRunScope;
+    this.preparedSubagents = preparedSubagents;
     // Caller-provided checkpointer wins. Graphs use this to share a
     // single per-Run instance across every ToolNode they compile so
     // `Run.rewindFiles()` reaches the same snapshot store regardless
@@ -961,6 +966,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     options?: Partial<RunnableConfig>
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ): Promise<any> {
+    return this.withToolScope(options, (scoped) => super.invoke(input, scoped));
+  }
+
+  private withToolScope<R>(
+    options: Partial<RunnableConfig> | undefined,
+    invoke: (config: Partial<RunnableConfig> | undefined) => Promise<R>
+  ): Promise<R> {
     // Explicit agent identity for tool callbacks: node-name parsing is
     // ambiguous when agent ids themselves embed node prefixes, so the
     // handler prefers this metadata (see `isForeignScope`).
@@ -995,7 +1007,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // `LangfuseRuntimeContext.agentId`).
         agentId: this.executingAgentId,
       }),
-      () => super.invoke(input, scopedOptions)
+      () => invoke(scopedOptions)
     );
   }
 
@@ -1280,6 +1292,105 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   /**
+   * Forward the graph state as langgraph 1.4's `runtime.state` so
+   * tools can read it off their second argument instead of the
+   * deprecated `getCurrentTaskInput()` (which relies on
+   * `node:async_hooks` and is browser-incompatible). Shape mirrors
+   * langgraph's prebuilt ToolNode runtime exactly.
+   */
+  private invokeWithRuntime(
+    tool: t.GenericTool,
+    invokeParams: Record<string, unknown>,
+    call: ToolCall,
+    config: RunnableConfig,
+    runInput?: RunToolBatchContext<T>['runInput']
+  ): Promise<unknown> {
+    const lgConfig = config as LangGraphRunnableConfig;
+    const runtime: ToolRuntime<T> = {
+      ...config,
+      state: runInput as ToolRuntime<T>['state'],
+      toolCallId: call.id ?? '',
+      config,
+      context: lgConfig.context as ToolRuntime<T>['context'],
+      store: (lgConfig.store ?? null) as ToolRuntime<T>['store'],
+      writer:
+        lgConfig.writer ??
+        (config.configurable?.writer as ToolRuntime<T>['writer']) ??
+        null,
+    };
+    this.throwIfBreakerTripped(config);
+    config.signal?.throwIfAborted();
+    return tool.invoke(invokeParams, runtime);
+  }
+
+  /** Only Graph's built-in subagent binding is allowed to call this seam. */
+  prestartSubagent(
+    call: ToolCall,
+    attempt: string,
+    config: RunnableConfig,
+    capacity: number
+  ): void {
+    const runId = (config.configurable?.run_id as string | undefined) ?? '';
+    if (
+      call.name !== Constants.SUBAGENT ||
+      call.id == null ||
+      call.args.run_in_background === true ||
+      call.args.subagent_thread_id != null ||
+      this.humanInTheLoop?.enabled === true ||
+      this.hookRegistry?.hasResultAlteringHooks(runId) === true ||
+      this.eagerEventToolExecution?.excludeToolNames?.includes(call.name) ===
+        true
+    ) {
+      return;
+    }
+    const tool = this.toolMap.get(call.name);
+    if (tool == null || this.preparedSubagents == null) {
+      return;
+    }
+    const scope = this.getRunScope?.();
+    const capturedConfig = {
+      ...config,
+      configurable: {
+        ...config.configurable,
+        [RUN_BREAKER_SCOPE_CONFIG_KEY]: scope,
+        [SUBAGENT_PARENT_BATCH_CONFIG_KEY]: attempt,
+      },
+    };
+    const args = JSON.parse(JSON.stringify(call.args)) as ToolCall['args'];
+    const preparedCall = { ...call, args };
+    this.preparedSubagents.start(
+      attempt,
+      this.executingAgentId ?? '',
+      preparedCall,
+      capacity,
+      (signal) => {
+        const turn = this.toolUsageCount.get(call.name) ?? 0;
+        this.toolUsageCount.set(call.name, turn + 1);
+        this.directPathTurns.set(call.id!, turn);
+        return this.withToolScope(capturedConfig, (scopedConfig) =>
+          this.invokeWithRuntime(
+            tool,
+            {
+              ...preparedCall,
+              type: 'tool_call',
+              turn,
+              stepId: this.toolCallStepIds?.get(call.id!),
+            },
+            preparedCall,
+            {
+              ...scopedConfig,
+              signal: composeAbortSignals(
+                signal,
+                composeAbortSignals(config.signal, scope?.controller.signal)
+              ),
+            }
+          )
+        );
+      }
+    );
+  }
+
+  /**
    * Runs a single tool call with error handling.
    *
    * `batchIndex` is the tool's position within the current ToolNode
@@ -1371,6 +1482,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        */
       const usageCount =
         batchContext.usageCount ??
+        this.directPathTurns.get(call.id ?? '') ??
         ((): number => {
           const next = this.toolUsageCount.get(call.name) ?? 0;
           this.toolUsageCount.set(call.name, next + 1);
@@ -1493,31 +1605,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         }
       }
 
-      /**
-       * Forward the graph state as langgraph 1.4's `runtime.state` so
-       * tools can read it off their second argument instead of the
-       * deprecated `getCurrentTaskInput()` (which relies on
-       * `node:async_hooks` and is browser-incompatible). Shape mirrors
-       * langgraph's prebuilt ToolNode runtime exactly.
-       */
-      const lgConfig = config as LangGraphRunnableConfig;
-      const runtime: ToolRuntime<T> = {
-        ...config,
-        state: runInput as ToolRuntime<T>['state'],
-        toolCallId: call.id ?? '',
-        config,
-        context: lgConfig.context as ToolRuntime<T>['context'],
-        store: (lgConfig.store ?? null) as ToolRuntime<T>['store'],
-        writer:
-          lgConfig.writer ??
-          (config.configurable?.writer as ToolRuntime<T>['writer']) ??
-          null,
-      };
-      /** A sibling can trip the breaker while the PreToolUse hooks above
-       * are awaited; a tool that never inspects its runtime signal would
-       * still run. Recheck at the last moment before execution. */
       this.throwIfBreakerTripped(config);
-      const output = await tool.invoke(invokeParams, runtime);
+      const output = await (this.preparedSubagents?.take(
+        this.executingAgentId ?? '',
+        { ...call, args }
+      ) ?? this.invokeWithRuntime(tool, invokeParams, call, config, runInput));
       if (isCommand(output)) {
         return output;
       }
@@ -1633,7 +1725,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
        * safety abort, not a tool failure to report back to the model. It
        * passes through like an interrupt so the whole run rejects.
        */
-      if (e instanceof StreamLimitExceededError) {
+      if (
+        e instanceof StreamLimitExceededError ||
+        e instanceof PreparedSubagentError
+      ) {
         throw e;
       }
       if (this.errorHandler) {
@@ -1777,6 +1872,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     config: RunnableConfig,
     batchContext: RunToolBatchContext<T> = {}
   ): Promise<BaseMessage | Command> {
+    if (
+      this.preparedSubagents?.owns(this.executingAgentId ?? '', call) === true &&
+      this.hookRegistry?.hasResultAlteringHooks(
+        (config.configurable?.run_id as string | undefined) ?? ''
+      ) === true
+    ) {
+      this.preparedSubagents.clear();
+      throw new PreparedSubagentError('Tool hooks changed after a subagent started.');
+    }
     const replayController = (
       this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
     )?.[SUBAGENT_REPLAY_CONTROLLER];
@@ -2735,7 +2839,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const signal = config.signal;
     if (
       signal?.aborted === true &&
-      signal.reason instanceof StreamLimitExceededError
+      (signal.reason instanceof StreamLimitExceededError || signal.reason instanceof PreparedSubagentError)
     ) {
       throw signal.reason;
     }
@@ -4435,7 +4539,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * otherwise perform side effects on a failed run. */
     if (
       composedSignal?.aborted === true &&
-      composedSignal.reason instanceof StreamLimitExceededError
+      (composedSignal.reason instanceof StreamLimitExceededError || composedSignal.reason instanceof PreparedSubagentError)
     ) {
       throw composedSignal.reason;
     }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1371,34 +1371,67 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // An early call is its own dispatch, before the completed batch exists.
         // Give it a real chain parent instead of borrowing the model's callback
         // parent or attempting to reparent already-exported observations later.
-        return this.withToolScope(capturedConfig, (scopedConfig) =>
-          RunnableLambda.from(async (_input, dispatchConfig) =>
-            this.invokeWithRuntime(
-              tool,
-              {
-                ...preparedCall,
-                type: 'tool_call',
-                turn,
-                stepId: this.toolCallStepIds?.get(call.id!),
-              },
-              preparedCall,
-              {
-                ...dispatchConfig,
-                signal: composeAbortSignals(
-                  signal,
-                  composeAbortSignals(config.signal, scope?.controller.signal)
-                ),
-              }
-            )
-          ).invoke(
-            { messages: [new AIMessage({ content: '', tool_calls: [preparedCall] })] },
-            { ...scopedConfig, runId: undefined, runName: `tools=${this.executingAgentId ?? ''}` }
-          )
-        );
+        return this.withToolScope(capturedConfig, async (scopedConfig) => {
+          let output: unknown;
+          let failure: { error: unknown } | undefined;
+          const dispatchOptions = {
+            ...scopedConfig,
+            runName: `tools=${this.executingAgentId ?? ''}`,
+          };
+          delete dispatchOptions.runId;
+          delete dispatchOptions.signal;
+          delete dispatchOptions.timeout;
+          // Isolate ambient cancellation too: RunnableLambda races its signal,
+          // but capacity must remain owned until the actual tool settles.
+          await AsyncLocalStorageProviderSingleton.runWithConfig(
+            dispatchOptions,
+            () =>
+              RunnableLambda.from(async (_input, dispatchConfig) => {
+                try {
+                  output = await this.invokeWithRuntime(
+                    tool,
+                    {
+                      ...preparedCall,
+                      type: 'tool_call',
+                      turn,
+                      stepId: this.toolCallStepIds?.get(call.id!),
+                    },
+                    preparedCall,
+                    {
+                      ...dispatchConfig,
+                      signal: composeAbortSignals(
+                        signal,
+                        composeAbortSignals(
+                          config.signal,
+                          scope?.controller.signal
+                        )
+                      ),
+                    }
+                  );
+                  // Raw output belongs to the tool observation, whose redaction policy
+                  // knows the tool name. A chain's scalar output has no such identity.
+                  return { status: 'completed' };
+                } catch (error) {
+                  failure = { error };
+                  return { status: 'failed' };
+                }
+              }).invoke(
+                {
+                  messages: [
+                    new AIMessage({ content: '', tool_calls: [preparedCall] }),
+                  ],
+                },
+                dispatchOptions
+              )
+          );
+          if (failure != null) {
+            throw failure.error;
+          }
+          return output;
+        });
       }
     );
   }
-
   /**
    * Runs a single tool call with error handling.
    *

--- a/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
+++ b/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
-import { tool } from '@langchain/core/tools';
 import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import { tool, DynamicStructuredTool } from '@langchain/core/tools';
+import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import { ToolOutputReferenceRegistry } from '../toolOutputReferences';
 import { PreparedSubagents } from '../preparedSubagents';
@@ -15,28 +16,33 @@ const call: ToolCall = {
 };
 const config = { configurable: { run_id: 'run', thread_id: 'thread' } };
 
-function fixture(hookRegistry?: HookRegistry) {
+function fixture(hookRegistry?: HookRegistry, nonCooperative = false) {
   let starts = 0;
   let finish!: (value: string) => void;
+  let fail!: (error: Error) => void;
   let onStarted!: () => void;
   const started = new Promise<void>((resolve) => {
     onStarted = resolve;
   });
-  const result = new Promise<string>((resolve) => {
+  const result = new Promise<string>((resolve, reject) => {
     finish = resolve;
+    fail = reject;
   });
-  const child = tool(
-    async () => {
-      starts++;
-      onStarted();
-      return result;
-    },
-    {
-      name: Constants.SUBAGENT,
-      description: 'Delegate research',
-      schema: z.object({ description: z.string(), subagent_type: z.string() }),
-    }
-  );
+  const func = async () => {
+    starts++;
+    onStarted();
+    return result;
+  };
+  const params = {
+    name: Constants.SUBAGENT,
+    description: 'Delegate research',
+    schema: z.object({ description: z.string(), subagent_type: z.string() }),
+  };
+  // tool() itself races cancellation. Use the direct class to model an
+  // invocation that remains pending after its signal aborts.
+  const child = nonCooperative
+    ? new DynamicStructuredTool({ ...params, func })
+    : tool(func, params);
   const prepared = new PreparedSubagents();
   const registry = new ToolOutputReferenceRegistry();
   const node = new ToolNode({
@@ -49,14 +55,92 @@ function fixture(hookRegistry?: HookRegistry) {
     toolOutputRegistry: registry,
     hookRegistry,
   });
-  return { node, prepared, started, finish, registry, starts: () => starts };
+  return {
+    node,
+    prepared,
+    started,
+    finish,
+    fail,
+    registry,
+    starts: () => starts,
+  };
 }
 
 describe('ToolNode prepared subagent adoption', () => {
+  it('retains capacity until a cancellation-ignoring tool actually settles', async () => {
+    const f = fixture(undefined, true);
+    const controller = new AbortController();
+    const scoped = { ...config, signal: controller.signal };
+    f.prepared.begin('old');
+    AsyncLocalStorageProviderSingleton.runWithConfig(scoped, () =>
+      f.node.prestartSubagent(call, 'old', scoped, 1)
+    );
+    await f.started;
+    controller.abort(new Error('cancelled'));
+    f.prepared.clear();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    f.prepared.begin('new');
+    expect(
+      f.prepared.start(
+        'new',
+        'parent',
+        { ...call, id: 'next' },
+        1,
+        async () => 'next'
+      )
+    ).toBe(false);
+    f.finish('late output');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(
+      f.prepared.start(
+        'new',
+        'parent',
+        { ...call, id: 'next' },
+        1,
+        async () => 'next'
+      )
+    ).toBe(true);
+    f.prepared.clear();
+  });
+
+  it('keeps raw failures out of the dispatch chain while preserving adoption errors', async () => {
+    const f = fixture();
+    const outputs: unknown[] = [];
+    const errors: unknown[] = [];
+    f.prepared.begin('attempt');
+    f.node.prestartSubagent(
+      call,
+      'attempt',
+      {
+        ...config,
+        callbacks: [
+          {
+            handleChainEnd: (output: unknown) => {
+              outputs.push(output);
+            },
+            handleChainError: (error: unknown) => {
+              errors.push(error);
+            },
+          },
+        ],
+      },
+      1
+    );
+    await f.started;
+    f.prepared.finish('attempt', [call]);
+    f.fail(new Error('sensitive failure detail'));
+    await expect(f.prepared.take('parent', call)).rejects.toThrow(
+      'sensitive failure detail'
+    );
+    expect(outputs).toEqual([{ status: 'failed' }]);
+    expect(errors).toEqual([]);
+  });
+
   it('parents each early tool beneath its own dispatch chain', async () => {
     const f = fixture();
     const chains: Array<{ id: string; name?: string; input: unknown }> = [];
     const parents: Array<string | undefined> = [];
+    const chainOutputs = new Map<string, unknown>();
     const tracedConfig = {
       ...config,
       runId: '00000000-0000-4000-8000-000000000001',
@@ -73,6 +157,9 @@ describe('ToolNode prepared subagent adoption', () => {
             name?: string
           ) => {
             chains.push({ id, name, input });
+          },
+          handleChainEnd: (output: unknown, id: string) => {
+            chainOutputs.set(id, output);
           },
           handleToolStart: (
             _tool: unknown,
@@ -97,10 +184,12 @@ describe('ToolNode prepared subagent adoption', () => {
     });
     f.prepared.finish('attempt', [call]);
     f.finish('research complete');
-    await f.node.invoke(
+    const result = await f.node.invoke(
       [new AIMessage({ content: '', tool_calls: [call] })],
       tracedConfig
     );
+    expect(result[0].content).toBe('research complete');
+    expect(chainOutputs.get(dispatch!.id)).toEqual({ status: 'completed' });
     expect(parents).toHaveLength(1);
   });
 

--- a/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
+++ b/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
@@ -53,6 +53,57 @@ function fixture(hookRegistry?: HookRegistry) {
 }
 
 describe('ToolNode prepared subagent adoption', () => {
+  it('parents each early tool beneath its own dispatch chain', async () => {
+    const f = fixture();
+    const chains: Array<{ id: string; name?: string; input: unknown }> = [];
+    const parents: Array<string | undefined> = [];
+    const tracedConfig = {
+      ...config,
+      runId: '00000000-0000-4000-8000-000000000001',
+      callbacks: [
+        {
+          handleChainStart: (
+            _chain: unknown,
+            input: unknown,
+            id: string,
+            _parent?: string,
+            _tags?: string[],
+            _metadata?: Record<string, unknown>,
+            _type?: string,
+            name?: string
+          ) => {
+            chains.push({ id, name, input });
+          },
+          handleToolStart: (
+            _tool: unknown,
+            _input: string,
+            _id: string,
+            parent?: string
+          ) => {
+            parents.push(parent);
+          },
+        },
+      ],
+    };
+    f.prepared.begin('attempt');
+    f.node.prestartSubagent(call, 'attempt', tracedConfig, 4);
+    await f.started;
+    expect(parents).toHaveLength(1);
+    const dispatch = chains.find((chain) => chain.id === parents[0]);
+    expect(dispatch?.name).toBe('tools=parent');
+    expect(dispatch?.id).not.toBe(tracedConfig.runId);
+    expect(dispatch?.input).toEqual({
+      messages: [expect.objectContaining({ tool_calls: [call] })],
+    });
+    f.prepared.finish('attempt', [call]);
+    f.finish('research complete');
+    await f.node.invoke(
+      [new AIMessage({ content: '', tool_calls: [call] })],
+      tracedConfig
+    );
+    expect(parents).toHaveLength(1);
+  });
+
   it('runs once before the batch and still registers the final output reference', async () => {
     const f = fixture();
     f.prepared.begin('attempt');

--- a/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
+++ b/src/tools/__tests__/ToolNode.preparedSubagents.test.ts
@@ -1,0 +1,129 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import { ToolOutputReferenceRegistry } from '../toolOutputReferences';
+import { PreparedSubagents } from '../preparedSubagents';
+import { HookRegistry } from '@/hooks';
+import { ToolNode } from '../ToolNode';
+import { Constants } from '@/common';
+
+const call: ToolCall = {
+  id: 'child-call',
+  name: Constants.SUBAGENT,
+  args: { description: 'Research this', subagent_type: 'researcher' },
+};
+const config = { configurable: { run_id: 'run', thread_id: 'thread' } };
+
+function fixture(hookRegistry?: HookRegistry) {
+  let starts = 0;
+  let finish!: (value: string) => void;
+  let onStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    onStarted = resolve;
+  });
+  const result = new Promise<string>((resolve) => {
+    finish = resolve;
+  });
+  const child = tool(
+    async () => {
+      starts++;
+      onStarted();
+      return result;
+    },
+    {
+      name: Constants.SUBAGENT,
+      description: 'Delegate research',
+      schema: z.object({ description: z.string(), subagent_type: z.string() }),
+    }
+  );
+  const prepared = new PreparedSubagents();
+  const registry = new ToolOutputReferenceRegistry();
+  const node = new ToolNode({
+    tools: [child],
+    executingAgentId: 'parent',
+    preparedSubagents: prepared,
+    eventDrivenMode: true,
+    directToolNames: new Set([Constants.SUBAGENT]),
+    eagerEventToolExecution: { enabled: true },
+    toolOutputRegistry: registry,
+    hookRegistry,
+  });
+  return { node, prepared, started, finish, registry, starts: () => starts };
+}
+
+describe('ToolNode prepared subagent adoption', () => {
+  it('runs once before the batch and still registers the final output reference', async () => {
+    const f = fixture();
+    f.prepared.begin('attempt');
+    f.node.prestartSubagent(call, 'attempt', config, 4);
+    await f.started;
+    expect(f.starts()).toBe(1);
+    f.prepared.finish('attempt', [call]);
+    const output = f.node.invoke(
+      [new AIMessage({ content: '', tool_calls: [call] })],
+      config
+    );
+    f.finish('research complete');
+    const messages = (await output) as ToolMessage[];
+    expect(f.starts()).toBe(1);
+    expect(messages[0].content).toBe('research complete');
+    expect(messages[0].additional_kwargs._refKey).toBeDefined();
+    expect(f.node.getToolUsageCounts().get(Constants.SUBAGENT)).toBe(1);
+  });
+
+  it('leaves calls behind parent approval hooks on the normal path', async () => {
+    const hooks = new HookRegistry();
+    hooks.register('PreToolUse', {
+      hooks: [async () => ({ decision: 'deny' as const })],
+    });
+    const f = fixture(hooks);
+    f.prepared.begin('attempt');
+    f.node.prestartSubagent(call, 'attempt', config, 4);
+    await Promise.resolve();
+    expect(f.starts()).toBe(0);
+    f.prepared.finish('attempt', [call]);
+    const output = (await f.node.invoke(
+      [new AIMessage({ content: '', tool_calls: [call] })],
+      config
+    )) as ToolMessage[];
+    expect(output[0].status).toBe('error');
+    expect(f.starts()).toBe(0);
+  });
+
+  it.each([{ run_in_background: true }, { subagent_thread_id: 'thread' }])(
+    'never speculatively starts detached or continued work: %p',
+    async (args) => {
+      const f = fixture();
+      f.prepared.begin('attempt');
+      f.node.prestartSubagent(
+        { ...call, args: { ...call.args, ...args } },
+        'attempt',
+        config,
+        4
+      );
+      await Promise.resolve();
+      expect(f.starts()).toBe(0);
+      f.prepared.clear();
+    }
+  );
+  it('fails closed if a parent policy hook is registered after admission', async () => {
+    const hooks = new HookRegistry();
+    const f = fixture(hooks);
+    f.prepared.begin('attempt');
+    f.node.prestartSubagent(call, 'attempt', config, 4);
+    await f.started;
+    f.prepared.finish('attempt', [call]);
+    hooks.register('PreToolUse', {
+      hooks: [async () => ({ decision: 'deny' as const })],
+    });
+    await expect(
+      f.node.invoke(
+        [new AIMessage({ content: '', tool_calls: [call] })],
+        config
+      )
+    ).rejects.toThrow('Tool hooks changed');
+    f.finish('cancelled child settles');
+    expect(f.starts()).toBe(1);
+  });
+});

--- a/src/tools/__tests__/preparedSubagents.test.ts
+++ b/src/tools/__tests__/preparedSubagents.test.ts
@@ -1,0 +1,194 @@
+import type { ToolCall } from '@langchain/core/messages/tool';
+import { PreparedSubagents, PreparedSubagentError } from '../preparedSubagents';
+
+const call: ToolCall = {
+  id: 'call-1',
+  name: 'subagent',
+  args: { description: 'research' },
+};
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('Prepared subagent invocation ownership', () => {
+  it('starts before attempt completion and adopts the same result once', async () => {
+    const owner = new PreparedSubagents();
+    const result = deferred<string>();
+    let starts = 0;
+    owner.begin('attempt');
+    expect(
+      owner.start('attempt', 'agent', call, 4, () => {
+        starts++;
+        return result.promise;
+      })
+    ).toBe(true);
+    await Promise.resolve();
+    expect(starts).toBe(1);
+    expect(
+      owner.start('attempt', 'agent', call, 4, () => {
+        throw new Error('duplicate');
+      })
+    ).toBe(false);
+    owner.finish('attempt', [call]);
+    const adopted = owner.take('agent', call);
+    result.resolve('child result');
+    await expect(adopted).resolves.toBe('child result');
+    await expect(owner.take('agent', call)).rejects.toThrow(PreparedSubagentError);
+    expect(starts).toBe(1);
+  });
+
+  it('bounds pending and settled-but-unadopted results', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('attempt');
+    expect(owner.start('attempt', 'agent', call, 1, async () => 'done')).toBe(
+      true
+    );
+    await Promise.resolve();
+    expect(
+      owner.start(
+        'attempt',
+        'agent',
+        { ...call, id: 'second' },
+        1,
+        async () => 'overflow'
+      )
+    ).toBe(false);
+    owner.finish('attempt', [call]);
+    await expect(owner.take('agent', call)).resolves.toBe('done');
+  });
+
+  it.each([undefined, [], [{ ...call, args: { description: 'different' } }]])(
+    'aborts and fails closed on a failed, discarded or revised attempt (%p)',
+    async (finalCalls) => {
+      const owner = new PreparedSubagents();
+      let signal!: AbortSignal;
+      owner.begin('attempt');
+      owner.start('attempt', 'agent', call, 1, async (value) => {
+        signal = value;
+        return 'done';
+      });
+      await Promise.resolve();
+      expect(() => owner.finish('attempt', finalCalls)).toThrow(
+        PreparedSubagentError
+      );
+      expect(signal.aborted).toBe(true);
+      expect(owner.isOpen('attempt')).toBe(false);
+      expect(owner.start('attempt', 'agent', call, 1, async () => 'late')).toBe(
+        false
+      );
+      expect(owner.owns('agent', call)).toBe(false);
+    }
+  );
+
+  it('cancels adopted work during graph cleanup', async () => {
+    const owner = new PreparedSubagents();
+    let signal!: AbortSignal;
+    const result = deferred<string>();
+    owner.begin('attempt');
+    owner.start('attempt', 'agent', call, 1, (value) => {
+      signal = value;
+      return result.promise;
+    });
+    await Promise.resolve();
+    owner.finish('attempt', [call]);
+    const adopted = owner.take('agent', call);
+    owner.clear();
+    expect(signal.aborted).toBe(true);
+    result.resolve('late result');
+    await expect(adopted).rejects.toThrow(PreparedSubagentError);
+  });
+
+  it('contains rejected child promises until adoption', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('attempt');
+    owner.start('attempt', 'agent', call, 1, async () => {
+      throw new Error('child failed');
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    owner.finish('attempt', [call]);
+    await expect(owner.take('agent', call)).rejects.toThrow('child failed');
+  });
+
+  it('rejects changed final invocation arguments without rerunning', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('attempt');
+    owner.start('attempt', 'agent', call, 1, async () => 'done');
+    owner.finish('attempt', [call]);
+    await expect(owner.take('agent', { ...call, args: {} })).rejects.toThrow(
+      PreparedSubagentError
+    );
+  });
+  it('fences a reset while a cancellation-ignoring model attempt drains', async () => {
+    const owner = new PreparedSubagents();
+    const result = deferred<string>();
+    owner.begin('old');
+    owner.start('old', 'agent', call, 1, () => result.promise);
+    await Promise.resolve();
+    owner.clear();
+    expect(owner.isOpen('old')).toBe(false);
+    owner.begin('new');
+    expect(owner.start('new', 'agent', call, 1, async () => 'new')).toBe(false);
+    expect(() => owner.finish('old', [call])).toThrow(PreparedSubagentError);
+    result.resolve('late result');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(owner.start('new', 'agent', call, 1, async () => 'new')).toBe(true);
+    owner.finish('new', [call]);
+    await expect(owner.take('agent', call)).resolves.toBe('new');
+  });
+
+  it('keeps separate agents isolated even with identical provider call IDs', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('left');
+    owner.begin('right');
+    owner.start('left', 'left-agent', call, 4, async () => 'left');
+    owner.start('right', 'right-agent', call, 4, async () => 'right');
+    const left = { ...call };
+    const right = { ...call };
+    owner.finish('left', [left]);
+    owner.finish('right', [right]);
+    await expect(owner.take('left-agent', left)).resolves.toBe('left');
+    await expect(owner.take('right-agent', right)).resolves.toBe('right');
+  });
+  it('never lets an old attempt cancel a new reservation with the same call ID', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('old');
+    owner.start('old', 'agent', call, 4, async () => 'old');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    owner.clear();
+    owner.begin('new');
+    owner.start('new', 'agent', call, 4, async () => 'new');
+    expect(() => owner.finish('old', [call])).toThrow(PreparedSubagentError);
+    owner.finish('new', [call]);
+    await expect(owner.take('agent', call)).resolves.toBe('new');
+  });
+  it('does not let a stale finalized call consume a new invocation', async () => {
+    const owner = new PreparedSubagents();
+    const oldCall = { ...call };
+    const newCall = { ...call };
+    owner.begin('old');
+    owner.start('old', 'agent', oldCall, 4, async () => 'old');
+    owner.finish('old', [oldCall]);
+    owner.clear();
+    owner.begin('new');
+    owner.start('new', 'agent', newCall, 4, async () => 'new');
+    owner.finish('new', [newCall]);
+    await expect(owner.take('agent', oldCall)).rejects.toThrow(PreparedSubagentError);
+    await expect(owner.take('agent', newCall)).resolves.toBe('new');
+  });
+
+  it('fences a settled result adopted just before reset', async () => {
+    const owner = new PreparedSubagents();
+    owner.begin('attempt');
+    owner.start('attempt', 'agent', call, 4, async () => 'done');
+    owner.finish('attempt', [call]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const result = owner.take('agent', call);
+    owner.clear();
+    await expect(result).rejects.toThrow(PreparedSubagentError);
+  });
+
+});

--- a/src/tools/__tests__/preparedSubagents.test.ts
+++ b/src/tools/__tests__/preparedSubagents.test.ts
@@ -15,6 +15,30 @@ function deferred<T>() {
 }
 
 describe('Prepared subagent invocation ownership', () => {
+  it('captures configuration separately for parallel model attempts', () => {
+    const owner = new PreparedSubagents();
+    const firstSignal = new AbortController().signal;
+    const config = {
+      configurable: { run_id: 'first' },
+      metadata: { step: 1 },
+      signal: firstSignal,
+    };
+    owner.begin('first', config);
+    config.configurable.run_id = 'second';
+    config.metadata.step = 2;
+    owner.begin('second', config);
+    expect(owner.getConfig('first')).toEqual({
+      configurable: { run_id: 'first' },
+      metadata: { step: 1 },
+      signal: firstSignal,
+    });
+    expect(owner.getConfig('second')?.configurable?.run_id).toBe('second');
+    owner.finish('first', []);
+    expect(owner.getConfig('first')).toBeUndefined();
+    owner.clear();
+    expect(owner.getConfig('second')).toBeUndefined();
+  });
+
   it('starts before attempt completion and adopts the same result once', async () => {
     const owner = new PreparedSubagents();
     const result = deferred<string>();
@@ -37,7 +61,9 @@ describe('Prepared subagent invocation ownership', () => {
     const adopted = owner.take('agent', call);
     result.resolve('child result');
     await expect(adopted).resolves.toBe('child result');
-    await expect(owner.take('agent', call)).rejects.toThrow(PreparedSubagentError);
+    await expect(owner.take('agent', call)).rejects.toThrow(
+      PreparedSubagentError
+    );
     expect(starts).toBe(1);
   });
 
@@ -176,7 +202,9 @@ describe('Prepared subagent invocation ownership', () => {
     owner.begin('new');
     owner.start('new', 'agent', newCall, 4, async () => 'new');
     owner.finish('new', [newCall]);
-    await expect(owner.take('agent', oldCall)).rejects.toThrow(PreparedSubagentError);
+    await expect(owner.take('agent', oldCall)).rejects.toThrow(
+      PreparedSubagentError
+    );
     await expect(owner.take('agent', newCall)).resolves.toBe('new');
   });
 
@@ -190,5 +218,4 @@ describe('Prepared subagent invocation ownership', () => {
     owner.clear();
     await expect(result).rejects.toThrow(PreparedSubagentError);
   });
-
 });

--- a/src/tools/preparedSubagents.ts
+++ b/src/tools/preparedSubagents.ts
@@ -1,3 +1,4 @@
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import { stableStringify, normalizeError } from './eagerEventExecution';
 
@@ -12,7 +13,11 @@ export class PreparedSubagentError extends Error {
 type Outcome =
   | { output: unknown; error?: never }
   | { error: Error; output?: never };
-type Attempt = { keys: Set<string>; cancelled: boolean };
+type Attempt = {
+  keys: Set<string>;
+  cancelled: boolean;
+  config: RunnableConfig;
+};
 
 const PREPARED_INVOCATION = Symbol('prepared-subagent-invocation');
 type PreparedCall = ToolCall & { [PREPARED_INVOCATION]?: symbol };
@@ -39,8 +44,21 @@ export class PreparedSubagents {
   private readonly running = new Set<AbortController>();
   private epoch = 0;
 
-  begin(attempt: string): void {
-    this.attempts.set(attempt, { keys: new Set(), cancelled: false });
+  begin(attempt: string, config: RunnableConfig = {}): void {
+    this.attempts.set(attempt, {
+      keys: new Set(),
+      cancelled: false,
+      config: {
+        ...config,
+        configurable: { ...config.configurable },
+        metadata: { ...config.metadata },
+      },
+    });
+  }
+
+  getConfig(attempt: string): RunnableConfig | undefined {
+    const entry = this.attempts.get(attempt);
+    return entry?.cancelled === false ? entry.config : undefined;
   }
 
   isOpen(attempt: string): boolean {
@@ -147,7 +165,10 @@ export class PreparedSubagents {
 
   owns(owner: string, call: ToolCall): boolean {
     const record = this.reservations.get(JSON.stringify([owner, call.id]));
-    return record != null && (call as PreparedCall)[PREPARED_INVOCATION] === record.token;
+    return (
+      record != null &&
+      (call as PreparedCall)[PREPARED_INVOCATION] === record.token
+    );
   }
 
   take(owner: string, call: ToolCall): Promise<unknown> | undefined {
@@ -158,7 +179,11 @@ export class PreparedSubagents {
       return undefined;
     }
     if (record == null || token !== record.token) {
-      return Promise.reject(new PreparedSubagentError('Eager subagent invocation is no longer owned by this call.'));
+      return Promise.reject(
+        new PreparedSubagentError(
+          'Eager subagent invocation is no longer owned by this call.'
+        )
+      );
     }
     this.reservations.delete(key);
     if (!record.committed || record.fingerprint !== fingerprint(call)) {
@@ -171,7 +196,9 @@ export class PreparedSubagents {
     const epoch = this.epoch;
     return record.outcome.then((result) => {
       if (this.epoch !== epoch) {
-        throw new PreparedSubagentError('Eager subagent result belongs to a retired run.');
+        throw new PreparedSubagentError(
+          'Eager subagent result belongs to a retired run.'
+        );
       }
       record.controller.signal.throwIfAborted();
       if ('error' in result) {

--- a/src/tools/preparedSubagents.ts
+++ b/src/tools/preparedSubagents.ts
@@ -1,0 +1,201 @@
+import type { ToolCall } from '@langchain/core/messages/tool';
+import { stableStringify, normalizeError } from './eagerEventExecution';
+
+/** A model attempt cannot safely retry after delegated work has started. */
+export class PreparedSubagentError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'PreparedSubagentError';
+  }
+}
+
+type Outcome =
+  | { output: unknown; error?: never }
+  | { error: Error; output?: never };
+type Attempt = { keys: Set<string>; cancelled: boolean };
+
+const PREPARED_INVOCATION = Symbol('prepared-subagent-invocation');
+type PreparedCall = ToolCall & { [PREPARED_INVOCATION]?: symbol };
+
+type Reservation = {
+  token: symbol;
+  callId: string;
+  attempt: string;
+  fingerprint: string;
+  controller: AbortController;
+  outcome: Promise<Outcome>;
+  committed: boolean;
+};
+
+/**
+ * Owns speculative invocation work, never tool results or graph state. Only
+ * explicitly open model attempts admit work; closing an attempt fences late
+ * callbacks without retaining tombstones. Normal ToolNode execution adopts the
+ * raw output and performs its existing lifecycle/output processing once.
+ */
+export class PreparedSubagents {
+  private readonly attempts = new Map<string, Attempt>();
+  private readonly reservations = new Map<string, Reservation>();
+  private readonly running = new Set<AbortController>();
+  private epoch = 0;
+
+  begin(attempt: string): void {
+    this.attempts.set(attempt, { keys: new Set(), cancelled: false });
+  }
+
+  isOpen(attempt: string): boolean {
+    return this.attempts.get(attempt)?.cancelled === false;
+  }
+
+  start(
+    attempt: string,
+    owner: string,
+    call: ToolCall,
+    capacity: number,
+    invoke: (signal: AbortSignal) => Promise<unknown>
+  ): boolean {
+    const entries = this.attempts.get(attempt);
+    if (
+      entries == null ||
+      entries.cancelled ||
+      call.id == null ||
+      call.id === ''
+    ) {
+      return false;
+    }
+    const key = JSON.stringify([owner, call.id]);
+    const canonical = fingerprint(call);
+    const previous = this.reservations.get(key);
+    if (previous != null) {
+      if (previous.attempt !== attempt || previous.fingerprint !== canonical) {
+        throw new PreparedSubagentError(
+          'Conflicting eager subagent call identity.'
+        );
+      }
+      return false;
+    }
+    if (
+      !Number.isSafeInteger(capacity) ||
+      capacity <= 0 ||
+      this.reservations.size >= capacity ||
+      this.running.size >= capacity
+    ) {
+      return false;
+    }
+    const controller = new AbortController();
+    this.running.add(controller);
+    const reservation: Reservation = {
+      token: Symbol(),
+      attempt,
+      callId: call.id,
+      fingerprint: canonical,
+      controller,
+      committed: false,
+      outcome: Promise.resolve()
+        .then(() => {
+          controller.signal.throwIfAborted();
+          return invoke(controller.signal);
+        })
+        .then(
+          (output): Outcome => ({ output }),
+          (error): Outcome => ({ error: normalizeError(error) })
+        )
+        .finally(() => {
+          this.running.delete(controller);
+        }),
+    };
+    entries.keys.add(key);
+    this.reservations.set(key, reservation);
+    return true;
+  }
+
+  finish(attempt: string, calls?: ToolCall[], cause?: unknown): void {
+    const entries = this.attempts.get(attempt);
+    this.attempts.delete(attempt);
+    if (entries == null || entries.keys.size === 0) {
+      return;
+    }
+    const finalCalls = new Map(calls?.map((call) => [call.id, call]));
+    for (const key of entries.keys) {
+      const record = this.reservations.get(key);
+      const finalCall =
+        record == null ? undefined : finalCalls.get(record.callId);
+      if (
+        entries.cancelled ||
+        record == null ||
+        record.attempt !== attempt ||
+        finalCall == null ||
+        fingerprint(finalCall) !== record.fingerprint
+      ) {
+        const error = new PreparedSubagentError(
+          'The model attempt ended or changed after a subagent started; refusing automatic retry.',
+          { cause }
+        );
+        for (const pendingKey of entries.keys) {
+          const pending = this.reservations.get(pendingKey);
+          if (pending?.attempt === attempt) {
+            pending.controller.abort(error);
+            this.reservations.delete(pendingKey);
+          }
+        }
+        throw error;
+      }
+      record.committed = true;
+      (finalCall as PreparedCall)[PREPARED_INVOCATION] = record.token;
+    }
+  }
+
+  owns(owner: string, call: ToolCall): boolean {
+    const record = this.reservations.get(JSON.stringify([owner, call.id]));
+    return record != null && (call as PreparedCall)[PREPARED_INVOCATION] === record.token;
+  }
+
+  take(owner: string, call: ToolCall): Promise<unknown> | undefined {
+    const key = JSON.stringify([owner, call.id]);
+    const record = this.reservations.get(key);
+    const token = (call as PreparedCall)[PREPARED_INVOCATION];
+    if (record == null && token == null) {
+      return undefined;
+    }
+    if (record == null || token !== record.token) {
+      return Promise.reject(new PreparedSubagentError('Eager subagent invocation is no longer owned by this call.'));
+    }
+    this.reservations.delete(key);
+    if (!record.committed || record.fingerprint !== fingerprint(call)) {
+      const error = new PreparedSubagentError(
+        'Subagent arguments changed after eager invocation.'
+      );
+      record.controller.abort(error);
+      return Promise.reject(error);
+    }
+    const epoch = this.epoch;
+    return record.outcome.then((result) => {
+      if (this.epoch !== epoch) {
+        throw new PreparedSubagentError('Eager subagent result belongs to a retired run.');
+      }
+      record.controller.signal.throwIfAborted();
+      if ('error' in result) {
+        throw result.error;
+      }
+      return result.output;
+    });
+  }
+
+  clear(): void {
+    this.epoch++;
+    const reason = new PreparedSubagentError(
+      'Eager subagent execution was cancelled.'
+    );
+    for (const controller of this.running) {
+      controller.abort(reason);
+    }
+    this.reservations.clear();
+    for (const attempt of this.attempts.values()) {
+      attempt.cancelled = true;
+    }
+  }
+}
+
+function fingerprint(call: ToolCall): string {
+  return stableStringify({ name: call.name, args: call.args });
+}

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -11,6 +11,7 @@ import type {
   ToolErrorData,
 } from './stream';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { PreparedSubagents } from '@/tools/preparedSubagents';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { HumanInTheLoopConfig } from './hitl';
 import type { LangfuseConfig } from './graph';
@@ -56,6 +57,13 @@ export type EagerEventToolExecutionConfig = {
    * execution with final args.
    */
   excludeToolNames?: string[];
+  /**
+   * Maximum retained early foreground subagent invocations per graph. Defaults
+   * to 4; 0 disables them. Checkpoints, parent tool hooks, background calls and
+   * control-flow graph tools retain normal batch execution. Once a child has
+   * started, a failed/revised model attempt fails instead of automatically retrying.
+   */
+  maxPendingSubagents?: number;
 };
 
 export type EagerEventToolExecutionOutcome =
@@ -290,6 +298,8 @@ export type ToolNodeOptions = {
    * controller.
    */
   getRunScope?: () => RunBreakerScope;
+  /** Internal graph-owned prepared invocation registry. */
+  preparedSubagents?: PreparedSubagents;
   /** SDK-owned checkpoint bridge for open run-step lifecycle state. */
   restoreRunStepResumeState?: (
     state?: RunStepResumeState,


### PR DESCRIPTION
## Summary

I enabled eligible foreground subagents to start as soon as their streamed tool calls are sealed, overlapping child execution with the parent's remaining generation.

- Reuse ToolNode invocation and result processing through bounded, attempt-owned preparation and adoption.
- Preserve provider sealing, cancellation, configuration ownership, and exact call identity; prevent automatic retry after delegated work starts.
- Restrict early startup to eligible event-driven graphs without checkpointing, approval, or result-altering hooks.
- Preserve dispatch trace ancestry while keeping raw outcomes outside the status-only dispatch observation.
- Document the design, eligibility, and invocation capacity limits in an architecture decision record.

## Change Type

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- Passed 22 focused regression suites (404 tests), including streaming, hooks, output references, fallbacks, subagent lifecycle, and tracing.
- Passed 14 graph, ownership, and tracing suites after review fixes (219 tests), including status-only trace output and noncooperative invocation cancellation.
- Passed `npx tsc --noEmit`, scoped ESLint, import ordering, and `git diff --check`.
- Verified actual child startup before parent completion with Responses, Bedrock, and Google seal styles.
- Live Langfuse validation was unavailable because this environment has no configured credentials.

### Test Configuration

Local Jest with real graph and ToolNode execution, fake model streams, and deterministic lifecycle failure injection.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
