### PR TITLE
🫆 feat: Configure Langfuse Trace User Identity

### DIFF
--- a/src/langfuse.ts
+++ b/src/langfuse.ts
@@ -895,6 +895,18 @@ function mergeLangfuseTags(
   return merged.length > 0 ? [...new Set(merged)] : undefined;
 }
 
+/**
+ * The trace's user identity: the host-configured `langfuse.userId` when
+ * present, else the caller's (normally `configurable.user_id`).
+ */
+export function resolveLangfuseTraceUserId(
+  langfuse: t.LangfuseConfig | undefined,
+  userId: string | undefined
+): string | undefined {
+  const configured = langfuse?.userId?.trim();
+  return isPresent(configured) ? configured : userId;
+}
+
 export function getLangfuseTraceName(
   traceMetadata?: LangfuseTraceMetadata,
   fallback: string = 'LibreChat Agent'
@@ -942,7 +954,7 @@ export function createLangfuseHandler({
     return undefined;
   }
   return new ScopedLangfuseCallbackHandler({
-    userId,
+    userId: resolveLangfuseTraceUserId(langfuse, userId),
     sessionId,
     traceMetadata:
       inheritTraceIdentity === true
@@ -972,7 +984,10 @@ function createPropagateAttributeParams({
   inheritTraceIdentity,
 }: LangfuseAttributeParams): PropagateAttributesParams {
   return {
-    userId: inheritTraceIdentity === true ? undefined : userId,
+    userId:
+      inheritTraceIdentity === true
+        ? undefined
+        : resolveLangfuseTraceUserId(langfuse, userId),
     sessionId: inheritTraceIdentity === true ? undefined : sessionId,
     traceName: inheritTraceIdentity === true ? undefined : traceName,
     tags: mergeLangfuseTags(tags, langfuse?.tags),

--- a/src/specs/langfuse-config.test.ts
+++ b/src/specs/langfuse-config.test.ts
@@ -76,6 +76,53 @@ describe('createLangfuseHandler', () => {
     });
   });
 
+  it('stamps the configured trace userId over the caller identity', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+
+    createLangfuseHandler({
+      langfuse: { userId: 'alice@example.com' },
+      userId: 'user-1',
+      sessionId: 'thread-1',
+      tags: ['librechat', 'agent'],
+    });
+
+    expect(MockedCallbackHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice@example.com', sessionId: 'thread-1' })
+    );
+  });
+
+  it('keeps the caller identity when the configured trace userId is blank', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+
+    createLangfuseHandler({
+      langfuse: { userId: '   ' },
+      userId: 'user-1',
+      sessionId: 'thread-1',
+    });
+
+    expect(MockedCallbackHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1' })
+    );
+  });
+
+  it('does not stamp the configured trace userId on inherited identities', () => {
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-env';
+
+    createLangfuseHandler({
+      langfuse: { userId: 'alice@example.com' },
+      userId: 'user-1',
+      sessionId: 'thread-1',
+      inheritTraceIdentity: true,
+    });
+
+    expect(MockedCallbackHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: undefined, sessionId: undefined })
+    );
+  });
+
   it('adds configured trace metadata and tags to the callback handler', () => {
     process.env.LANGFUSE_PUBLIC_KEY = 'pk-env';
     process.env.LANGFUSE_SECRET_KEY = 'sk-env';

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -830,6 +830,14 @@ export interface LangfuseConfig {
   additionalHeaders?: Record<string, string>;
   metadata?: Record<string, string | number | boolean | null | undefined>;
   /**
+   * User identity stamped on every trace this run emits — the agent stream,
+   * titles, activity and reasoning labels, and phases. Hosts set it when the
+   * observability identity differs from `configurable.user_id` (an email or
+   * IdP subject instead of an internal database id); that id remains the
+   * fallback when unset or blank.
+   */
+  userId?: string;
+  /**
    * Internal OTLP span attributes to attach to Langfuse observations before
    * export. Intended for collector-side routing/filtering; strip these in the
    * collector before forwarding spans to Langfuse.


### PR DESCRIPTION
## Summary

Adds `userId` to `LangfuseConfig`. When a host sets it, every trace the run emits — the agent stream, titles, activity and reasoning labels, and phases — carries that identity as the Langfuse `userId` instead of `configurable.user_id`. Unset or blank keeps today's derivation, so existing hosts see no change.

Resolution lives in one place (`resolveLangfuseTraceUserId`), applied where handlers and propagated attributes are built, so every call site that already passes `langfuse` picks it up without touching the `configurable` contract that tools and MCP auth key on. Inherited identities (`inheritTraceIdentity`) stay untouched.

Host side: danny-avila/LibreChat#13529 — LibreChat resolves the user field an operator selected (email, username, IdP subject, …) and passes it here.

## Testing

```bash
npx jest src/specs/langfuse-config.test.ts   # 16 passed
npx tsc --noEmit
npx eslint src/langfuse.ts src/types/graph.ts src/specs/langfuse-config.test.ts
```