### PR TITLE
📭 fix: Surface Artifact Delivery Failures

### DIFF
--- a/src/tools/ArtifactDelivery.ts
+++ b/src/tools/ArtifactDelivery.ts
@@ -28,7 +28,13 @@ export function normalizeArtifactDeliveryFailure(
     return undefined;
   }
 
-  return candidate as ArtifactDeliveryFailure;
+  return {
+    code: candidate.code,
+    status: candidate.status,
+    attempted: candidate.attempted,
+    delivered: candidate.delivered,
+    failed: candidate.failed,
+  };
 }
 
 export function appendArtifactDeliveryWarning(

--- a/src/tools/ArtifactDelivery.ts
+++ b/src/tools/ArtifactDelivery.ts
@@ -1,0 +1,44 @@
+import type { ArtifactDeliveryFailure } from '@/types';
+
+export const ARTIFACT_DELIVERY_WARNING_PREFIX = 'Artifact delivery warning:';
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+export function normalizeArtifactDeliveryFailure(
+  value: unknown
+): ArtifactDeliveryFailure | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const candidate = value as Partial<ArtifactDeliveryFailure>;
+  if (
+    candidate.code !== 'artifact_delivery_failed' ||
+    (candidate.status !== 'partial' && candidate.status !== 'failed') ||
+    !isNonNegativeInteger(candidate.attempted) ||
+    !isNonNegativeInteger(candidate.delivered) ||
+    !isNonNegativeInteger(candidate.failed) ||
+    candidate.failed === 0 ||
+    candidate.attempted !== candidate.delivered + candidate.failed ||
+    (candidate.status === 'failed' && candidate.delivered !== 0) ||
+    (candidate.status === 'partial' && candidate.delivered === 0)
+  ) {
+    return undefined;
+  }
+
+  return candidate as ArtifactDeliveryFailure;
+}
+
+export function appendArtifactDeliveryWarning(
+  output: string,
+  delivery: ArtifactDeliveryFailure | undefined
+): string {
+  if (delivery == null) {
+    return output;
+  }
+
+  const warning = `${ARTIFACT_DELIVERY_WARNING_PREFIX} ${delivery.failed} of ${delivery.attempted} generated files could not be persisted. Do not assume missing files are available to later calls or downloadable. The code itself ran; do not rerun automatically because it may have had side effects.`;
+  return `${output.trimEnd()}\n${warning}\n`;
+}

--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -18,6 +18,10 @@ import {
   resolveCodeApiAuthHeaders,
   selectRuntimeSessionHint,
 } from './CodeExecutor';
+import {
+  appendArtifactDeliveryWarning,
+  normalizeArtifactDeliveryFailure,
+} from '@/tools/ArtifactDelivery';
 import { logCodeApiDiagnostic } from '@/tools/diagnostics';
 import { resolveFetchProxyAgent } from '@/utils/proxy';
 import { INTENT_PROPERTY } from '@/tools/intentArg';
@@ -300,6 +304,13 @@ function createBashExecutionTool(
           formattedOutput,
           command
         );
+        const artifactDelivery = normalizeArtifactDeliveryFailure(
+          result.artifact_delivery
+        );
+        const outputWithDeliveryWarning = appendArtifactDeliveryWarning(
+          outputWithReminder,
+          artifactDelivery
+        );
         const hasFiles = result.files != null && result.files.length > 0;
         const runtimeEcho =
           result.runtime_session_id != null
@@ -309,15 +320,21 @@ function createBashExecutionTool(
             }
             : {};
         return [
-          appendCodeSessionFileSummary(outputWithReminder, result.files),
+          appendCodeSessionFileSummary(outputWithDeliveryWarning, result.files),
           (hasFiles
             ? {
               session_id: result.session_id,
               files: result.files,
+              ...(artifactDelivery != null
+                ? { artifact_delivery: artifactDelivery }
+                : {}),
               ...runtimeEcho,
             }
             : {
               session_id: result.session_id,
+              ...(artifactDelivery != null
+                ? { artifact_delivery: artifactDelivery }
+                : {}),
               ...runtimeEcho,
             }) satisfies t.CodeExecutionArtifact,
         ];

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -6,6 +6,10 @@ import type { Readable } from 'node:stream';
 import type { CodeApiMethod } from '@/tools/diagnostics';
 import type * as t from '@/types';
 import {
+  appendArtifactDeliveryWarning,
+  normalizeArtifactDeliveryFailure,
+} from '@/tools/ArtifactDelivery';
+import {
   describeCodeApiError,
   logCodeApiDiagnostic,
 } from '@/tools/diagnostics';
@@ -564,6 +568,13 @@ function createCodeExecutionTool(
           formattedOutput,
           code
         );
+        const artifactDelivery = normalizeArtifactDeliveryFailure(
+          result.artifact_delivery
+        );
+        const outputWithDeliveryWarning = appendArtifactDeliveryWarning(
+          outputWithReminder,
+          artifactDelivery
+        );
         const hasFiles = result.files != null && result.files.length > 0;
         /* Echo the durable runtime session (stateful backends only) so hosts
          * can surface a "session active / was reset" signal later. Additive:
@@ -576,15 +587,21 @@ function createCodeExecutionTool(
             }
             : {};
         return [
-          appendCodeSessionFileSummary(outputWithReminder, result.files),
+          appendCodeSessionFileSummary(outputWithDeliveryWarning, result.files),
           (hasFiles
             ? {
               session_id: result.session_id,
               files: result.files,
+              ...(artifactDelivery != null
+                ? { artifact_delivery: artifactDelivery }
+                : {}),
               ...runtimeEcho,
             }
             : {
               session_id: result.session_id,
+              ...(artifactDelivery != null
+                ? { artifact_delivery: artifactDelivery }
+                : {}),
               ...runtimeEcho,
             }) satisfies t.CodeExecutionArtifact,
         ];

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -34,6 +34,10 @@ import {
   resolveCodeApiRunTimeoutMs,
 } from './ptcTimeout';
 import {
+  appendArtifactDeliveryWarning,
+  normalizeArtifactDeliveryFailure,
+} from '@/tools/ArtifactDelivery';
+import {
   describeCodeApiError,
   logCodeApiDiagnostic,
 } from '@/tools/diagnostics';
@@ -871,12 +875,22 @@ export function formatCompletedResponse(
   }
 
   const outputWithReminder = appendTmpScratchReminder(formatted, sourceCode);
+  const artifactDelivery = normalizeArtifactDeliveryFailure(
+    response.artifact_delivery
+  );
+  const outputWithDeliveryWarning = appendArtifactDeliveryWarning(
+    outputWithReminder,
+    artifactDelivery
+  );
 
   return [
-    appendCodeSessionFileSummary(outputWithReminder, response.files),
+    appendCodeSessionFileSummary(outputWithDeliveryWarning, response.files),
     {
       session_id: response.session_id,
       files: response.files,
+      ...(artifactDelivery != null
+        ? { artifact_delivery: artifactDelivery }
+        : {}),
       ...(response.runtime_session_id != null
         ? {
           runtime_session_id: response.runtime_session_id,

--- a/src/tools/__tests__/ArtifactDelivery.test.ts
+++ b/src/tools/__tests__/ArtifactDelivery.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  ARTIFACT_DELIVERY_WARNING_PREFIX,
+  appendArtifactDeliveryWarning,
+  normalizeArtifactDeliveryFailure,
+} from '../ArtifactDelivery';
+
+describe('artifact delivery failures', () => {
+  it('normalizes the bounded Code API failure contract', () => {
+    expect(
+      normalizeArtifactDeliveryFailure({
+        code: 'artifact_delivery_failed',
+        status: 'partial',
+        attempted: 3,
+        delivered: 2,
+        failed: 1,
+      })
+    ).toEqual({
+      code: 'artifact_delivery_failed',
+      status: 'partial',
+      attempted: 3,
+      delivered: 2,
+      failed: 1,
+    });
+  });
+
+  it.each([
+    null,
+    {
+      code: 'storage_error',
+      status: 'failed',
+      attempted: 1,
+      delivered: 0,
+      failed: 1,
+    },
+    {
+      code: 'artifact_delivery_failed',
+      status: 'failed',
+      attempted: 2,
+      delivered: 1,
+      failed: 1,
+    },
+    {
+      code: 'artifact_delivery_failed',
+      status: 'partial',
+      attempted: 1,
+      delivered: 0,
+      failed: 1,
+    },
+    {
+      code: 'artifact_delivery_failed',
+      status: 'failed',
+      attempted: 1,
+      delivered: 0,
+      failed: -1,
+    },
+  ])('rejects malformed external values', (value) => {
+    expect(normalizeArtifactDeliveryFailure(value)).toBeUndefined();
+  });
+
+  it('warns without claiming the code execution failed or recommending a retry', () => {
+    const output = appendArtifactDeliveryWarning('stdout:\ndone\n', {
+      code: 'artifact_delivery_failed',
+      status: 'failed',
+      attempted: 1,
+      delivered: 0,
+      failed: 1,
+    });
+
+    expect(output).toContain(ARTIFACT_DELIVERY_WARNING_PREFIX);
+    expect(output).toContain('1 of 1 generated files could not be persisted');
+    expect(output).toContain('The code itself ran');
+    expect(output).toContain('do not rerun automatically');
+  });
+});

--- a/src/tools/__tests__/ArtifactDelivery.test.ts
+++ b/src/tools/__tests__/ArtifactDelivery.test.ts
@@ -14,6 +14,7 @@ describe('artifact delivery failures', () => {
         attempted: 3,
         delivered: 2,
         failed: 1,
+        detail: 'private storage failure',
       })
     ).toEqual({
       code: 'artifact_delivery_failed',

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -282,6 +282,54 @@ describe('CodeAPI auth header injection', () => {
     ).not.toHaveProperty('authHeaders');
   });
 
+  it('surfaces artifact delivery failures from direct code execution', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        session_id: 'session_123',
+        stdout: 'code completed\n',
+        files: [],
+        artifact_delivery: {
+          code: 'artifact_delivery_failed',
+          status: 'failed',
+          attempted: 1,
+          delivered: 0,
+          failed: 1,
+        },
+      })
+    );
+    const tool = createCodeExecutionTool();
+
+    const output = await tool.invoke({ lang: 'py', code: 'print(1)' });
+
+    expect(output).toContain('stdout:\ncode completed');
+    expect(output).toContain('Artifact delivery warning:');
+    expect(output).toContain('do not rerun automatically');
+  });
+
+  it('surfaces artifact delivery failures from direct bash execution', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        session_id: 'session_123',
+        stdout: 'bash completed\n',
+        files: [],
+        artifact_delivery: {
+          code: 'artifact_delivery_failed',
+          status: 'failed',
+          attempted: 1,
+          delivered: 0,
+          failed: 1,
+        },
+      })
+    );
+    const tool = createBashExecutionTool();
+
+    const output = await tool.invoke({ command: 'echo done' });
+
+    expect(output).toContain('stdout:\nbash completed');
+    expect(output).toContain('Artifact delivery warning:');
+    expect(output).toContain('do not rerun automatically');
+  });
+
   it('routes direct code tools by trusted per-agent profile', async () => {
     fetchMock.mockResolvedValue(
       jsonResponse({ session_id: 'session_123', stdout: '1\n' })

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -22,17 +22,17 @@ import {
   normalizeBashToolResultsForReplay,
 } from '../BashProgrammaticToolCalling';
 import {
-  projectProgrammaticToolMap,
-  resolveProgrammaticToolDefinitions,
-  selectProgrammaticTools,
-} from '../ProgrammaticCallerPolicy';
-import {
   createProgrammaticToolRegistry,
   createGetTeamMembersTool,
   createGetExpensesTool,
   createGetWeatherTool,
   createCalculatorTool,
 } from '@/test/mockTools';
+import {
+  projectProgrammaticToolMap,
+  resolveProgrammaticToolDefinitions,
+  selectProgrammaticTools,
+} from '../ProgrammaticCallerPolicy';
 import { Constants } from '@/common';
 
 describe('ProgrammaticToolCalling', () => {
@@ -984,9 +984,9 @@ for member in team:
         ['send_email', emailTool],
       ]);
 
-      expect(
-        projectProgrammaticToolMap(toolMap, [{ name: 'search' }])
-      ).toEqual(new Map([['search', searchTool]]));
+      expect(projectProgrammaticToolMap(toolMap, [{ name: 'search' }])).toEqual(
+        new Map([['search', searchTool]])
+      );
     });
   });
 
@@ -1036,6 +1036,30 @@ for member in team:
 
       expect(output).toContain('stdout:\nOutput');
       expect(output).toContain('stderr:\nWarning: deprecated function');
+    });
+
+    it('surfaces artifact delivery failures while preserving execution output', () => {
+      const response: t.ProgrammaticExecutionResponse = {
+        status: 'completed',
+        stdout: 'Code completed\n',
+        stderr: '',
+        files: [],
+        session_id: 'sess_abc123',
+        artifact_delivery: {
+          code: 'artifact_delivery_failed',
+          status: 'failed',
+          attempted: 1,
+          delivered: 0,
+          failed: 1,
+        },
+      };
+
+      const [output, artifact] = formatCompletedResponse(response);
+
+      expect(output).toContain('stdout:\nCode completed');
+      expect(output).toContain('Artifact delivery warning:');
+      expect(output).toContain('do not rerun automatically');
+      expect(artifact.artifact_delivery).toEqual(response.artifact_delivery);
     });
 
     it('adds a /tmp scratch reminder when source code used /tmp', () => {

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -481,6 +481,14 @@ export type FileRef = {
 
 export type FileRefs = FileRef[];
 
+export type ArtifactDeliveryFailure = {
+  code: 'artifact_delivery_failed';
+  status: 'partial' | 'failed';
+  attempted: number;
+  delivered: number;
+  failed: number;
+};
+
 export type ExecuteResult = {
   /**
    * Execution session id — the (transient) sandbox run that produced
@@ -491,6 +499,7 @@ export type ExecuteResult = {
   stdout: string;
   stderr: string;
   files?: FileRefs;
+  artifact_delivery?: ArtifactDeliveryFailure;
   /**
    * Durable runtime session id echoed by a stateful Code API backend
    * (hash of tenant+user+hint). Additive; absent on stateless servers.
@@ -1327,6 +1336,7 @@ export type ProgrammaticExecutionResponse = {
   stdout?: string;
   stderr?: string;
   files?: FileRefs;
+  artifact_delivery?: ArtifactDeliveryFailure;
 
   /** Durable runtime session echo from a stateful backend (additive). */
   runtime_session_id?: string;
@@ -1343,6 +1353,7 @@ export type ProgrammaticExecutionArtifact = {
   /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
+  artifact_delivery?: ArtifactDeliveryFailure;
   /** Durable runtime session echo from a stateful backend (additive). */
   runtime_session_id?: string;
   runtime_status?: 'new' | 'reused';
@@ -1409,6 +1420,7 @@ export type CodeExecutionArtifact = {
   /** Execution session — see `CodeSessionContext.session_id`. */
   session_id?: string;
   files?: FileRefs;
+  artifact_delivery?: ArtifactDeliveryFailure;
   /** Durable runtime session echo from a stateful backend (additive). */
   runtime_session_id?: string;
   runtime_status?: 'new' | 'reused';


### PR DESCRIPTION
## Summary

I propagated the Code API artifact-delivery status through the execution tools so the model and host can distinguish successful execution from failed persistence.

- Add a shared typed artifact-delivery contract with strict runtime normalization.
- Append a model-visible warning while preserving useful stdout and stderr.
- Tell the model not to assume missing files are durable or downloadable and not to rerun side-effecting code automatically.
- Carry validated delivery status in direct and programmatic execution artifacts.
- Cover code, Bash, and programmatic execution paths plus malformed external values.
- Pair with LibreChat-AI/code-interpreter#119 and address danny-avila/LibreChat#15659.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran 159 focused Jest tests across artifact delivery, direct Code API execution, and programmatic execution.
- Ran TypeScript without emit successfully.
- Ran ESLint on the new shared helper and its tests with no warnings.
- Built CJS, ESM, and declarations successfully.

### **Test Configuration**:

- Node.js 24-compatible project toolchain
- npm 10 workspace

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
- [ ] Any changes dependent on mine have been merged and published in downstream modules.