### PR TITLE
🧺 fix: Bound Summarization Inputs

### DIFF
--- a/docs/summarization-behavior.md
+++ b/docs/summarization-behavior.md
@@ -62,29 +62,30 @@ All budget comparisons multiply raw counts by `calibrationRatio` to approximate 
 
 5. **Summarization trigger**: If `messagesToRefine` is non-empty, `shouldTriggerSummarization` evaluates the configured trigger (or defaults to "any pruned messages"). `shouldSkipSummarization` only blocks when the message count hasn't changed since the last summary (prevents re-summarizing identical content). If triggered: **full compaction** fires.
 
-### Full Compaction
+### Bounded Compaction
 
 When summarization fires:
 
-- The **entire conversation** (un-masked originals from the snapshot) is sent to the summarizer — not just the dropped messages.
-- The summarizer produces a structured checkpoint covering the full conversation history.
-- Graph state is wiped completely (`createRemoveAllMessage()`) — no surviving messages.
+- The older conversation head uses the un-masked originals from the snapshot; the configured recent user-led turns remain verbatim.
+- Before invocation, the runtime subtracts instruction/tool-schema overhead and an output reserve from the selected summarizer model's context window. A dedicated summarizer can declare `summarizationConfig.maxContextTokens`; otherwise the agent context window is used.
+- If the full head fits, one full-compaction request produces the checkpoint. If it does not fit, the runtime partitions it at complete message and tool-call/result boundaries, summarizes at most eight bounded chunks, and sends their bounded summaries through one synthesis request.
+- An open tool call is never detached from later messages. The synthesis prompt preserves the original objective, exact identifiers, tool outcomes, and unfinished work while the recent unconsumed tail remains in graph state.
+- Graph state is replaced with `createRemoveAllMessage()` plus the retained recent tail only after a usable checkpoint succeeds.
 - The summary is stored on `AgentContext` but **not** injected into the system prompt (doesn't inflate `instructionTokens`).
 
 ### Post-Compaction Clean Slate
 
-After compaction, the message array is empty. On the next agent node turn:
+After compaction, the older head is removed and the recent tail may remain. On the next agent node turn:
 
-- The system runnable detects `messages.length === 0` with a mid-run summary present.
-- It injects `[SystemMessage(instructions), HumanMessage(summary)]`.
+- The system runnable injects the checkpoint before the retained recent messages.
 - The model reads the checkpoint as a user message and continues naturally — making tool calls or responding.
 - The summary competes for message budget rather than permanently reducing the instruction ceiling.
 
 ### Summarization Invocation
 
-Raw conversation messages are sent to the LLM via `attemptInvoke` with the summarization instruction appended as the final HumanMessage. Tools are bound so providers that require tool definitions (e.g. Bedrock) accept the messages. This preserves the original message format and enables cache hits on the system prompt + tool definitions prefix.
+Raw conversation messages are sent to the LLM via `attemptInvoke` with the summarization instruction appended as the final HumanMessage. Tools are bound so providers that require tool definitions (e.g. Bedrock) accept the messages. This preserves the original message format and enables cache hits on the system prompt + tool definitions prefix. Oversized inputs use intermediate chunk checkpoints and a final synthesis call instead of sending an over-limit request.
 
-If the primary call fails, fallback providers are attempted (via `tryFallbackProviders`). If all providers fail, a metadata stub is generated mechanically — no LLM call, just tool names and message counts.
+If the primary call fails, at most two fallback providers are attempted via `tryFallbackProviders`. If a chunk, synthesis, primary, or fallback attempt fails, the original history is preserved and `ON_SUMMARIZE_COMPLETE` reports a recoverable error; a structural metadata stub is never committed as the conversation replacement. Structured logs record full versus staged mode, estimated and provider-reported token counts, chunk/call counts, and the fallback outcome.
 
 ### Summarization Prompt
 

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -86,6 +86,7 @@ async function createCompactingRun(
       summarizationEnabled: true,
       summarizationConfig: {
         provider: Providers.OPENAI,
+        maxContextTokens: 32_000,
         retainRecent,
       },
     },

--- a/src/llm/anthropic/index.ts
+++ b/src/llm/anthropic/index.ts
@@ -27,8 +27,24 @@ const MAX_STREAM_QUEUE_CHUNKS = 256;
 const MAX_STREAM_QUEUE_TEXT_CHARS = 8192;
 const STREAM_CHUNK_MIN_SIZE = 4;
 const STREAM_BOUNDARIES = new Set([' ', '.', ',', '!', '?', ';', ':']);
+const defaultOutputTokensByModel = new Map<string, number>();
 
 type StreamTokenType = 'string' | 'input' | 'content';
+
+export function getAnthropicDefaultMaxOutputTokens(model?: string): number {
+  const cacheKey = model ?? '';
+  const cached = defaultOutputTokensByModel.get(cacheKey);
+  if (cached != null) {
+    return cached;
+  }
+  const resolver = new ChatAnthropicMessages({
+    model,
+    apiKey: 'output-budget-resolution-only',
+  });
+  const resolved = resolver.maxTokens;
+  defaultOutputTokensByModel.set(cacheKey, resolved);
+  return resolved;
+}
 
 const ANTHROPIC_TOOL_BETAS: Partial<Record<string, AnthropicBeta>> = {
   tool_search_tool_regex_20251119: 'advanced-tool-use-2025-11-20',

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -1186,16 +1186,11 @@ export class AgentSession {
         metadata: { run_id: compactRunId },
       }
     );
-    if (graph.summaryError != null) {
+    if (graph.summaryError != null || graph.completedSummary == null) {
       return undefined;
     }
     const completedSummaryText = getSummaryText(graph.completedSummary);
-    const contextSummaryText = agentContext.getSummaryText();
-    let summaryText = completedSummaryText;
-    if (summaryText === '' && contextSummaryText != null) {
-      summaryText = contextSummaryText;
-    }
-    if (summaryText === '') {
+    if (completedSummaryText === '') {
       return undefined;
     }
     const retainedMessages = filterRemoveMessages(
@@ -1212,7 +1207,7 @@ export class AgentSession {
       (entry) => !retainedEntryIdSet.has(entry.id)
     );
     const summary = await store.appendEntryForCompaction({
-      text: summaryText,
+      text: completedSummaryText,
       tokenCount: getSummaryTokenCount(graph.completedSummary),
       retainedEntryIds,
       summarizedEntryIds: summarized.map((entry) => entry.id),

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -519,7 +519,7 @@ function createAgentInputFromGraphConfig(
   const summarizationConfig: t.SummarizationConfig = {
     ...(agent.summarizationConfig ?? {}),
     ...(instructions != null && instructions !== ''
-      ? { prompt: instructions }
+      ? { prompt: instructions, updatePrompt: instructions }
       : {}),
     retainRecent: {
       ...(agent.summarizationConfig?.retainRecent ?? {}),

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -540,12 +540,14 @@ function createManualCompactGraph(params: {
 }): {
   graph: Parameters<typeof createSummarizeNode>[0]['graph'];
   completedSummary?: t.SummaryContentBlock;
+  summaryError?: string;
 } {
   const contentData: t.RunStep[] = [];
   const contentIndexMap = new Map<string, number>();
   const result: {
     graph: Parameters<typeof createSummarizeNode>[0]['graph'];
     completedSummary?: t.SummaryContentBlock;
+    summaryError?: string;
   } = {
     graph: {
       contentData,
@@ -570,6 +572,8 @@ function createManualCompactGraph(params: {
         };
         if (completed.type === 'summary') {
           result.completedSummary = completed.summary;
+        } else if (completed.type === 'summary_error') {
+          result.summaryError = completed.error;
         }
         await params.customHandlers?.[
           GraphEvents.ON_RUN_STEP_COMPLETED
@@ -1182,6 +1186,9 @@ export class AgentSession {
         metadata: { run_id: compactRunId },
       }
     );
+    if (graph.summaryError != null) {
+      return undefined;
+    }
     const completedSummaryText = getSummaryText(graph.completedSummary);
     const contextSummaryText = agentContext.getSummaryText();
     let summaryText = completedSummaryText;

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -15,6 +15,7 @@ import * as providers from '@/llm/providers';
 import { GraphEvents } from '@/common';
 import type * as t from '@/types';
 import { Run } from '@/run';
+import { AgentContext } from '@/agents/AgentContext';
 
 type MockRun = {
   processStream: jest.MockedFunction<Run<t.IState>['processStream']>;
@@ -1019,6 +1020,7 @@ describe('JsonlSessionStore', () => {
   });
 
   it('compacts into a summary plus retained active path', async () => {
+    const fromConfig = jest.spyOn(AgentContext, 'fromConfig');
     mockSummarizer('summary of old work');
     const tokenCounter: t.TokenCounter = () => 7;
     const session = await createAgentSession({
@@ -1043,6 +1045,16 @@ describe('JsonlSessionStore', () => {
       instructions: 'summary of old work',
       retainRecentTurns: 1,
     });
+
+    expect(fromConfig).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        summarizationConfig: expect.objectContaining({
+          prompt: 'summary of old work',
+          updatePrompt: 'summary of old work',
+        }),
+      }),
+      tokenCounter
+    );
 
     expect(store?.getMessages().map((message) => message.content)).toEqual([
       'summary of old work',

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1085,16 +1085,18 @@ describe('JsonlSessionStore', () => {
     expect(compaction?.data.retainedEntryIds).toEqual([]);
   });
 
-  it('does not persist a manual compaction when summarization fails', async () => {
-    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
-      class {
-        constructor() {
-          return {
-            invoke: jest.fn().mockRejectedValue(new Error('chunk failed')),
-          };
-        }
-      } as never
-    );
+  it('does not discard newer history when re-compaction fails', async () => {
+    const modelClassSpy = jest
+      .spyOn(providers, 'getChatModelClass')
+      .mockReturnValue(
+        class {
+          constructor() {
+            return {
+              invoke: jest.fn().mockResolvedValue({ content: 'prior summary' }),
+            };
+          }
+        } as never
+      );
     const session = await createAgentSession({
       cwd: dir,
       runId: 'template-run',
@@ -1110,20 +1112,32 @@ describe('JsonlSessionStore', () => {
     const store = session.getSessionStore();
     await store?.appendMessage(new HumanMessage('old'));
     await store?.appendMessage(new AIMessage('old answer'));
+    await session.compact({ retainRecentTurns: 0 });
 
+    await store?.appendMessage(new HumanMessage('new question'));
+    await store?.appendMessage(new AIMessage('new answer'));
+    modelClassSpy.mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest.fn().mockRejectedValue(new Error('chunk failed')),
+          };
+        }
+      } as never
+    );
     await session.compact({ retainRecentTurns: 0 });
 
     expect(store?.getMessages().map((message) => message.content)).toEqual([
-      'old',
-      'old answer',
+      'prior summary',
+      'new question',
+      'new answer',
     ]);
     expect(
-      store
-        ?.getEntries()
-        .some(
-          (entry) => entry.type === 'summary' || entry.type === 'compaction'
-        )
-    ).toBe(false);
+      store?.getEntries().filter((entry) => entry.type === 'summary')
+    ).toHaveLength(1);
+    expect(
+      store?.getEntries().filter((entry) => entry.type === 'compaction')
+    ).toHaveLength(1);
   });
 
   it('carries calibration ratio forward after resumeInterrupt', async () => {

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1085,6 +1085,47 @@ describe('JsonlSessionStore', () => {
     expect(compaction?.data.retainedEntryIds).toEqual([]);
   });
 
+  it('does not persist a manual compaction when summarization fails', async () => {
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest.fn().mockRejectedValue(new Error('chunk failed')),
+          };
+        }
+      } as never
+    );
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    await store?.appendMessage(new HumanMessage('old'));
+    await store?.appendMessage(new AIMessage('old answer'));
+
+    await session.compact({ retainRecentTurns: 0 });
+
+    expect(store?.getMessages().map((message) => message.content)).toEqual([
+      'old',
+      'old answer',
+    ]);
+    expect(
+      store
+        ?.getEntries()
+        .some(
+          (entry) => entry.type === 'summary' || entry.type === 'compaction'
+        )
+    ).toBe(false);
+  });
+
   it('carries calibration ratio forward after resumeInterrupt', async () => {
     const mockRun = createMockRun('resumed');
     mockRun.getCalibrationRatio.mockReturnValue(2);

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -1140,6 +1140,50 @@ describe('JsonlSessionStore', () => {
     ).toHaveLength(1);
   });
 
+  it('does not persist a stale summary when re-compaction is a no-op', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'prior summary' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const session = await createAgentSession({
+      cwd: dir,
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: {
+          provider: 'openAI' as never,
+          model: 'test-model',
+        },
+        instructions: 'test',
+      },
+    });
+    const store = session.getSessionStore();
+    await store?.appendMessage(new HumanMessage('old'));
+    await store?.appendMessage(new AIMessage('old answer'));
+    await session.compact({ retainRecentTurns: 0 });
+
+    await store?.appendMessage(new HumanMessage('new question'));
+    await store?.appendMessage(new AIMessage('new answer'));
+    await session.compact({ retainRecentTurns: 1 });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(store?.getMessages().map((message) => message.content)).toEqual([
+      'prior summary',
+      'new question',
+      'new answer',
+    ]);
+    expect(
+      store?.getEntries().filter((entry) => entry.type === 'summary')
+    ).toHaveLength(1);
+    expect(
+      store?.getEntries().filter((entry) => entry.type === 'compaction')
+    ).toHaveLength(1);
+  });
+
   it('carries calibration ratio forward after resumeInterrupt', async () => {
     const mockRun = createMockRun('resumed');
     mockRun.getCalibrationRatio.mockReturnValue(2);

--- a/src/session/handlers.ts
+++ b/src/session/handlers.ts
@@ -13,6 +13,7 @@ import { toJsonValue } from './messageSerialization';
 
 type CompletedRunStepResult =
   | t.ToolEndEvent
+  | (t.SummaryFailed & { id: string; index: number })
   | (t.SummaryCompleted & { id: string; index: number });
 
 function isToolCompletion(

--- a/src/specs/multi-agent-summarization.test.ts
+++ b/src/specs/multi-agent-summarization.test.ts
@@ -146,6 +146,7 @@ describe('Multi-agent summarization', () => {
         summarizationEnabled: true,
         summarizationConfig: {
           provider: Providers.OPENAI,
+          maxContextTokens: 32_000,
         },
       },
       {

--- a/src/specs/summarization.test.ts
+++ b/src/specs/summarization.test.ts
@@ -158,6 +158,7 @@ async function createSummarizationRun(opts: {
       summarizationConfig: {
         provider: opts.summarizationProvider,
         model: opts.summarizationModel,
+        maxContextTokens: 32_000,
         maxSummaryTokens: opts.maxSummaryTokens,
       },
     },
@@ -1381,6 +1382,7 @@ describe('Cross-run summary lifecycle (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
         },
         returnContent: true,
@@ -1611,6 +1613,7 @@ describe('Cross-run summary lifecycle (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
         },
         returnContent: true,
@@ -1866,6 +1869,7 @@ describe('Tight context with oversized tool results (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
         },
         returnContent: true,
@@ -1983,6 +1987,7 @@ describe('Tight context with oversized tool results (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
         },
         returnContent: true,
@@ -2156,6 +2161,7 @@ describe('Tight context with oversized tool results (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
           initialSummary,
         },
@@ -2842,6 +2848,7 @@ describe('Enrichment and prompt selection (no API keys)', () => {
         summarizationEnabled: true,
         summarizationConfig: {
           provider: Providers.OPENAI,
+          maxContextTokens: 32_000,
         },
       },
       returnContent: true,
@@ -3000,6 +3007,7 @@ describe('Summarization deduplication correctness (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
             parameters: {},
           },
         },
@@ -3164,6 +3172,7 @@ describe('Summarization deduplication correctness (no API keys)', () => {
           summarizationEnabled: true,
           summarizationConfig: {
             provider: Providers.OPENAI,
+            maxContextTokens: 32_000,
           },
           initialSummary,
         },

--- a/src/specs/token-accounting-e2e.test.ts
+++ b/src/specs/token-accounting-e2e.test.ts
@@ -180,6 +180,7 @@ describe('Token accounting E2E — Run + Graph + real token counter', () => {
         summarizationEnabled: true,
         summarizationConfig: {
           provider: Providers.OPENAI,
+          maxContextTokens: 32_000,
         },
         initialSummary: opts.initialSummary,
       },

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1472,13 +1472,9 @@ export function createContentAggregator(): t.ContentAggregatorResult {
         contentParts[runStep.index] = result.summary as t.MessageContentComplex;
       } else if (result.type === 'summary_error' && 'error' in result) {
         contentParts[runStep.index] = {
-          type: ContentTypes.SUMMARY,
-          content: [
-            {
-              type: ContentTypes.TEXT,
-              text: `Summarization failed; conversation history was preserved. ${result.error}`,
-            },
-          ],
+          type: ContentTypes.ERROR,
+          [ContentTypes.ERROR]:
+            `Summarization failed; conversation history was preserved. ${result.error}`,
         } as t.MessageContentComplex;
       } else if ('tool_call' in result) {
         const contentPart: t.MessageContentComplex = {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1456,6 +1456,7 @@ export function createContentAggregator(): t.ContentAggregatorResult {
       const { result } = data as unknown as {
         result:
           | t.ToolEndEvent
+          | (t.SummaryFailed & { id: string; index: number })
           | (t.SummaryCompleted & { id: string; index: number });
       };
 
@@ -1469,6 +1470,16 @@ export function createContentAggregator(): t.ContentAggregatorResult {
 
       if (result.type === ContentTypes.SUMMARY && 'summary' in result) {
         contentParts[runStep.index] = result.summary as t.MessageContentComplex;
+      } else if (result.type === 'summary_error' && 'error' in result) {
+        contentParts[runStep.index] = {
+          type: ContentTypes.SUMMARY,
+          content: [
+            {
+              type: ContentTypes.TEXT,
+              text: `Summarization failed; conversation history was preserved. ${result.error}`,
+            },
+          ],
+        } as t.MessageContentComplex;
       } else if ('tool_call' in result) {
         const contentPart: t.MessageContentComplex = {
           type: ContentTypes.TOOL_CALL,

--- a/src/summarization/__tests__/aggregator.test.ts
+++ b/src/summarization/__tests__/aggregator.test.ts
@@ -179,10 +179,11 @@ describe('createContentAggregator – SUMMARY accumulation', () => {
       } as never,
     });
 
-    const summary = contentParts[0] as t.SummaryContentBlock;
-    expect((summary.content?.[0] as { text: string }).text).toContain(
-      'conversation history was preserved'
-    );
-    expect(summary.boundary).toBeUndefined();
+    const failure = contentParts[0] as {
+      type: ContentTypes.ERROR;
+      error: string;
+    };
+    expect(failure.type).toBe(ContentTypes.ERROR);
+    expect(failure.error).toContain('conversation history was preserved');
   });
 });

--- a/src/summarization/__tests__/aggregator.test.ts
+++ b/src/summarization/__tests__/aggregator.test.ts
@@ -150,4 +150,39 @@ describe('createContentAggregator – SUMMARY accumulation', () => {
 
     consoleSpy.mockRestore();
   });
+
+  it('renders summary failure completion without creating a durable summary', () => {
+    const { aggregateContent, contentParts } = createContentAggregator();
+    const runStep: t.RunStep = {
+      stepIndex: 0,
+      id: 'step_sum_failed',
+      type: StepTypes.MESSAGE_CREATION,
+      index: 0,
+      stepDetails: {
+        type: StepTypes.MESSAGE_CREATION,
+        message_creation: { message_id: 'step_sum_failed' },
+      },
+      summary: { type: ContentTypes.SUMMARY },
+      usage: null,
+    };
+    aggregateContent({ event: GraphEvents.ON_RUN_STEP, data: runStep });
+
+    aggregateContent({
+      event: GraphEvents.ON_RUN_STEP_COMPLETED,
+      data: {
+        result: {
+          id: 'step_sum_failed',
+          index: 0,
+          type: 'summary_error',
+          error: 'chunk failed',
+        },
+      } as never,
+    });
+
+    const summary = contentParts[0] as t.SummaryContentBlock;
+    expect((summary.content?.[0] as { text: string }).text).toContain(
+      'conversation history was preserved'
+    );
+    expect(summary.boundary).toBeUndefined();
+  });
 });

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -1,0 +1,88 @@
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  createSummarizationInputBudget,
+  MAX_SUMMARIZATION_CHUNKS,
+  planSummarizationChunks,
+} from '@/summarization/input';
+
+describe('summarization input preparation', () => {
+  it('subtracts instruction overhead and output reserve from the context window', () => {
+    expect(
+      createSummarizationInputBudget({
+        maxContextTokens: 1_000_000,
+        fixedOverheadTokens: 25_000,
+        maxSummaryTokens: 80_000,
+      })
+    ).toEqual({
+      contextTokens: 1_000_000,
+      fixedOverheadTokens: 25_000,
+      outputReserveTokens: 80_000,
+      messageBudgetTokens: 895_000,
+    });
+  });
+
+  it('never separates a tool call from its result', () => {
+    const toolCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'call_1', name: 'read', args: {} }],
+    });
+    const toolResult = new ToolMessage({
+      content: 'result'.repeat(40),
+      tool_call_id: 'call_1',
+      name: 'read',
+    });
+    const result = planSummarizationChunks({
+      messages: [
+        new HumanMessage('objective'.repeat(20)),
+        toolCall,
+        toolResult,
+        new HumanMessage('next'.repeat(60)),
+      ],
+      messageBudgetTokens: 320,
+      tokenCounter: (message) => String(message.content).length,
+    });
+
+    expect(result.error).toBeUndefined();
+    const chunks = result.plan?.chunks ?? [];
+    const callChunk = chunks.findIndex((chunk) => chunk.includes(toolCall));
+    const resultChunk = chunks.findIndex((chunk) => chunk.includes(toolResult));
+    expect(callChunk).toBeGreaterThanOrEqual(0);
+    expect(resultChunk).toBe(callChunk);
+  });
+
+  it('keeps an unresolved tool call with all following messages', () => {
+    const openCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'open_call', name: 'exec', args: {} }],
+    });
+    const following = new HumanMessage('do not detach this');
+    const result = planSummarizationChunks({
+      messages: [new HumanMessage('objective'), openCall, following],
+      messageBudgetTokens: 500,
+      tokenCounter: () => 100,
+    });
+
+    expect(result.error).toBeUndefined();
+    const chunks = result.plan?.chunks ?? [];
+    const callChunk = chunks.findIndex((chunk) => chunk.includes(openCall));
+    const followingChunk = chunks.findIndex((chunk) =>
+      chunk.includes(following)
+    );
+    expect(callChunk).toBeGreaterThanOrEqual(0);
+    expect(followingChunk).toBe(callChunk);
+  });
+
+  it('fails before invoking a model when the bounded chunk count is exceeded', () => {
+    const result = planSummarizationChunks({
+      messages: Array.from(
+        { length: MAX_SUMMARIZATION_CHUNKS + 1 },
+        (_, index) => new HumanMessage(`message-${index}`)
+      ),
+      messageBudgetTokens: 120,
+      tokenCounter: () => 100,
+    });
+
+    expect(result.error).toContain('bounded limit');
+    expect(result.plan).toBeUndefined();
+  });
+});

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -74,6 +74,39 @@ describe('summarization input preparation', () => {
     expect(resultChunk).toBe(callChunk);
   });
 
+  it('keeps serialized tool calls with their results', () => {
+    const toolCall = new AIMessage({ content: '' });
+    toolCall.additional_kwargs.tool_calls = [
+      {
+        id: 'call_serialized',
+        type: 'function',
+        function: { name: 'read', arguments: '{}' },
+      },
+    ];
+    const toolResult = new ToolMessage({
+      content: 'result'.repeat(40),
+      tool_call_id: 'call_serialized',
+      name: 'read',
+    });
+    const result = planSummarizationChunks({
+      messages: [
+        new HumanMessage('objective'.repeat(20)),
+        toolCall,
+        toolResult,
+        new HumanMessage('next'.repeat(60)),
+      ],
+      messageBudgetTokens: 600,
+      tokenCounter: (message) => String(message.content).length,
+    });
+
+    expect(result.error).toBeUndefined();
+    const chunks = result.plan?.chunks ?? [];
+    const callChunk = chunks.findIndex((chunk) => chunk.includes(toolCall));
+    const resultChunk = chunks.findIndex((chunk) => chunk.includes(toolResult));
+    expect(callChunk).toBeGreaterThanOrEqual(0);
+    expect(resultChunk).toBe(callChunk);
+  });
+
   it('keeps an unresolved tool call with all following messages', () => {
     const openCall = new AIMessage({
       content: '',

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -160,7 +160,7 @@ describe('summarization input preparation', () => {
     expect(resultChunk).toBe(callChunk);
   });
 
-  it('keeps an unresolved tool call with all following messages', () => {
+  it('repairs an unresolved tool call before planning later messages', () => {
     const openCall = new AIMessage({
       content: '',
       tool_calls: [{ id: 'open_call', name: 'exec', args: {} }],
@@ -179,7 +179,34 @@ describe('summarization input preparation', () => {
       chunk.includes(following)
     );
     expect(callChunk).toBeGreaterThanOrEqual(0);
-    expect(followingChunk).toBe(callChunk);
+    expect(followingChunk).toBeGreaterThan(callChunk);
+    expect(
+      chunks[callChunk]?.some(
+        (message) =>
+          message instanceof ToolMessage && message.tool_call_id === 'open_call'
+      )
+    ).toBe(true);
+  });
+
+  it('budgets every synthetic result for multiple interrupted calls', () => {
+    const openCalls = new AIMessage({
+      content: '',
+      tool_calls: [
+        { id: 'open_1', name: 'first', args: {} },
+        { id: 'open_2', name: 'second', args: {} },
+      ],
+    });
+    const result = planSummarizationChunks({
+      messages: [new HumanMessage('objective'), openCalls],
+      messageBudgetTokens: 300,
+      tokenCounter: () => 100,
+    });
+
+    expect(result.error).toContain('complete message/tool-call unit');
+    if (result.plan != null) {
+      throw new Error('Expected repaired calls to exceed the input budget');
+    }
+    expect(result.estimatedMessageTokens).toBeGreaterThan(300);
   });
 
   it('does not treat provider-executed server tools as open client calls', () => {

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -33,6 +33,18 @@ describe('summarization input preparation', () => {
     });
   });
 
+  it('applies calibration while preserving an explicit zero reserve ratio', () => {
+    expect(
+      createSummarizationInputBudget({
+        maxContextTokens: 1_000,
+        fixedOverheadTokens: 100,
+        maxSummaryTokens: 100,
+        reserveRatio: 0,
+        calibrationRatio: 2,
+      }).messageBudgetTokens
+    ).toBe(350);
+  });
+
   it('never separates a tool call from its result', () => {
     const toolCall = new AIMessage({
       content: '',
@@ -90,7 +102,7 @@ describe('summarization input preparation', () => {
         { length: MAX_SUMMARIZATION_CHUNKS + 1 },
         (_, index) => new HumanMessage(`message-${index}`)
       ),
-      messageBudgetTokens: 120,
+      messageBudgetTokens: 220,
       tokenCounter: () => 100,
     });
 

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -182,6 +182,29 @@ describe('summarization input preparation', () => {
     expect(followingChunk).toBe(callChunk);
   });
 
+  it('does not treat provider-executed server tools as open client calls', () => {
+    const serverCall = new AIMessage({
+      content: 'searched the web',
+      tool_calls: [
+        { id: 'srvtoolu_search', name: 'web_search', args: { query: 'news' } },
+      ],
+    });
+    const result = planSummarizationChunks({
+      messages: [
+        new HumanMessage('objective'),
+        serverCall,
+        new HumanMessage('next question'),
+        new AIMessage('next answer'),
+      ],
+      messageBudgetTokens: 250,
+      tokenCounter: () => 100,
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.plan?.chunks).toHaveLength(4);
+    expect(result.plan?.chunks[1]).toContain(serverCall);
+  });
+
   it('fails before invoking a model when the bounded chunk count is exceeded', () => {
     const result = planSummarizationChunks({
       messages: Array.from(

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -42,7 +42,18 @@ describe('summarization input preparation', () => {
         reserveRatio: 0,
         calibrationRatio: 2,
       }).messageBudgetTokens
-    ).toBe(350);
+    ).toBe(400);
+  });
+
+  it('subtracts fixed overhead before expanding a calibrated raw budget', () => {
+    expect(
+      createSummarizationInputBudget({
+        maxContextTokens: 1_000,
+        fixedOverheadTokens: 200,
+        maxSummaryTokens: 100,
+        calibrationRatio: 0.5,
+      }).messageBudgetTokens
+    ).toBe(1_400);
   });
 
   it('never separates a tool call from its result', () => {

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -38,7 +38,7 @@ describe('summarization input preparation', () => {
         toolResult,
         new HumanMessage('next'.repeat(60)),
       ],
-      messageBudgetTokens: 320,
+      messageBudgetTokens: 400,
       tokenCounter: (message) => String(message.content).length,
     });
 

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -1,4 +1,9 @@
-import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  AIMessageChunk,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import {
   createSummarizationInputBudget,
   estimateMessageTokens,
@@ -97,6 +102,43 @@ describe('summarization input preparation', () => {
     const toolResult = new ToolMessage({
       content: 'result'.repeat(40),
       tool_call_id: 'call_serialized',
+      name: 'read',
+    });
+    const result = planSummarizationChunks({
+      messages: [
+        new HumanMessage('objective'.repeat(20)),
+        toolCall,
+        toolResult,
+        new HumanMessage('next'.repeat(60)),
+      ],
+      messageBudgetTokens: 600,
+      tokenCounter: (message) => String(message.content).length,
+    });
+
+    expect(result.error).toBeUndefined();
+    const chunks = result.plan?.chunks ?? [];
+    const callChunk = chunks.findIndex((chunk) => chunk.includes(toolCall));
+    const resultChunk = chunks.findIndex((chunk) => chunk.includes(toolResult));
+    expect(callChunk).toBeGreaterThanOrEqual(0);
+    expect(resultChunk).toBe(callChunk);
+  });
+
+  it('keeps streamed tool-call chunks with their results', () => {
+    const toolCall = new AIMessageChunk({
+      content: '',
+      tool_call_chunks: [
+        {
+          id: 'call_streamed',
+          name: 'read',
+          args: '{}',
+          index: 0,
+          type: 'tool_call_chunk',
+        },
+      ],
+    });
+    const toolResult = new ToolMessage({
+      content: 'result'.repeat(40),
+      tool_call_id: 'call_streamed',
       name: 'read',
     });
     const result = planSummarizationChunks({

--- a/src/summarization/__tests__/input.test.ts
+++ b/src/summarization/__tests__/input.test.ts
@@ -1,11 +1,23 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import {
   createSummarizationInputBudget,
+  estimateMessageTokens,
   MAX_SUMMARIZATION_CHUNKS,
   planSummarizationChunks,
 } from '@/summarization/input';
 
 describe('summarization input preparation', () => {
+  it('accounts for tool-call metadata omitted by content token counters', () => {
+    const message = new AIMessage({
+      content: 'ok',
+      tool_calls: [
+        { id: 'call_1', name: 'read', args: { path: '/'.repeat(100) } },
+      ],
+    });
+
+    expect(estimateMessageTokens(message, () => 2)).toBeGreaterThan(10);
+  });
+
   it('subtracts instruction overhead and output reserve from the context window', () => {
     expect(
       createSummarizationInputBudget({

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -6,6 +6,7 @@ import {
   createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  getSummarizationToolSchemaTokens,
   parseProviderContextOverflow,
 } from '@/summarization/node';
 import * as providers from '@/llm/providers';
@@ -1237,6 +1238,21 @@ describe('emoji-heavy content does not break summarization', () => {
 });
 
 describe('bounded summarization input', () => {
+  it('recalculates tool-schema overhead for a dedicated Anthropic summarizer', () => {
+    const agentContext = createAgentContext({
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4.1' },
+      toolSchemaTokens: 140,
+    });
+
+    expect(
+      getSummarizationToolSchemaTokens(agentContext, {
+        provider: Providers.ANTHROPIC,
+        clientOptions: { model: 'claude-sonnet-4-5' },
+      })
+    ).toBe(260);
+  });
+
   it('never sends an estimated million-token conversation as one provider request', async () => {
     captureEvents();
     const capturedCalls: unknown[][] = [];

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1287,6 +1287,63 @@ describe('bounded summarization input', () => {
     expect(String(capturedMessages[0]?.content)).toContain('## Checkpoint');
   });
 
+  it('bridges a trailing tool result before the instruction', async () => {
+    let capturedMessages: BaseMessage[] = [];
+    const invoke = jest.fn().mockImplementation((messages: BaseMessage[]) => {
+      capturedMessages = messages;
+      return Promise.resolve({ content: 'checkpoint' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      provider: Providers.BEDROCK,
+      clientOptions: { model: 'anthropic.claude-3-5-sonnet' },
+      maxContextTokens: 2_000,
+      tokenCounter: () => 10,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+    const toolCall = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'call_1', name: 'read', args: {} }],
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          toolCall,
+          new ToolMessage({
+            content: 'result',
+            tool_call_id: 'call_1',
+            name: 'read',
+          }),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(capturedMessages.map((message) => message.getType())).toEqual([
+      'ai',
+      'tool',
+      'ai',
+      'human',
+    ]);
+    expect(String(capturedMessages.at(-1)?.content)).toContain('## Checkpoint');
+  });
+
   it('recalculates tool-schema overhead for a dedicated Anthropic summarizer', () => {
     const agentContext = createAgentContext({
       provider: Providers.OPENAI,

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1574,6 +1574,7 @@ describe('bounded summarization input', () => {
         model: 'claude-sonnet-4-5',
         retainRecent: { turns: 0 },
         maxContextTokens: 2_000,
+        maxSummaryTokens: 100,
       },
       tokenCounter: () => 1,
     });
@@ -1718,6 +1719,49 @@ describe('bounded summarization input', () => {
         messages: [
           new HumanMessage('x'.repeat(2_250)),
           new AIMessage('y'.repeat(2_250)),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('reserves the Anthropic constructor output allowance', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { model: 'claude-opus-4-7' },
+      maxContextTokens: 20_000,
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 20_000,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('x'.repeat(6_000)),
+          new AIMessage('y'.repeat(6_000)),
         ],
         summarizationRequest: {
           remainingContextTokens: 0,

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -11,6 +11,7 @@ import {
 } from '@/summarization/node';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
+import * as tokenUtils from '@/utils/tokens';
 import { AgentContext } from '@/agents/AgentContext';
 
 // ---------------------------------------------------------------------------
@@ -1360,6 +1361,94 @@ describe('bounded summarization input', () => {
       {} as RunnableConfig
     );
 
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('rescales tool-schema overhead before dedicated-model preflight', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      provider: Providers.ANTHROPIC,
+      clientOptions: { model: 'claude-sonnet-4-5' },
+      maxContextTokens: 4_000,
+      systemMessageTokens: 100,
+      toolSchemaTokens: 2_600,
+      summarizationConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-4.1',
+        retainRecent: { turns: 0 },
+        maxContextTokens: 2_000,
+      },
+      tokenCounter: () => 10,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts chunks with the dedicated summarizer tokenizer', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const createCounter = jest
+      .spyOn(tokenUtils, 'createTokenCounter')
+      .mockResolvedValue(() => 10);
+    const agentContext = createAgentContext({
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4.1' },
+      maxContextTokens: 2_000,
+      summarizationConfig: {
+        provider: Providers.ANTHROPIC,
+        model: 'claude-sonnet-4-5',
+        retainRecent: { turns: 0 },
+        maxContextTokens: 2_000,
+      },
+      tokenCounter: () => 1,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(createCounter).toHaveBeenCalledWith('claude');
     expect(invoke).toHaveBeenCalledTimes(1);
   });
 

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -6,6 +6,7 @@ import {
   createSummarizeNode,
   DEFAULT_SUMMARIZATION_PROMPT,
   DEFAULT_UPDATE_SUMMARIZATION_PROMPT,
+  parseProviderContextOverflow,
 } from '@/summarization/node';
 import * as providers from '@/llm/providers';
 import * as eventUtils from '@/utils/events';
@@ -293,7 +294,7 @@ describe('createSummarizeNode', () => {
     );
   });
 
-  it('produces metadata stub when all LLM attempts fail', async () => {
+  it('preserves history and emits a recoverable error when all LLM attempts fail', async () => {
     const events = captureEvents();
 
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -334,27 +335,21 @@ describe('createSummarizeNode', () => {
     );
 
     expect(result.summarizationRequest).toBeUndefined();
-    // After summarization, REMOVE_ALL + surviving context is returned
-    expect(result.messages).toBeDefined();
-    expect(result.messages!.length).toBeGreaterThanOrEqual(1);
-    expect(result.messages![0]._getType()).toBe('remove');
+    expect(result.messages).toBeUndefined();
+    expect(setSummary).not.toHaveBeenCalled();
 
-    // Tier 3 fallback: metadata stub is used as summary text
     const completeEvent = events.find(
       (e) => e.event === GraphEvents.ON_SUMMARIZE_COMPLETE
     );
     expect(
-      (
-        (completeEvent?.data as t.SummarizeCompleteEvent).summary!
-          .content?.[0] as { text: string } | undefined
-      )?.text
-    ).toMatch(/^\[Metadata summary:/);
-    expect(
-      (completeEvent?.data as t.SummarizeCompleteEvent).error
+      (completeEvent?.data as t.SummarizeCompleteEvent).summary
     ).toBeUndefined();
+    expect((completeEvent?.data as t.SummarizeCompleteEvent).error).toBe(
+      'Model error'
+    );
   });
 
-  it('catches model initialization errors and falls back to metadata stub', async () => {
+  it('catches model initialization errors without replacing history', async () => {
     captureEvents();
 
     /**
@@ -362,7 +357,7 @@ describe('createSummarizeNode', () => {
      * forwards an unrecognized provider name (custom-endpoint label) that
      * getChatModelClass cannot resolve. Prior to the defense-in-depth fix,
      * this error was thrown outside the try/catch in executeSummarizationWithFallback
-     * and bubbled up silently. Now it is caught and the metadata stub is used.
+     * and bubbled up silently. It is now surfaced without mutating history.
      */
     jest.spyOn(providers, 'getChatModelClass').mockImplementation(() => {
       throw new Error('Unsupported LLM provider: Ollama');
@@ -390,13 +385,10 @@ describe('createSummarizeNode', () => {
       )
     ).resolves.not.toThrow();
 
-    expect(setSummary).toHaveBeenCalledWith(
-      expect.stringContaining('[Metadata summary:'),
-      expect.any(Number)
-    );
+    expect(setSummary).not.toHaveBeenCalled();
   });
 
-  it('falls back to metadata stub when primary LLM call fails', async () => {
+  it('does not persist a structural stub when the primary LLM call fails', async () => {
     captureEvents();
 
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -429,10 +421,7 @@ describe('createSummarizeNode', () => {
       {} as RunnableConfig
     );
 
-    expect(setSummary).toHaveBeenCalledWith(
-      expect.stringContaining('[Metadata summary:'),
-      expect.any(Number)
-    );
+    expect(setSummary).not.toHaveBeenCalled();
   });
 
   it('calls setSummary with the final text', async () => {
@@ -1242,5 +1231,133 @@ describe('emoji-heavy content does not break summarization', () => {
     // Should complete without throwing JSON serialization errors
     expect(result.messages).toBeDefined();
     expect(result.messages!.length).toBeGreaterThan(0);
+  });
+});
+
+describe('bounded summarization input', () => {
+  it('never sends an estimated million-token conversation as one provider request', async () => {
+    captureEvents();
+    const capturedCalls: unknown[][] = [];
+    const invoke = jest.fn().mockImplementation(async (messages: unknown[]) => {
+      capturedCalls.push(messages);
+      return { content: `checkpoint-${capturedCalls.length}` };
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      maxContextTokens: 1_000_000,
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 1_000_000,
+        maxSummaryTokens: 50_000,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+      setSummary,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+    const payload = 'x'.repeat(1_200_000);
+
+    const result = await summarizeNode(
+      {
+        messages: [
+          new HumanMessage(`objective:${payload}`),
+          new AIMessage(payload),
+          new HumanMessage(payload),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedCalls).toHaveLength(3);
+    for (const call of capturedCalls) {
+      const estimatedContentTokens = call.reduce<number>((total, raw) => {
+        const message = raw as { content?: unknown };
+        return total + Math.ceil(String(message.content ?? '').length / 3);
+      }, 0);
+      expect(estimatedContentTokens).toBeLessThan(1_000_000);
+    }
+    expect(setSummary).toHaveBeenCalledWith('checkpoint-3', expect.any(Number));
+    expect(result.messages?.[0]?._getType()).toBe('remove');
+  });
+
+  it('preserves the original history when a staged chunk fails', async () => {
+    const events = captureEvents();
+    const invoke = jest
+      .fn()
+      .mockResolvedValueOnce({ content: 'first chunk' })
+      .mockRejectedValueOnce(new Error('chunk failed'));
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+
+    const setSummary = jest.fn();
+    const agentContext = createAgentContext({
+      maxContextTokens: 1_000_000,
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 1_000_000,
+        maxSummaryTokens: 50_000,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+      setSummary,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+    const payload = 'x'.repeat(1_800_000);
+
+    const result = await summarizeNode(
+      {
+        messages: [new HumanMessage(payload), new AIMessage(payload)],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(result.messages).toBeUndefined();
+    expect(setSummary).not.toHaveBeenCalled();
+    const completion = events.find(
+      (event) => event.event === GraphEvents.ON_SUMMARIZE_COMPLETE
+    );
+    expect((completion?.data as t.SummarizeCompleteEvent).error).toBe(
+      'chunk failed'
+    );
+  });
+
+  it('parses Bedrock provider-reported prompt limits for telemetry', () => {
+    expect(
+      parseProviderContextOverflow(
+        new Error(
+          'ValidationException: prompt is too long: 1131518 tokens > 1000000 maximum'
+        )
+      )
+    ).toEqual({ inputTokens: 1_131_518, maxTokens: 1_000_000 });
   });
 });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1360,7 +1360,7 @@ describe('bounded summarization input', () => {
     ).toBe(260);
   });
 
-  it('repairs an interrupted open tool call before the next user turn', async () => {
+  it('repairs a serialized interrupted tool call before the next user turn', async () => {
     const capturedMessages: BaseMessage[] = [];
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
       class {
@@ -1381,14 +1381,20 @@ describe('bounded summarization input', () => {
       generateStepId,
     });
 
+    const serializedOpenCall = new AIMessage({ content: '' });
+    serializedOpenCall.additional_kwargs.tool_calls = [
+      {
+        id: 'open_call',
+        type: 'function',
+        function: { name: 'search', arguments: '{}' },
+      },
+    ];
+
     await summarizeNode(
       {
         messages: [
           new HumanMessage('objective'),
-          new AIMessage({
-            content: '',
-            tool_calls: [{ id: 'open_call', name: 'search', args: {} }],
-          }),
+          serializedOpenCall,
           new HumanMessage('continue without the interrupted result'),
         ],
         summarizationRequest: {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1391,6 +1391,7 @@ describe('bounded summarization input', () => {
         retainRecent: { turns: 0 },
         maxContextTokens: 1_000_000,
         maxSummaryTokens: 50_000,
+        prompt: 'Preserve CUSTOM_POLICY identifiers verbatim.',
       },
       tokenCounter: (message: { content: unknown }) =>
         Math.ceil(String(message.content).length / 3),
@@ -1429,6 +1430,9 @@ describe('bounded summarization input', () => {
     }
     expect(capturedCalls[2]).toHaveLength(1);
     expect((capturedCalls[2]?.[0] as HumanMessage).getType()).toBe('human');
+    expect(String((capturedCalls[2]?.[0] as HumanMessage).content)).toContain(
+      'CUSTOM_POLICY'
+    );
     expect(setSummary).toHaveBeenCalledWith('checkpoint-3', 43);
     expect(result.messages?.[0]?._getType()).toBe('remove');
   });

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1731,7 +1731,7 @@ describe('bounded summarization input', () => {
     expect(invoke).toHaveBeenCalledTimes(3);
   });
 
-  it('reserves the Anthropic constructor output allowance', async () => {
+  it('reserves the Anthropic constructor output allowance for modelName', async () => {
     const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
       class {
@@ -1742,7 +1742,7 @@ describe('bounded summarization input', () => {
     );
     const agentContext = createAgentContext({
       provider: Providers.ANTHROPIC,
-      clientOptions: { model: 'claude-opus-4-7' },
+      clientOptions: { modelName: 'claude-opus-4-7' },
       maxContextTokens: 20_000,
       summarizationConfig: {
         retainRecent: { turns: 0 },

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1360,6 +1360,89 @@ describe('bounded summarization input', () => {
     ).toBe(260);
   });
 
+  it('repairs an interrupted open tool call before the next user turn', async () => {
+    const capturedMessages: BaseMessage[] = [];
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return {
+            invoke: jest.fn().mockImplementation(async (messages) => {
+              capturedMessages.push(...messages);
+              return { content: 'checkpoint' };
+            }),
+          };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext();
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('objective'),
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'open_call', name: 'search', args: {} }],
+          }),
+          new HumanMessage('continue without the interrupted result'),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(capturedMessages.map((message) => message.getType())).toEqual([
+      'human',
+      'ai',
+      'tool',
+      'human',
+    ]);
+    expect((capturedMessages[2] as ToolMessage).tool_call_id).toBe('open_call');
+  });
+
+  it('counts bound tool schemas without a supplied token counter', async () => {
+    const modelClass = jest.spyOn(providers, 'getChatModelClass');
+    const agentContext = createAgentContext({
+      maxContextTokens: 1_000,
+      tokenCounter: undefined,
+    });
+    jest
+      .spyOn(agentContext, 'getToolsForBinding')
+      .mockReturnValue([{ name: 'large_tool' }] as never);
+    const calculateTokens = jest
+      .spyOn(agentContext, 'calculateInstructionTokens')
+      .mockImplementation(async () => {
+        agentContext.toolSchemaTokens = 1_200;
+      });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(calculateTokens).toHaveBeenCalledWith(expect.any(Function));
+    expect(modelClass).not.toHaveBeenCalled();
+  });
+
   it('never sends an estimated million-token conversation as one provider request', async () => {
     captureEvents();
     const capturedCalls: unknown[][] = [];

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1,4 +1,5 @@
 import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { GraphEvents, Providers } from '@/common';
@@ -522,14 +523,15 @@ describe('createSummarizeNode', () => {
       {} as RunnableConfig
     );
 
-    // The raw messages should be sent + instruction appended as the last HumanMessage
-    // messagesToRefine has 3 HumanMessages, instruction adds 1 more
-    expect(capturedMessages.length).toBe(4);
+    // The raw messages should be sent with the instruction merged into a
+    // trailing HumanMessage so providers never receive consecutive user roles.
+    expect(capturedMessages.length).toBe(3);
     expect(capturedMessages[0].type).toBe('human');
     expect(capturedMessages[0].content).toBe('Message 1');
-    expect(capturedMessages[3].type).toBe('human');
+    expect(capturedMessages[2].type).toBe('human');
+    expect(capturedMessages[2].content).toContain('Message 3');
     // The last message should contain the summarization prompt
-    expect(capturedMessages[3].content).toContain(
+    expect(capturedMessages[2].content).toContain(
       'context window is filling up'
     );
   });
@@ -1242,6 +1244,49 @@ describe('emoji-heavy content does not break summarization', () => {
 });
 
 describe('bounded summarization input', () => {
+  it('merges the instruction into a trailing human message', async () => {
+    let capturedMessages: BaseMessage[] = [];
+    const invoke = jest.fn().mockImplementation((messages: BaseMessage[]) => {
+      capturedMessages = messages;
+      return Promise.resolve({ content: 'checkpoint' });
+    });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      provider: Providers.BEDROCK,
+      clientOptions: { model: 'anthropic.claude-3-5-sonnet' },
+      maxContextTokens: 2_000,
+      tokenCounter: () => 10,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(capturedMessages).toHaveLength(1);
+    expect(capturedMessages[0]).toBeInstanceOf(HumanMessage);
+    expect(String(capturedMessages[0]?.content)).toContain('objective');
+    expect(String(capturedMessages[0]?.content)).toContain('## Checkpoint');
+  });
+
   it('recalculates tool-schema overhead for a dedicated Anthropic summarizer', () => {
     const agentContext = createAgentContext({
       provider: Providers.OPENAI,

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1336,6 +1336,7 @@ describe('bounded summarization input', () => {
 
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(capturedMessages.map((message) => message.getType())).toEqual([
+      'human',
       'ai',
       'tool',
       'ai',
@@ -1419,6 +1420,7 @@ describe('bounded summarization input', () => {
 
     expect(capturedCalls).toHaveLength(3);
     for (const call of capturedCalls) {
+      expect(call[0]).toBeInstanceOf(HumanMessage);
       const estimatedContentTokens = call.reduce<number>((total, raw) => {
         const message = raw as { content?: unknown };
         return total + Math.ceil(String(message.content ?? '').length / 3);
@@ -1510,6 +1512,41 @@ describe('bounded summarization input', () => {
     );
 
     expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes tool-schema tokens after deferred-tool discovery', async () => {
+    const modelClass = jest.spyOn(providers, 'getChatModelClass');
+    const agentContext = createAgentContext({
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4.1' },
+      maxContextTokens: 2_000,
+      tokenCounter: () => 10,
+    });
+    agentContext.discoveredToolNames.add('deferred_tool');
+    const refreshTokens = jest
+      .spyOn(agentContext, 'calculateInstructionTokens')
+      .mockImplementation(async () => {
+        agentContext.toolSchemaTokens = 2_500;
+      });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(refreshTokens).toHaveBeenCalledWith(agentContext.tokenCounter);
+    expect(modelClass).not.toHaveBeenCalled();
   });
 
   it('counts chunks with the dedicated summarizer tokenizer', async () => {

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -339,7 +339,9 @@ describe('createSummarizeNode', () => {
     expect(setSummary).not.toHaveBeenCalled();
 
     const completeEvent = events.find(
-      (e) => e.event === GraphEvents.ON_SUMMARIZE_COMPLETE
+      (e) =>
+        e.event === GraphEvents.ON_SUMMARIZE_COMPLETE &&
+        (e.data as t.SummarizeCompleteEvent).error != null
     );
     expect(
       (completeEvent?.data as t.SummarizeCompleteEvent).summary
@@ -1240,7 +1242,16 @@ describe('bounded summarization input', () => {
     const capturedCalls: unknown[][] = [];
     const invoke = jest.fn().mockImplementation(async (messages: unknown[]) => {
       capturedCalls.push(messages);
-      return { content: `checkpoint-${capturedCalls.length}` };
+      const callNumber = capturedCalls.length;
+      const outputTokens = callNumber === 3 ? 10 : 100;
+      return new AIMessage({
+        content: `checkpoint-${callNumber}`,
+        usage_metadata: {
+          input_tokens: 10,
+          output_tokens: outputTokens,
+          total_tokens: 10 + outputTokens,
+        },
+      });
     });
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
       class {
@@ -1292,8 +1303,91 @@ describe('bounded summarization input', () => {
       }, 0);
       expect(estimatedContentTokens).toBeLessThan(1_000_000);
     }
-    expect(setSummary).toHaveBeenCalledWith('checkpoint-3', expect.any(Number));
+    expect(capturedCalls[2]).toHaveLength(1);
+    expect((capturedCalls[2]?.[0] as HumanMessage).getType()).toBe('human');
+    expect(setSummary).toHaveBeenCalledWith('checkpoint-3', 43);
     expect(result.messages?.[0]?._getType()).toBe('remove');
+  });
+
+  it('uses the dedicated summarizer context window for preflight', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      maxContextTokens: 100,
+      systemMessageTokens: 150,
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 1_000,
+      },
+      tokenCounter: () => 10,
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [new HumanMessage('objective')],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the learned calibration ratio to chunk selection', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      maxContextTokens: 2_000,
+      calibrationRatio: 2,
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 2_000,
+        maxSummaryTokens: 100,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('x'.repeat(1_200)),
+          new AIMessage('y'.repeat(1_200)),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(3);
   });
 
   it('preserves the original history when a staged chunk fails', async () => {
@@ -1311,6 +1405,7 @@ describe('bounded summarization input', () => {
     );
 
     const setSummary = jest.fn();
+    const onStepCompleted = jest.fn();
     const agentContext = createAgentContext({
       maxContextTokens: 1_000_000,
       summarizationConfig: {
@@ -1324,7 +1419,7 @@ describe('bounded summarization input', () => {
     });
     const summarizeNode = createSummarizeNode({
       agentContext,
-      graph: mockGraph() as never,
+      graph: mockGraph(onStepCompleted) as never,
       generateStepId,
     });
     const payload = 'x'.repeat(1_800_000);
@@ -1343,6 +1438,10 @@ describe('bounded summarization input', () => {
     expect(invoke).toHaveBeenCalledTimes(2);
     expect(result.messages).toBeUndefined();
     expect(setSummary).not.toHaveBeenCalled();
+    expect(onStepCompleted).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ type: 'summary' })
+    );
     const completion = events.find(
       (event) => event.event === GraphEvents.ON_SUMMARIZE_COMPLETE
     );

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -1390,6 +1390,48 @@ describe('bounded summarization input', () => {
     expect(invoke).toHaveBeenCalledTimes(3);
   });
 
+  it('reserves the inherited model output allowance', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      maxContextTokens: 3_000,
+      clientOptions: { maxTokens: 1_500 },
+      summarizationConfig: {
+        retainRecent: { turns: 0 },
+        maxContextTokens: 3_000,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('x'.repeat(2_250)),
+          new AIMessage('y'.repeat(2_250)),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+
   it('preserves the original history when a staged chunk fails', async () => {
     const events = captureEvents();
     const invoke = jest
@@ -1440,7 +1482,10 @@ describe('bounded summarization input', () => {
     expect(setSummary).not.toHaveBeenCalled();
     expect(onStepCompleted).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ type: 'summary' })
+      expect.objectContaining({
+        type: 'summary_error',
+        error: 'chunk failed',
+      })
     );
     const completion = events.find(
       (event) => event.event === GraphEvents.ON_SUMMARIZE_COMPLETE

--- a/src/summarization/__tests__/node.test.ts
+++ b/src/summarization/__tests__/node.test.ts
@@ -629,12 +629,14 @@ describe('DEFAULT_UPDATE_SUMMARIZATION_PROMPT', () => {
   });
 });
 
-describe('budget check — instructions exceed context', () => {
-  it('skips summarization when instructionTokens >= maxContextTokens', async () => {
+describe('summarizer preflight budget', () => {
+  it('skips summarization when tool definitions exceed the context', async () => {
     const events = captureEvents();
     const agentContext = createAgentContext({
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4.1' },
       maxContextTokens: 4000,
-      systemMessageTokens: 5000,
+      toolSchemaTokens: 5000,
       formatTokenBudgetBreakdown: () => 'mock breakdown',
     });
 
@@ -669,7 +671,7 @@ describe('budget check — instructions exceed context', () => {
     expect(summarizeEvents).toHaveLength(0);
   });
 
-  it('proceeds normally when instructionTokens < maxContextTokens', async () => {
+  it('does not charge agent-only instructions to the summarizer', async () => {
     captureEvents();
 
     jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
@@ -682,7 +684,8 @@ describe('budget check — instructions exceed context', () => {
 
     const agentContext = createAgentContext({
       maxContextTokens: 8000,
-      systemMessageTokens: 2000,
+      systemMessageTokens: 9000,
+      dynamicInstructionTokens: 1000,
       formatTokenBudgetBreakdown: () => 'mock breakdown',
     });
 
@@ -1483,6 +1486,53 @@ describe('bounded summarization input', () => {
         messages: [
           new HumanMessage('x'.repeat(1_200)),
           new AIMessage('y'.repeat(1_200)),
+        ],
+        summarizationRequest: {
+          remainingContextTokens: 0,
+          agentId: 'agent_0',
+        },
+      },
+      {} as RunnableConfig
+    );
+
+    expect(invoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets calibration for a different summarizer model', async () => {
+    const invoke = jest.fn().mockResolvedValue({ content: 'checkpoint' });
+    jest.spyOn(providers, 'getChatModelClass').mockReturnValue(
+      class {
+        constructor() {
+          return { invoke };
+        }
+      } as never
+    );
+    const agentContext = createAgentContext({
+      provider: Providers.OPENAI,
+      clientOptions: { model: 'gpt-4.1' },
+      maxContextTokens: 2_000,
+      calibrationRatio: 0.5,
+      summarizationConfig: {
+        provider: Providers.OPENAI,
+        model: 'gpt-4o-mini',
+        retainRecent: { turns: 0 },
+        maxContextTokens: 2_000,
+        maxSummaryTokens: 100,
+      },
+      tokenCounter: (message: { content: unknown }) =>
+        Math.ceil(String(message.content).length / 3),
+    });
+    const summarizeNode = createSummarizeNode({
+      agentContext,
+      graph: mockGraph() as never,
+      generateStepId,
+    });
+
+    await summarizeNode(
+      {
+        messages: [
+          new HumanMessage('x'.repeat(3_600)),
+          new AIMessage('y'.repeat(3_600)),
         ],
         summarizationRequest: {
           remainingContextTokens: 0,

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -5,6 +5,7 @@ import {
 } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { TokenCounter } from '@/types';
+import { Constants } from '@/common';
 
 export const DEFAULT_SUMMARIZATION_CONTEXT_TOKENS = 32_000;
 export const MAX_SUMMARIZATION_CHUNKS = 8;
@@ -169,7 +170,11 @@ function getToolCallIds(message: BaseMessage): string[] {
   const ids = new Set<string>();
   if (Array.isArray(message.tool_calls)) {
     for (const call of message.tool_calls) {
-      if (typeof call.id === 'string' && call.id !== '') {
+      if (
+        typeof call.id === 'string' &&
+        call.id !== '' &&
+        !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+      ) {
         ids.add(call.id);
       }
     }
@@ -182,7 +187,11 @@ function getToolCallIds(message: BaseMessage): string[] {
         continue;
       }
       const id = (call as { id?: unknown }).id;
-      if (typeof id === 'string' && id !== '') {
+      if (
+        typeof id === 'string' &&
+        id !== '' &&
+        !id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
+      ) {
         ids.add(id);
       }
     }

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -30,6 +30,21 @@ export type SummarizationChunkResult =
   | { plan: SummarizationChunkPlan; error?: never }
   | { plan?: never; error: string; estimatedMessageTokens: number };
 
+interface SerializedToolCall {
+  id?: unknown;
+  name?: unknown;
+  function?: { name?: unknown };
+}
+
+interface ToolCallMetadata {
+  tool_calls?: SerializedToolCall[];
+}
+
+interface ClientToolCall {
+  id: string;
+  name: string;
+}
+
 function estimateContentLength(message: BaseMessage): number {
   let serialized = '';
   try {
@@ -163,11 +178,11 @@ export function createSummarizationInputBudget(params: {
   };
 }
 
-function getToolCallIds(message: BaseMessage): string[] {
+function getClientToolCalls(message: BaseMessage): ClientToolCall[] {
   if (!isAIMessage(message)) {
     return [];
   }
-  const ids = new Set<string>();
+  const calls = new Map<string, ClientToolCall>();
   if (Array.isArray(message.tool_calls)) {
     for (const call of message.tool_calls) {
       if (
@@ -175,11 +190,11 @@ function getToolCallIds(message: BaseMessage): string[] {
         call.id !== '' &&
         !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
       ) {
-        ids.add(call.id);
+        calls.set(call.id, { id: call.id, name: call.name });
       }
     }
   }
-  const serializedCalls = (message.additional_kwargs as Record<string, unknown>)
+  const serializedCalls = (message.additional_kwargs as ToolCallMetadata)
     .tool_calls;
   if (Array.isArray(serializedCalls)) {
     for (const call of serializedCalls) {
@@ -192,11 +207,51 @@ function getToolCallIds(message: BaseMessage): string[] {
         id !== '' &&
         !id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX)
       ) {
-        ids.add(id);
+        const serializedName =
+          typeof call.name === 'string'
+            ? call.name
+            : typeof call.function?.name === 'string'
+              ? call.function.name
+              : 'interrupted_tool';
+        calls.set(id, { id, name: serializedName });
       }
     }
   }
-  return [...ids];
+  return [...calls.values()];
+}
+
+export function repairInterruptedToolCalls(
+  messages: BaseMessage[]
+): BaseMessage[] {
+  const toolResultIds = new Set<string>();
+  for (const message of messages) {
+    if (
+      message instanceof ToolMessage &&
+      typeof message.tool_call_id === 'string' &&
+      message.tool_call_id !== ''
+    ) {
+      toolResultIds.add(message.tool_call_id);
+    }
+  }
+
+  const repaired: BaseMessage[] = [];
+  for (const message of messages) {
+    repaired.push(message);
+    for (const call of getClientToolCalls(message)) {
+      if (toolResultIds.has(call.id)) {
+        continue;
+      }
+      repaired.push(
+        new ToolMessage({
+          content: 'Tool execution was interrupted before producing a result.',
+          tool_call_id: call.id,
+          name: call.name,
+        })
+      );
+      toolResultIds.add(call.id);
+    }
+  }
+  return repaired;
 }
 
 function buildAtomicMessageUnits(messages: BaseMessage[]): BaseMessage[][] {
@@ -205,9 +260,9 @@ function buildAtomicMessageUnits(messages: BaseMessage[]): BaseMessage[][] {
 
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i] as BaseMessage;
-    for (const id of getToolCallIds(message)) {
-      if (!callStarts.has(id)) {
-        callStarts.set(id, i);
+    for (const call of getClientToolCalls(message)) {
+      if (!callStarts.has(call.id)) {
+        callStarts.set(call.id, i);
       }
     }
     if (
@@ -263,7 +318,9 @@ export function planSummarizationChunks(params: {
     };
   }
 
-  const units = buildAtomicMessageUnits(params.messages);
+  const units = buildAtomicMessageUnits(
+    repairInterruptedToolCalls(params.messages)
+  );
   const unitTokenEstimates: number[] = [];
   let estimatedMessageTokens = 0;
   let oversizedUnitTokens = 0;

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -154,8 +154,10 @@ export function createSummarizationInputBudget(params: {
     outputReserveTokens,
     messageBudgetTokens: Math.max(
       0,
-      Math.floor((contextTokens - outputReserveTokens) / calibrationRatio) -
-        fixedOverheadTokens
+      Math.floor(
+        (contextTokens - outputReserveTokens - fixedOverheadTokens) /
+          calibrationRatio
+      )
     ),
   };
 }

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -1,4 +1,8 @@
-import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import {
+  AIMessage,
+  SystemMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { TokenCounter } from '@/types';
 
@@ -42,7 +46,7 @@ function estimateContentLength(message: BaseMessage): number {
   return serialized.length;
 }
 
-function estimateMetadataLength(message: BaseMessage): number {
+function serializeMetadata(message: BaseMessage): string {
   try {
     return JSON.stringify({
       additional_kwargs:
@@ -53,9 +57,9 @@ function estimateMetadataLength(message: BaseMessage): number {
       tool_call_id:
         message instanceof ToolMessage ? message.tool_call_id : undefined,
       name: message.name || undefined,
-    }).length;
+    });
   } catch {
-    return estimateContentLength(message);
+    return String(message.additional_kwargs);
   }
 }
 
@@ -75,10 +79,22 @@ export function estimateMessageTokens(
     }
   }
 
-  const contentTokens =
-    counted > 0
-      ? counted + estimateMetadataLength(message)
-      : estimateContentLength(message);
+  let contentTokens = estimateContentLength(message);
+  if (counted > 0) {
+    const serializedMetadata = serializeMetadata(message);
+    let metadataTokens = serializedMetadata.length;
+    if (tokenCounter) {
+      try {
+        const value = tokenCounter(new SystemMessage(serializedMetadata));
+        if (Number.isFinite(value) && value >= 0) {
+          metadataTokens = Math.ceil(value);
+        }
+      } catch {
+        // Keep the conservative character-count fallback.
+      }
+    }
+    contentTokens = counted + metadataTokens;
+  }
   return contentTokens + MESSAGE_ENVELOPE_TOKENS;
 }
 
@@ -98,6 +114,7 @@ export function createSummarizationInputBudget(params: {
   fixedOverheadTokens: number;
   maxSummaryTokens?: number;
   reserveRatio?: number;
+  calibrationRatio?: number;
 }): SummarizationInputBudget {
   const contextTokens =
     params.maxContextTokens != null &&
@@ -114,7 +131,7 @@ export function createSummarizationInputBudget(params: {
   const reserveRatio =
     params.reserveRatio != null &&
     Number.isFinite(params.reserveRatio) &&
-    params.reserveRatio > 0 &&
+    params.reserveRatio >= 0 &&
     params.reserveRatio < 1
       ? params.reserveRatio
       : DEFAULT_OUTPUT_RESERVE_RATIO;
@@ -124,6 +141,12 @@ export function createSummarizationInputBudget(params: {
     0,
     Math.ceil(params.fixedOverheadTokens)
   );
+  const calibrationRatio =
+    params.calibrationRatio != null &&
+    Number.isFinite(params.calibrationRatio) &&
+    params.calibrationRatio > 0
+      ? params.calibrationRatio
+      : 1;
 
   return {
     contextTokens,
@@ -131,7 +154,8 @@ export function createSummarizationInputBudget(params: {
     outputReserveTokens,
     messageBudgetTokens: Math.max(
       0,
-      contextTokens - fixedOverheadTokens - outputReserveTokens
+      Math.floor((contextTokens - outputReserveTokens) / calibrationRatio) -
+        fixedOverheadTokens
     ),
   };
 }

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -1,0 +1,245 @@
+import { AIMessage, ToolMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { TokenCounter } from '@/types';
+
+export const DEFAULT_SUMMARIZATION_CONTEXT_TOKENS = 32_000;
+export const MAX_SUMMARIZATION_CHUNKS = 8;
+
+const DEFAULT_OUTPUT_RESERVE_RATIO = 0.05;
+const MESSAGE_ENVELOPE_TOKENS = 8;
+const CHARS_PER_TOKEN = 3;
+
+export interface SummarizationInputBudget {
+  contextTokens: number;
+  fixedOverheadTokens: number;
+  outputReserveTokens: number;
+  messageBudgetTokens: number;
+}
+
+export interface SummarizationChunkPlan {
+  chunks: BaseMessage[][];
+  estimatedMessageTokens: number;
+  chunkTokenEstimates: number[];
+}
+
+export type SummarizationChunkResult =
+  | { plan: SummarizationChunkPlan; error?: never }
+  | { plan?: never; error: string; estimatedMessageTokens: number };
+
+function estimateContentTokens(message: BaseMessage): number {
+  let serialized = '';
+  try {
+    serialized = JSON.stringify({
+      type: message.getType(),
+      content: message.content,
+      additional_kwargs: message.additional_kwargs,
+    });
+  } catch {
+    serialized = String(message.content);
+  }
+  return Math.ceil(serialized.length / CHARS_PER_TOKEN);
+}
+
+export function estimateMessageTokens(
+  message: BaseMessage,
+  tokenCounter?: TokenCounter
+): number {
+  let counted = 0;
+  if (tokenCounter) {
+    try {
+      const value = tokenCounter(message);
+      if (Number.isFinite(value) && value > 0) {
+        counted = Math.ceil(value);
+      }
+    } catch {
+      counted = 0;
+    }
+  }
+
+  return (
+    Math.max(counted, estimateContentTokens(message)) + MESSAGE_ENVELOPE_TOKENS
+  );
+}
+
+export function estimateMessagesTokens(
+  messages: BaseMessage[],
+  tokenCounter?: TokenCounter
+): number {
+  let total = 0;
+  for (const message of messages) {
+    total += estimateMessageTokens(message, tokenCounter);
+  }
+  return total;
+}
+
+export function createSummarizationInputBudget(params: {
+  maxContextTokens?: number;
+  fixedOverheadTokens: number;
+  maxSummaryTokens?: number;
+  reserveRatio?: number;
+}): SummarizationInputBudget {
+  const contextTokens =
+    params.maxContextTokens != null &&
+    Number.isFinite(params.maxContextTokens) &&
+    params.maxContextTokens > 0
+      ? Math.floor(params.maxContextTokens)
+      : DEFAULT_SUMMARIZATION_CONTEXT_TOKENS;
+  const configuredReserve =
+    params.maxSummaryTokens != null &&
+    Number.isFinite(params.maxSummaryTokens) &&
+    params.maxSummaryTokens > 0
+      ? Math.ceil(params.maxSummaryTokens)
+      : 0;
+  const reserveRatio =
+    params.reserveRatio != null &&
+    Number.isFinite(params.reserveRatio) &&
+    params.reserveRatio > 0 &&
+    params.reserveRatio < 1
+      ? params.reserveRatio
+      : DEFAULT_OUTPUT_RESERVE_RATIO;
+  const ratioReserve = Math.max(1, Math.ceil(contextTokens * reserveRatio));
+  const outputReserveTokens = Math.max(configuredReserve, ratioReserve);
+  const fixedOverheadTokens = Math.max(
+    0,
+    Math.ceil(params.fixedOverheadTokens)
+  );
+
+  return {
+    contextTokens,
+    fixedOverheadTokens,
+    outputReserveTokens,
+    messageBudgetTokens: Math.max(
+      0,
+      contextTokens - fixedOverheadTokens - outputReserveTokens
+    ),
+  };
+}
+
+function getToolCallIds(message: BaseMessage): string[] {
+  if (!(message instanceof AIMessage) || !Array.isArray(message.tool_calls)) {
+    return [];
+  }
+  return message.tool_calls
+    .map((call) => call.id)
+    .filter((id): id is string => typeof id === 'string' && id !== '');
+}
+
+function buildAtomicMessageUnits(messages: BaseMessage[]): BaseMessage[][] {
+  const callStarts = new Map<string, number>();
+  const callResults = new Map<string, number>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i] as BaseMessage;
+    for (const id of getToolCallIds(message)) {
+      if (!callStarts.has(id)) {
+        callStarts.set(id, i);
+      }
+    }
+    if (
+      message instanceof ToolMessage &&
+      typeof message.tool_call_id === 'string' &&
+      message.tool_call_id !== '' &&
+      !callResults.has(message.tool_call_id)
+    ) {
+      callResults.set(message.tool_call_id, i);
+    }
+  }
+
+  const boundaryDelta = new Int32Array(messages.length + 1);
+  for (const [id, start] of callStarts) {
+    const result = callResults.get(id);
+    const end =
+      result != null && result >= start ? result : messages.length - 1;
+    if (end <= start) {
+      continue;
+    }
+    boundaryDelta[start] += 1;
+    boundaryDelta[end] -= 1;
+  }
+
+  const units: BaseMessage[][] = [];
+  let current: BaseMessage[] = [];
+  let protectedBoundaries = 0;
+  for (let i = 0; i < messages.length; i++) {
+    protectedBoundaries += boundaryDelta[i] as number;
+    current.push(messages[i] as BaseMessage);
+    if (protectedBoundaries === 0) {
+      units.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) {
+    units.push(current);
+  }
+  return units;
+}
+
+export function planSummarizationChunks(params: {
+  messages: BaseMessage[];
+  messageBudgetTokens: number;
+  tokenCounter?: TokenCounter;
+  maxChunks?: number;
+}): SummarizationChunkResult {
+  if (params.messageBudgetTokens <= 0) {
+    return {
+      error:
+        'Summarization instructions and output reserve exhaust the model context window',
+      estimatedMessageTokens: 0,
+    };
+  }
+
+  const units = buildAtomicMessageUnits(params.messages);
+  const unitTokenEstimates: number[] = [];
+  let estimatedMessageTokens = 0;
+  let oversizedUnitTokens = 0;
+  for (const unit of units) {
+    const unitTokens = estimateMessagesTokens(unit, params.tokenCounter);
+    unitTokenEstimates.push(unitTokens);
+    estimatedMessageTokens += unitTokens;
+    oversizedUnitTokens = Math.max(oversizedUnitTokens, unitTokens);
+  }
+  if (oversizedUnitTokens > params.messageBudgetTokens) {
+    return {
+      error: `A complete message/tool-call unit requires ${oversizedUnitTokens} tokens but the summarizer input budget is ${params.messageBudgetTokens}`,
+      estimatedMessageTokens,
+    };
+  }
+
+  const chunks: BaseMessage[][] = [];
+  const chunkTokenEstimates: number[] = [];
+  let current: BaseMessage[] = [];
+  let currentTokens = 0;
+
+  for (let i = 0; i < units.length; i++) {
+    const unit = units[i] as BaseMessage[];
+    const unitTokens = unitTokenEstimates[i] as number;
+    if (
+      current.length > 0 &&
+      currentTokens + unitTokens > params.messageBudgetTokens
+    ) {
+      chunks.push(current);
+      chunkTokenEstimates.push(currentTokens);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(...unit);
+    currentTokens += unitTokens;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
+    chunkTokenEstimates.push(currentTokens);
+  }
+
+  const maxChunks = params.maxChunks ?? MAX_SUMMARIZATION_CHUNKS;
+  if (chunks.length > maxChunks) {
+    return {
+      error: `Summarization requires ${chunks.length} chunks, exceeding the bounded limit of ${maxChunks}`,
+      estimatedMessageTokens,
+    };
+  }
+
+  return {
+    plan: { chunks, estimatedMessageTokens, chunkTokenEstimates },
+  };
+}

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -161,12 +161,31 @@ export function createSummarizationInputBudget(params: {
 }
 
 function getToolCallIds(message: BaseMessage): string[] {
-  if (!(message instanceof AIMessage) || !Array.isArray(message.tool_calls)) {
+  if (!(message instanceof AIMessage)) {
     return [];
   }
-  return message.tool_calls
-    .map((call) => call.id)
-    .filter((id): id is string => typeof id === 'string' && id !== '');
+  const ids = new Set<string>();
+  if (Array.isArray(message.tool_calls)) {
+    for (const call of message.tool_calls) {
+      if (typeof call.id === 'string' && call.id !== '') {
+        ids.add(call.id);
+      }
+    }
+  }
+  const serializedCalls = (message.additional_kwargs as Record<string, unknown>)
+    .tool_calls;
+  if (Array.isArray(serializedCalls)) {
+    for (const call of serializedCalls) {
+      if (call == null || typeof call !== 'object') {
+        continue;
+      }
+      const id = (call as { id?: unknown }).id;
+      if (typeof id === 'string' && id !== '') {
+        ids.add(id);
+      }
+    }
+  }
+  return [...ids];
 }
 
 function buildAtomicMessageUnits(messages: BaseMessage[]): BaseMessage[][] {

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -42,6 +42,23 @@ function estimateContentLength(message: BaseMessage): number {
   return serialized.length;
 }
 
+function estimateMetadataLength(message: BaseMessage): number {
+  try {
+    return JSON.stringify({
+      additional_kwargs:
+        Object.keys(message.additional_kwargs).length > 0
+          ? message.additional_kwargs
+          : undefined,
+      tool_calls: message instanceof AIMessage ? message.tool_calls : undefined,
+      tool_call_id:
+        message instanceof ToolMessage ? message.tool_call_id : undefined,
+      name: message.name || undefined,
+    }).length;
+  } catch {
+    return estimateContentLength(message);
+  }
+}
+
 export function estimateMessageTokens(
   message: BaseMessage,
   tokenCounter?: TokenCounter
@@ -58,7 +75,10 @@ export function estimateMessageTokens(
     }
   }
 
-  const contentTokens = counted > 0 ? counted : estimateContentLength(message);
+  const contentTokens =
+    counted > 0
+      ? counted + estimateMetadataLength(message)
+      : estimateContentLength(message);
   return contentTokens + MESSAGE_ENVELOPE_TOKENS;
 }
 

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -7,7 +7,6 @@ export const MAX_SUMMARIZATION_CHUNKS = 8;
 
 const DEFAULT_OUTPUT_RESERVE_RATIO = 0.05;
 const MESSAGE_ENVELOPE_TOKENS = 8;
-const CHARS_PER_TOKEN = 3;
 
 export interface SummarizationInputBudget {
   contextTokens: number;
@@ -26,18 +25,21 @@ export type SummarizationChunkResult =
   | { plan: SummarizationChunkPlan; error?: never }
   | { plan?: never; error: string; estimatedMessageTokens: number };
 
-function estimateContentTokens(message: BaseMessage): number {
+function estimateContentLength(message: BaseMessage): number {
   let serialized = '';
   try {
     serialized = JSON.stringify({
       type: message.getType(),
       content: message.content,
       additional_kwargs: message.additional_kwargs,
+      tool_calls: message instanceof AIMessage ? message.tool_calls : undefined,
+      tool_call_id:
+        message instanceof ToolMessage ? message.tool_call_id : undefined,
     });
   } catch {
     serialized = String(message.content);
   }
-  return Math.ceil(serialized.length / CHARS_PER_TOKEN);
+  return serialized.length;
 }
 
 export function estimateMessageTokens(
@@ -56,9 +58,8 @@ export function estimateMessageTokens(
     }
   }
 
-  return (
-    Math.max(counted, estimateContentTokens(message)) + MESSAGE_ENVELOPE_TOKENS
-  );
+  const contentTokens = counted > 0 ? counted : estimateContentLength(message);
+  return contentTokens + MESSAGE_ENVELOPE_TOKENS;
 }
 
 export function estimateMessagesTokens(

--- a/src/summarization/input.ts
+++ b/src/summarization/input.ts
@@ -1,7 +1,7 @@
 import {
-  AIMessage,
   SystemMessage,
   ToolMessage,
+  isAIMessage,
 } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { TokenCounter } from '@/types';
@@ -36,7 +36,7 @@ function estimateContentLength(message: BaseMessage): number {
       type: message.getType(),
       content: message.content,
       additional_kwargs: message.additional_kwargs,
-      tool_calls: message instanceof AIMessage ? message.tool_calls : undefined,
+      tool_calls: isAIMessage(message) ? message.tool_calls : undefined,
       tool_call_id:
         message instanceof ToolMessage ? message.tool_call_id : undefined,
     });
@@ -53,7 +53,7 @@ function serializeMetadata(message: BaseMessage): string {
         Object.keys(message.additional_kwargs).length > 0
           ? message.additional_kwargs
           : undefined,
-      tool_calls: message instanceof AIMessage ? message.tool_calls : undefined,
+      tool_calls: isAIMessage(message) ? message.tool_calls : undefined,
       tool_call_id:
         message instanceof ToolMessage ? message.tool_call_id : undefined,
       name: message.name || undefined,
@@ -163,7 +163,7 @@ export function createSummarizationInputBudget(params: {
 }
 
 function getToolCallIds(message: BaseMessage): string[] {
-  if (!(message instanceof AIMessage)) {
+  if (!isAIMessage(message)) {
     return [];
   }
   const ids = new Set<string>();

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -30,6 +30,7 @@ import {
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { addCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
+import { getAnthropicDefaultMaxOutputTokens } from '@/llm/anthropic';
 import { extractErrorMessage } from '@/utils/errors';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
@@ -326,12 +327,18 @@ function buildSummarizationClientConfig(
 
   const outputTokensKey = getMaxOutputTokensKey(provider);
   const inheritedOutputTokens = Number(clientOptions[outputTokensKey]);
+  const constructorDefaultOutputTokens =
+    provider === Providers.ANTHROPIC
+      ? getAnthropicDefaultMaxOutputTokens(
+          String(clientOptions.model ?? modelName ?? '')
+        )
+      : undefined;
   const effectiveMaxSummaryTokens =
     paramMaxSummaryTokens ??
     summarizationConfig?.maxSummaryTokens ??
     (Number.isFinite(inheritedOutputTokens) && inheritedOutputTokens > 0
       ? inheritedOutputTokens
-      : undefined);
+      : constructorDefaultOutputTokens);
 
   if (effectiveMaxSummaryTokens != null) {
     clientOptions[outputTokensKey] = effectiveMaxSummaryTokens;

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -547,6 +547,30 @@ function describeFallbackError(
   };
 }
 
+function appendSummarizationInstruction(
+  messages: BaseMessage[],
+  instruction: string
+): BaseMessage[] {
+  const lastMessage = messages.at(-1);
+  if (!(lastMessage instanceof HumanMessage)) {
+    return [...messages, new HumanMessage(instruction)];
+  }
+  const mergedContent =
+    typeof lastMessage.content === 'string'
+      ? `${lastMessage.content}\n\n${instruction}`
+      : [...lastMessage.content, { type: 'text' as const, text: instruction }];
+  return [
+    ...messages.slice(0, -1),
+    new HumanMessage({
+      content: mergedContent,
+      additional_kwargs: lastMessage.additional_kwargs,
+      response_metadata: lastMessage.response_metadata,
+      id: lastMessage.id,
+      name: lastMessage.name,
+    }),
+  ];
+}
+
 /**
  * Runs the summarization LLM call with a bounded primary + fallback set.
  * Exhaustion is explicit so callers preserve the original history.
@@ -639,16 +663,14 @@ async function executeSummarizationWithFallback(params: {
         const fbResult = await tryFallbackProviders({
           fallbacks,
           tools: agentContext.getToolsForBinding(),
-          messages: [
-            ...messages,
-            new HumanMessage(
-              buildSummarizationInstruction(
-                clientConfig.promptText,
-                clientConfig.updatePromptText,
-                priorSummaryText
-              )
-            ),
-          ],
+          messages: appendSummarizationInstruction(
+            messages,
+            buildSummarizationInstruction(
+              clientConfig.promptText,
+              clientConfig.updatePromptText,
+              priorSummaryText
+            )
+          ),
           config: traceConfig(summarizeConfig, 'cache_hit_compaction'),
           primaryError,
           onChunk,
@@ -1606,7 +1628,7 @@ async function summarizeWithCacheHit({
     priorSummaryText
   );
 
-  const fullMessages = [...messages, new HumanMessage(instruction)];
+  const fullMessages = appendSummarizationInstruction(messages, instruction);
   const invokeMessages =
     usePromptCache === true ? addCacheControl(fullMessages) : fullMessages;
 
@@ -1640,8 +1662,7 @@ async function summarizeWithCacheHit({
     usageSource = 'usage_metadata';
   } else if (responseMsg != null) {
     const respMeta = responseMsg.response_metadata as
-      | Record<string, unknown>
-      | undefined;
+      Record<string, unknown> | undefined;
     const raw = (respMeta?.metadata as Record<string, unknown> | undefined)
       ?.usage as Record<string, unknown> | undefined;
     if (raw != null) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -63,6 +63,8 @@ const CHUNK_SUMMARIZATION_PROMPT = `Create a faithful checkpoint for only this b
 const SYNTHESIS_SUMMARIZATION_PROMPT = `Synthesize the numbered bounded checkpoints into one usable continuation checkpoint. Preserve the original user objective, constraints, exact identifiers, tool outcomes, failures, decisions, current progress, and next steps. Resolve repetition without dropping unique facts. Do not continue the task. Return only the consolidated checkpoint.`;
 
 const TOOL_RESULT_TURN_BRIDGE = 'I have received the tool result.';
+const CONTINUATION_TURN_BRIDGE =
+  'Continue from the prior bounded conversation segment.';
 
 /** Structured checkpoint prompt for fresh summarization (no prior summary). */
 export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
@@ -553,23 +555,27 @@ function appendSummarizationInstruction(
   messages: BaseMessage[],
   instruction: string
 ): BaseMessage[] {
-  const lastMessage = messages.at(-1);
+  const providerMessages =
+    messages.length > 0 && !(messages[0] instanceof HumanMessage)
+      ? [new HumanMessage(CONTINUATION_TURN_BRIDGE), ...messages]
+      : [...messages];
+  const lastMessage = providerMessages.at(-1);
   if (lastMessage instanceof ToolMessage) {
     return [
-      ...messages,
+      ...providerMessages,
       new AIMessage(TOOL_RESULT_TURN_BRIDGE),
       new HumanMessage(instruction),
     ];
   }
   if (!(lastMessage instanceof HumanMessage)) {
-    return [...messages, new HumanMessage(instruction)];
+    return [...providerMessages, new HumanMessage(instruction)];
   }
   const mergedContent =
     typeof lastMessage.content === 'string'
       ? `${lastMessage.content}\n\n${instruction}`
       : [...lastMessage.content, { type: 'text' as const, text: instruction }];
   return [
-    ...messages.slice(0, -1),
+    ...providerMessages.slice(0, -1),
     new HumanMessage({
       content: mergedContent,
       additional_kwargs: lastMessage.additional_kwargs,
@@ -838,6 +844,10 @@ async function executePreparedSummarization(params: {
     Math.max(...instructionEstimates) +
     estimateMessageTokens(
       new AIMessage(TOOL_RESULT_TURN_BRIDGE),
+      summarizerTokenCounter
+    ) +
+    estimateMessageTokens(
+      new HumanMessage(CONTINUATION_TURN_BRIDGE),
       summarizerTokenCounter
     );
   const summarizerToolSchemaTokens = getSummarizationToolSchemaTokens(
@@ -1154,6 +1164,12 @@ export function createSummarizeNode({
       agentContext,
       agentContext.summarizationConfig
     );
+    if (
+      agentContext.tokenCounter != null &&
+      agentContext.discoveredToolNames.size > 0
+    ) {
+      await agentContext.calculateInstructionTokens(agentContext.tokenCounter);
+    }
     const configuredSummarizerMax = clientConfig.maxContextTokens;
     const maxCtx =
       configuredSummarizerMax != null &&

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -3,7 +3,6 @@ import {
   ToolMessage,
   HumanMessage,
   SystemMessage,
-  isAIMessage,
 } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
@@ -14,7 +13,6 @@ import type * as t from '@/types';
 import {
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   ContentTypes,
-  Constants,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
   GraphEvents,
   StepTypes,
@@ -566,41 +564,10 @@ function appendSummarizationInstruction(
   messages: BaseMessage[],
   instruction: string
 ): BaseMessage[] {
-  const toolResultIds = new Set(
-    messages
-      .filter(
-        (message): message is ToolMessage => message instanceof ToolMessage
-      )
-      .map((message) => message.tool_call_id)
-  );
-  const repairedMessages: BaseMessage[] = [];
-  for (const message of messages) {
-    repairedMessages.push(message);
-    if (!isAIMessage(message)) {
-      continue;
-    }
-    const openCalls = (message.tool_calls ?? []).filter(
-      (call) =>
-        typeof call.id === 'string' &&
-        call.id !== '' &&
-        !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
-        !toolResultIds.has(call.id)
-    );
-    for (const call of openCalls) {
-      repairedMessages.push(
-        new ToolMessage({
-          content: 'Tool execution was interrupted before producing a result.',
-          tool_call_id: call.id as string,
-          name: call.name,
-        })
-      );
-    }
-  }
   const providerMessages =
-    repairedMessages.length > 0 &&
-    !(repairedMessages[0] instanceof HumanMessage)
-      ? [new HumanMessage(CONTINUATION_TURN_BRIDGE), ...repairedMessages]
-      : repairedMessages;
+    messages.length > 0 && !(messages[0] instanceof HumanMessage)
+      ? [new HumanMessage(CONTINUATION_TURN_BRIDGE), ...messages]
+      : [...messages];
   const lastMessage = providerMessages.at(-1);
   if (lastMessage instanceof ToolMessage) {
     return [
@@ -937,7 +904,7 @@ async function executePreparedSummarization(params: {
   if (plan.chunks.length === 1) {
     const result = await executeSummarizationWithFallback({
       agentContext,
-      messages,
+      messages: plan.chunks[0] as BaseMessage[],
       clientConfig,
       summarizeConfig,
       stepId,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -3,6 +3,7 @@ import {
   ToolMessage,
   HumanMessage,
   SystemMessage,
+  isAIMessage,
 } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { UsageMetadata, BaseMessage } from '@langchain/core/messages';
@@ -13,6 +14,7 @@ import type * as t from '@/types';
 import {
   ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
   ContentTypes,
+  Constants,
   DEFAULT_TOOL_TOKEN_MULTIPLIER,
   GraphEvents,
   StepTypes,
@@ -564,10 +566,41 @@ function appendSummarizationInstruction(
   messages: BaseMessage[],
   instruction: string
 ): BaseMessage[] {
+  const toolResultIds = new Set(
+    messages
+      .filter(
+        (message): message is ToolMessage => message instanceof ToolMessage
+      )
+      .map((message) => message.tool_call_id)
+  );
+  const repairedMessages: BaseMessage[] = [];
+  for (const message of messages) {
+    repairedMessages.push(message);
+    if (!isAIMessage(message)) {
+      continue;
+    }
+    const openCalls = (message.tool_calls ?? []).filter(
+      (call) =>
+        typeof call.id === 'string' &&
+        call.id !== '' &&
+        !call.id.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) &&
+        !toolResultIds.has(call.id)
+    );
+    for (const call of openCalls) {
+      repairedMessages.push(
+        new ToolMessage({
+          content: 'Tool execution was interrupted before producing a result.',
+          tool_call_id: call.id as string,
+          name: call.name,
+        })
+      );
+    }
+  }
   const providerMessages =
-    messages.length > 0 && !(messages[0] instanceof HumanMessage)
-      ? [new HumanMessage(CONTINUATION_TURN_BRIDGE), ...messages]
-      : [...messages];
+    repairedMessages.length > 0 &&
+    !(repairedMessages[0] instanceof HumanMessage)
+      ? [new HumanMessage(CONTINUATION_TURN_BRIDGE), ...repairedMessages]
+      : repairedMessages;
   const lastMessage = providerMessages.at(-1);
   if (lastMessage instanceof ToolMessage) {
     return [
@@ -1178,11 +1211,15 @@ export function createSummarizeNode({
       agentContext,
       agentContext.summarizationConfig
     );
+    const boundTools = agentContext.getToolsForBinding();
     if (
-      agentContext.tokenCounter != null &&
-      agentContext.discoveredToolNames.size > 0
+      agentContext.discoveredToolNames.size > 0 ||
+      ((boundTools?.length ?? 0) > 0 && agentContext.toolSchemaTokens <= 0)
     ) {
-      await agentContext.calculateInstructionTokens(agentContext.tokenCounter);
+      const schemaTokenCounter =
+        agentContext.tokenCounter ??
+        ((message: BaseMessage) => estimateMessageTokens(message));
+      await agentContext.calculateInstructionTokens(schemaTokenCounter);
     }
     const configuredSummarizerMax = clientConfig.maxContextTokens;
     const maxCtx =

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -62,6 +62,8 @@ const CHUNK_SUMMARIZATION_PROMPT = `Create a faithful checkpoint for only this b
 
 const SYNTHESIS_SUMMARIZATION_PROMPT = `Synthesize the numbered bounded checkpoints into one usable continuation checkpoint. Preserve the original user objective, constraints, exact identifiers, tool outcomes, failures, decisions, current progress, and next steps. Resolve repetition without dropping unique facts. Do not continue the task. Return only the consolidated checkpoint.`;
 
+const TOOL_RESULT_TURN_BRIDGE = 'I have received the tool result.';
+
 /** Structured checkpoint prompt for fresh summarization (no prior summary). */
 export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
 
@@ -552,6 +554,13 @@ function appendSummarizationInstruction(
   instruction: string
 ): BaseMessage[] {
   const lastMessage = messages.at(-1);
+  if (lastMessage instanceof ToolMessage) {
+    return [
+      ...messages,
+      new AIMessage(TOOL_RESULT_TURN_BRIDGE),
+      new HumanMessage(instruction),
+    ];
+  }
   if (!(lastMessage instanceof HumanMessage)) {
     return [...messages, new HumanMessage(instruction)];
   }
@@ -825,7 +834,12 @@ async function executePreparedSummarization(params: {
   ].map((instruction) =>
     estimateMessageTokens(new HumanMessage(instruction), summarizerTokenCounter)
   );
-  const instructionTokens = Math.max(...instructionEstimates);
+  const instructionTokens =
+    Math.max(...instructionEstimates) +
+    estimateMessageTokens(
+      new AIMessage(TOOL_RESULT_TURN_BRIDGE),
+      summarizerTokenCounter
+    );
   const summarizerToolSchemaTokens = getSummarizationToolSchemaTokens(
     agentContext,
     clientConfig
@@ -844,8 +858,8 @@ async function executePreparedSummarization(params: {
   });
   if (chunkResult.plan == null) {
     const estimatedInputTokens = Math.ceil(
-      (budget.fixedOverheadTokens + chunkResult.estimatedMessageTokens) *
-        calibrationRatio
+      budget.fixedOverheadTokens +
+        chunkResult.estimatedMessageTokens * calibrationRatio
     );
     return {
       text: '',
@@ -860,8 +874,7 @@ async function executePreparedSummarization(params: {
   }
   const { plan } = chunkResult;
   const estimatedInputTokens = Math.ceil(
-    (budget.fixedOverheadTokens + plan.estimatedMessageTokens) *
-      calibrationRatio
+    budget.fixedOverheadTokens + plan.estimatedMessageTokens * calibrationRatio
   );
 
   if (plan.chunks.length === 1) {
@@ -1662,7 +1675,8 @@ async function summarizeWithCacheHit({
     usageSource = 'usage_metadata';
   } else if (responseMsg != null) {
     const respMeta = responseMsg.response_metadata as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const raw = (respMeta?.metadata as Record<string, unknown> | undefined)
       ?.usage as Record<string, unknown> | undefined;
     if (raw != null) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -756,6 +756,13 @@ async function executePreparedSummarization(params: {
     agentContext.provider as string,
     (agentContext.clientOptions as Record<string, unknown> | undefined)?.model
   );
+  const summarizerModel = String(
+    clientConfig.clientOptions.model ?? clientConfig.modelName ?? ''
+  );
+  const agentModel = String(
+    (agentContext.clientOptions as Record<string, unknown> | undefined)
+      ?.model ?? ''
+  );
   let summarizerTokenCounter = agentContext.tokenCounter;
   if (
     clientConfig.provider !== (agentContext.provider as string) ||
@@ -775,6 +782,8 @@ async function executePreparedSummarization(params: {
   }
   const calibrationRatio =
     clientConfig.provider === (agentContext.provider as string) &&
+    summarizerModel === agentModel &&
+    summarizerEncoding === agentEncoding &&
     Number.isFinite(agentContext.calibrationRatio) &&
     agentContext.calibrationRatio > 0
       ? agentContext.calibrationRatio
@@ -801,11 +810,7 @@ async function executePreparedSummarization(params: {
   );
   const budget = createSummarizationInputBudget({
     maxContextTokens,
-    fixedOverheadTokens:
-      agentContext.systemMessageTokens +
-      agentContext.dynamicInstructionTokens +
-      summarizerToolSchemaTokens +
-      instructionTokens,
+    fixedOverheadTokens: summarizerToolSchemaTokens + instructionTokens,
     maxSummaryTokens: clientConfig.effectiveMaxSummaryTokens,
     reserveRatio: agentContext.summarizationConfig?.reserveRatio,
     calibrationRatio,
@@ -1121,18 +1126,18 @@ export function createSummarizeNode({
       configuredSummarizerMax > 0
         ? configuredSummarizerMax
         : (agentContext.maxContextTokens ?? 0);
-    const preflightInstructionTokens =
-      agentContext.systemMessageTokens +
-      agentContext.dynamicInstructionTokens +
-      getSummarizationToolSchemaTokens(agentContext, clientConfig);
-    if (maxCtx > 0 && preflightInstructionTokens >= maxCtx) {
+    const preflightToolSchemaTokens = getSummarizationToolSchemaTokens(
+      agentContext,
+      clientConfig
+    );
+    if (maxCtx > 0 && preflightToolSchemaTokens >= maxCtx) {
       emitAgentLog(
         config,
         'warn',
         'summarize',
-        'Summarization skipped, instructions exceed context budget. Reduce the number of tools or increase maxContextTokens.',
+        'Summarization skipped, tool definitions exceed context budget. Reduce the number of tools or increase maxContextTokens.',
         {
-          instructionTokens: preflightInstructionTokens,
+          toolSchemaTokens: preflightToolSchemaTokens,
           maxContextTokens: maxCtx,
           breakdown: agentContext.formatTokenBudgetBreakdown(),
         },

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -18,7 +18,6 @@ import { splitAtRecencyBoundary } from '@/messages/recency';
 import {
   createSummarizationInputBudget,
   estimateMessageTokens,
-  estimateMessagesTokens,
   planSummarizationChunks,
 } from '@/summarization/input';
 import { getMaxOutputTokensKey } from '@/llm/request';
@@ -646,6 +645,7 @@ async function executeSummarizationWithFallback(params: {
 }
 
 type PreparedSummarizationResult = SummarizationCallResult & {
+  retainedUsage?: Partial<UsageMetadata>;
   mode: 'full' | 'staged';
   chunkCount: number;
   callCount: number;
@@ -690,6 +690,19 @@ async function executePreparedSummarization(params: {
     log,
   } = params;
   const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
+  const configuredContextTokens = clientConfig.maxContextTokens;
+  const maxContextTokens =
+    configuredContextTokens != null &&
+    Number.isFinite(configuredContextTokens) &&
+    configuredContextTokens > 0
+      ? configuredContextTokens
+      : agentContext.maxContextTokens;
+  const calibrationRatio =
+    clientConfig.provider === (agentContext.provider as string) &&
+    Number.isFinite(agentContext.calibrationRatio) &&
+    agentContext.calibrationRatio > 0
+      ? agentContext.calibrationRatio
+      : 1;
   const instructionEstimates = [
     buildSummarizationInstruction(
       clientConfig.promptText,
@@ -710,11 +723,11 @@ async function executePreparedSummarization(params: {
   );
   const instructionTokens = Math.max(...instructionEstimates);
   const budget = createSummarizationInputBudget({
-    maxContextTokens:
-      clientConfig.maxContextTokens ?? agentContext.maxContextTokens,
+    maxContextTokens,
     fixedOverheadTokens: agentContext.instructionTokens + instructionTokens,
     maxSummaryTokens: clientConfig.effectiveMaxSummaryTokens,
     reserveRatio: agentContext.summarizationConfig?.reserveRatio,
+    calibrationRatio,
   });
   const chunkResult = planSummarizationChunks({
     messages,
@@ -722,8 +735,10 @@ async function executePreparedSummarization(params: {
     tokenCounter: agentContext.tokenCounter,
   });
   if (chunkResult.plan == null) {
-    const estimatedInputTokens =
-      budget.fixedOverheadTokens + chunkResult.estimatedMessageTokens;
+    const estimatedInputTokens = Math.ceil(
+      (budget.fixedOverheadTokens + chunkResult.estimatedMessageTokens) *
+        calibrationRatio
+    );
     return {
       text: '',
       fallbackResult: 'failed',
@@ -736,8 +751,10 @@ async function executePreparedSummarization(params: {
     };
   }
   const { plan } = chunkResult;
-  const estimatedInputTokens =
-    budget.fixedOverheadTokens + plan.estimatedMessageTokens;
+  const estimatedInputTokens = Math.ceil(
+    (budget.fixedOverheadTokens + plan.estimatedMessageTokens) *
+      calibrationRatio
+  );
 
   if (plan.chunks.length === 1) {
     const result = await executeSummarizationWithFallback({
@@ -752,6 +769,7 @@ async function executePreparedSummarization(params: {
     });
     return {
       ...result,
+      retainedUsage: result.usage,
       mode: 'full',
       chunkCount: 1,
       callCount: 1,
@@ -767,11 +785,12 @@ async function executePreparedSummarization(params: {
     fixedOverheadTokens: budget.fixedOverheadTokens,
     outputReserveTokens: budget.outputReserveTokens,
     inputBudgetTokens: budget.messageBudgetTokens,
+    calibrationRatio,
     chunkCount: plan.chunks.length,
     chunkTokenEstimates: plan.chunkTokenEstimates,
   });
 
-  const chunkSummaries: BaseMessage[] = [];
+  const chunkSummaries: string[] = [];
   let usage: Partial<UsageMetadata> | undefined;
   let fallbackResult: SummarizationCallResult['fallbackResult'] = 'primary';
   let providerReportedInputTokens: number | undefined;
@@ -813,22 +832,21 @@ async function executePreparedSummarization(params: {
       };
     }
     chunkSummaries.push(
-      new HumanMessage(
-        `<bounded-checkpoint index="${i + 1}">\n${result.text}\n</bounded-checkpoint>`
-      )
+      `<bounded-checkpoint index="${i + 1}">\n${result.text}\n</bounded-checkpoint>`
     );
   }
 
-  const synthesisTokens = estimateMessagesTokens(
-    chunkSummaries,
+  const synthesisPrompt = `${chunkSummaries.join('\n\n')}\n\n${SYNTHESIS_SUMMARIZATION_PROMPT}`;
+  const synthesisCheckpointTokens = estimateMessageTokens(
+    new HumanMessage(chunkSummaries.join('\n\n')),
     agentContext.tokenCounter
   );
-  if (synthesisTokens > budget.messageBudgetTokens) {
+  if (synthesisCheckpointTokens > budget.messageBudgetTokens) {
     return {
       text: '',
       usage,
       fallbackResult: 'failed',
-      error: `Synthesis input requires ${synthesisTokens} tokens but the summarizer input budget is ${budget.messageBudgetTokens}`,
+      error: `Synthesis input requires ${synthesisCheckpointTokens} tokens but the summarizer input budget is ${budget.messageBudgetTokens}`,
       mode: 'staged',
       chunkCount: plan.chunks.length,
       callCount,
@@ -839,11 +857,11 @@ async function executePreparedSummarization(params: {
 
   const synthesis = await executeSummarizationWithFallback({
     agentContext,
-    messages: chunkSummaries,
+    messages: [],
     clientConfig: {
       ...clientConfig,
-      promptText: SYNTHESIS_SUMMARIZATION_PROMPT,
-      updatePromptText: SYNTHESIS_SUMMARIZATION_PROMPT,
+      promptText: synthesisPrompt,
+      updatePromptText: synthesisPrompt,
     },
     summarizeConfig: traceConfig(summarizeConfig, 'synthesis'),
     stepId,
@@ -864,6 +882,7 @@ async function executePreparedSummarization(params: {
   return {
     ...synthesis,
     usage,
+    retainedUsage: synthesis.usage,
     fallbackResult:
       synthesis.fallbackResult === 'failed' ? 'failed' : fallbackResult,
     providerReportedInputTokens,
@@ -1010,7 +1029,14 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
-    const maxCtx = agentContext.maxContextTokens ?? 0;
+    const configuredSummarizerMax =
+      agentContext.summarizationConfig?.maxContextTokens;
+    const maxCtx =
+      configuredSummarizerMax != null &&
+      Number.isFinite(configuredSummarizerMax) &&
+      configuredSummarizerMax > 0
+        ? configuredSummarizerMax
+        : (agentContext.maxContextTokens ?? 0);
     if (maxCtx > 0 && agentContext.instructionTokens >= maxCtx) {
       emitAgentLog(
         config,
@@ -1226,15 +1252,32 @@ export function createSummarizeNode({
 
     if (!rawText) {
       agentContext.markSummarizationTriggered(state.messages.length);
+      const failureReason =
+        preparedResult.error ??
+        'Summarization failed without replacing conversation history';
+      await graph.dispatchRunStepCompleted(
+        stepId,
+        {
+          type: 'summary',
+          summary: {
+            ...placeholderSummary,
+            content: [
+              {
+                type: ContentTypes.TEXT,
+                text: `Summarization failed; conversation history was preserved. ${failureReason}`,
+              },
+            ],
+          },
+        } satisfies t.SummaryCompleted,
+        runnableConfig
+      );
       if (runnableConfig) {
         await safeDispatchCustomEvent(
           GraphEvents.ON_SUMMARIZE_COMPLETE,
           {
             id: stepId,
             agentId: request.agentId,
-            error:
-              preparedResult.error ??
-              'Summarization failed without replacing conversation history',
+            error: failureReason,
           } satisfies t.SummarizeCompleteEvent,
           runnableConfig
         );
@@ -1243,10 +1286,14 @@ export function createSummarizeNode({
     }
 
     const summaryText = enrichSummary(rawText, messagesToRefine);
+    const retainedSummaryUsage =
+      preparedResult.mode === 'staged'
+        ? preparedResult.retainedUsage
+        : summaryUsage;
 
     const tokenCount = computeSummaryTokenCount(
       summaryText,
-      summaryUsage,
+      retainedSummaryUsage,
       agentContext.tokenCounter
     );
 

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -15,9 +15,16 @@ import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
 import { splitAtRecencyBoundary } from '@/messages/recency';
+import {
+  createSummarizationInputBudget,
+  estimateMessageTokens,
+  estimateMessagesTokens,
+  planSummarizationChunks,
+} from '@/summarization/input';
 import { getMaxOutputTokensKey } from '@/llm/request';
 import { addCacheControl } from '@/messages/cache';
 import { initializeModel } from '@/llm/init';
+import { extractErrorMessage } from '@/utils/errors';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
 
@@ -42,6 +49,11 @@ const DEFAULT_RETAIN_RECENT_TURNS = 2;
  * ~33 tokens on Anthropic, ~24-27 on OpenAI.  Using 33 as a safe ceiling.
  */
 const SUMMARY_WRAPPER_OVERHEAD_TOKENS = 33;
+const MAX_FALLBACK_PROVIDERS = 2;
+
+const CHUNK_SUMMARIZATION_PROMPT = `Create a faithful checkpoint for only this bounded conversation segment. Preserve the original user objective when it appears, exact identifiers, decisions, completed tool calls and their results, failures, and unfinished work. Do not continue the task. Return only the checkpoint.`;
+
+const SYNTHESIS_SUMMARIZATION_PROMPT = `Synthesize the numbered bounded checkpoints into one usable continuation checkpoint. Preserve the original user objective, constraints, exact identifiers, tool outcomes, failures, decisions, current progress, and next steps. Resolve repetition without dropping unique facts. Do not continue the task. Return only the consolidated checkpoint.`;
 
 /** Structured checkpoint prompt for fresh summarization (no prior summary). */
 export const DEFAULT_SUMMARIZATION_PROMPT = `Hold on, before you continue I need you to write me a checkpoint of everything so far. Your context window is filling up and this checkpoint replaces the messages above, so capture everything you need to pick right back up.
@@ -117,50 +129,6 @@ function separateParameters(parameters: Record<string, unknown>): {
   }
 
   return { llmParams, maxSummaryTokens };
-}
-
-/**
- * Generates a structural metadata summary without making an LLM call.
- * Used as a last-resort fallback when all summarization attempts fail.
- * Preserves tool names and message counts so the agent retains basic context.
- */
-function generateMetadataStub(messages: BaseMessage[]): string {
-  const counts: Record<string, number> = {};
-  const toolNames = new Set<string>();
-
-  for (const msg of messages) {
-    const role = msg.getType();
-    counts[role] = (counts[role] ?? 0) + 1;
-
-    if (role === 'tool' && msg.name != null && msg.name !== '') {
-      toolNames.add(msg.name);
-    }
-
-    if (
-      role === 'ai' &&
-      msg instanceof AIMessage &&
-      msg.tool_calls &&
-      msg.tool_calls.length > 0
-    ) {
-      for (const tc of msg.tool_calls) {
-        toolNames.add(tc.name);
-      }
-    }
-  }
-
-  const countParts = Object.entries(counts)
-    .map(([role, count]) => `${count} ${role}`)
-    .join(', ');
-
-  const lines = [
-    `[Metadata summary: ${messages.length} messages (${countParts})]`,
-  ];
-
-  if (toolNames.size > 0) {
-    lines.push(`[Tools used: ${Array.from(toolNames).join(', ')}]`);
-  }
-
-  return lines.join('\n');
 }
 
 /** Maximum number of tool failures to include in the enrichment section. */
@@ -270,6 +238,7 @@ interface SummarizationClientConfig {
   modelName?: string;
   clientOptions: Record<string, unknown>;
   effectiveMaxSummaryTokens?: number;
+  maxContextTokens?: number;
   promptText: string;
   updatePromptText: string;
 }
@@ -319,6 +288,7 @@ function buildSummarizationClientConfig(
     modelName,
     clientOptions,
     effectiveMaxSummaryTokens,
+    maxContextTokens: summarizationConfig?.maxContextTokens,
     promptText,
     updatePromptText,
   };
@@ -378,6 +348,38 @@ type LogFn = (
   message: string,
   data?: Record<string, unknown>
 ) => void;
+
+export interface ProviderContextOverflowDetails {
+  inputTokens?: number;
+  maxTokens?: number;
+}
+
+export function parseProviderContextOverflow(
+  error: unknown
+): ProviderContextOverflowDetails | undefined {
+  const message = extractErrorMessage(error);
+  const match = message.match(
+    /prompt is too long:\s*([\d,]+)\s*tokens\s*>\s*([\d,]+)\s*maximum/i
+  );
+  if (!match) {
+    return undefined;
+  }
+  const inputTokens = Number((match[1] as string).replaceAll(',', ''));
+  const maxTokens = Number((match[2] as string).replaceAll(',', ''));
+  return {
+    ...(Number.isFinite(inputTokens) ? { inputTokens } : {}),
+    ...(Number.isFinite(maxTokens) ? { maxTokens } : {}),
+  };
+}
+
+type SummarizationCallResult = {
+  text: string;
+  usage?: Partial<UsageMetadata>;
+  fallbackResult: 'primary' | 'fallback' | 'failed';
+  error?: string;
+  providerReportedInputTokens?: number;
+  providerReportedMaxTokens?: number;
+};
 
 /**
  * Extracts an HTTP status code from a thrown LLM-provider error. Returns
@@ -496,18 +498,19 @@ function describeFallbackError(
 }
 
 /**
- * Runs the summarization LLM call with primary + fallback providers,
- * falling back to a metadata stub when all calls fail.
+ * Runs the summarization LLM call with a bounded primary + fallback set.
+ * Exhaustion is explicit so callers preserve the original history.
  */
 async function executeSummarizationWithFallback(params: {
   agentContext: AgentContext;
   messages: BaseMessage[];
   clientConfig: SummarizationClientConfig;
   summarizeConfig?: RunnableConfig;
-  stepId: string;
+  stepId?: string;
   usePromptCache: boolean;
   log: LogFn;
-}): Promise<{ text: string; usage?: Partial<UsageMetadata> }> {
+  priorSummaryText?: string;
+}): Promise<SummarizationCallResult> {
   const {
     agentContext,
     messages,
@@ -518,10 +521,14 @@ async function executeSummarizationWithFallback(params: {
     log,
   } = params;
 
-  const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
+  const priorSummaryText =
+    params.priorSummaryText ?? agentContext.getSummaryText()?.trim() ?? '';
 
   let summaryText = '';
   let summaryUsage: Partial<UsageMetadata> | undefined;
+  let fallbackResult: SummarizationCallResult['fallbackResult'] = 'primary';
+  let failureMessage: string | undefined;
+  let overflowDetails: ProviderContextOverflowDetails | undefined;
 
   try {
     /**
@@ -551,6 +558,8 @@ async function executeSummarizationWithFallback(params: {
     summaryText = result.text;
     summaryUsage = result.usage;
   } catch (primaryError) {
+    failureMessage = extractErrorMessage(primaryError);
+    overflowDetails = parseProviderContextOverflow(primaryError);
     const primaryDescribed = describeProviderError(
       primaryError,
       clientConfig.provider,
@@ -559,12 +568,16 @@ async function executeSummarizationWithFallback(params: {
     log('error', `Summarization LLM call failed ${primaryDescribed.suffix}`, {
       ...primaryDescribed.data,
       messagesToRefineCount: messages.length,
+      providerReportedInputTokens: overflowDetails?.inputTokens,
+      providerReportedMaxTokens: overflowDetails?.maxTokens,
     });
 
     const rawFallbacks = (
       clientConfig.clientOptions as unknown as t.LLMConfig | undefined
     )?.fallbacks;
-    const fallbacks = Array.isArray(rawFallbacks) ? rawFallbacks : [];
+    const fallbacks = Array.isArray(rawFallbacks)
+      ? rawFallbacks.slice(0, MAX_FALLBACK_PROVIDERS)
+      : [];
     if (fallbacks.length > 0) {
       try {
         const onChunk = createSummarizationChunkHandler({
@@ -595,28 +608,260 @@ async function executeSummarizationWithFallback(params: {
           summaryText = extractResponseText(
             fbMsg as { content: string | object }
           );
+          if (summaryText !== '') {
+            fallbackResult = 'fallback';
+          }
         }
       } catch (fbErr) {
+        failureMessage = extractErrorMessage(fbErr) || failureMessage;
+        overflowDetails =
+          parseProviderContextOverflow(fbErr) ?? overflowDetails;
         const fbDescribed = describeFallbackError(fbErr, fallbacks);
         log('warn', `Fallback providers also failed ${fbDescribed.suffix}`, {
           ...fbDescribed.data,
+          providerReportedInputTokens: overflowDetails?.inputTokens,
+          providerReportedMaxTokens: overflowDetails?.maxTokens,
         });
       }
     }
     if (!summaryText) {
-      log(
-        'warn',
-        `Summarization failed, falling back to metadata stub ${primaryDescribed.suffix}`,
-        {
-          ...primaryDescribed.data,
-          messagesToRefineCount: messages.length,
-        }
-      );
-      summaryText = generateMetadataStub(messages);
+      fallbackResult = 'failed';
+      log('warn', 'Summarization exhausted without replacing history', {
+        ...primaryDescribed.data,
+        messagesToRefineCount: messages.length,
+        providerReportedInputTokens: overflowDetails?.inputTokens,
+        providerReportedMaxTokens: overflowDetails?.maxTokens,
+      });
     }
   }
 
-  return { text: summaryText, usage: summaryUsage };
+  return {
+    text: summaryText,
+    usage: summaryUsage,
+    fallbackResult,
+    error: failureMessage,
+    providerReportedInputTokens: overflowDetails?.inputTokens,
+    providerReportedMaxTokens: overflowDetails?.maxTokens,
+  };
+}
+
+type PreparedSummarizationResult = SummarizationCallResult & {
+  mode: 'full' | 'staged';
+  chunkCount: number;
+  callCount: number;
+  estimatedInputTokens: number;
+  inputBudgetTokens: number;
+};
+
+function combineUsage(
+  current: Partial<UsageMetadata> | undefined,
+  next: Partial<UsageMetadata> | undefined
+): Partial<UsageMetadata> | undefined {
+  if (!current && !next) {
+    return undefined;
+  }
+  return {
+    input_tokens:
+      (Number(current?.input_tokens) || 0) + (Number(next?.input_tokens) || 0),
+    output_tokens:
+      (Number(current?.output_tokens) || 0) +
+      (Number(next?.output_tokens) || 0),
+    total_tokens:
+      (Number(current?.total_tokens) || 0) + (Number(next?.total_tokens) || 0),
+  };
+}
+
+async function executePreparedSummarization(params: {
+  agentContext: AgentContext;
+  messages: BaseMessage[];
+  clientConfig: SummarizationClientConfig;
+  summarizeConfig?: RunnableConfig;
+  stepId: string;
+  usePromptCache: boolean;
+  log: LogFn;
+}): Promise<PreparedSummarizationResult> {
+  const {
+    agentContext,
+    messages,
+    clientConfig,
+    summarizeConfig,
+    stepId,
+    usePromptCache,
+    log,
+  } = params;
+  const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
+  const instructionEstimates = [
+    buildSummarizationInstruction(
+      clientConfig.promptText,
+      clientConfig.updatePromptText,
+      priorSummaryText
+    ),
+    CHUNK_SUMMARIZATION_PROMPT,
+    buildSummarizationInstruction(
+      SYNTHESIS_SUMMARIZATION_PROMPT,
+      undefined,
+      priorSummaryText
+    ),
+  ].map((instruction) =>
+    estimateMessageTokens(
+      new HumanMessage(instruction),
+      agentContext.tokenCounter
+    )
+  );
+  const instructionTokens = Math.max(...instructionEstimates);
+  const budget = createSummarizationInputBudget({
+    maxContextTokens:
+      clientConfig.maxContextTokens ?? agentContext.maxContextTokens,
+    fixedOverheadTokens: agentContext.instructionTokens + instructionTokens,
+    maxSummaryTokens: clientConfig.effectiveMaxSummaryTokens,
+    reserveRatio: agentContext.summarizationConfig?.reserveRatio,
+  });
+  const chunkResult = planSummarizationChunks({
+    messages,
+    messageBudgetTokens: budget.messageBudgetTokens,
+    tokenCounter: agentContext.tokenCounter,
+  });
+  if (chunkResult.plan == null) {
+    const estimatedInputTokens =
+      budget.fixedOverheadTokens + chunkResult.estimatedMessageTokens;
+    return {
+      text: '',
+      fallbackResult: 'failed',
+      error: chunkResult.error,
+      mode: 'staged',
+      chunkCount: 0,
+      callCount: 0,
+      estimatedInputTokens,
+      inputBudgetTokens: budget.messageBudgetTokens,
+    };
+  }
+  const { plan } = chunkResult;
+  const estimatedInputTokens =
+    budget.fixedOverheadTokens + plan.estimatedMessageTokens;
+
+  if (plan.chunks.length === 1) {
+    const result = await executeSummarizationWithFallback({
+      agentContext,
+      messages,
+      clientConfig,
+      summarizeConfig,
+      stepId,
+      usePromptCache,
+      log,
+      priorSummaryText,
+    });
+    return {
+      ...result,
+      mode: 'full',
+      chunkCount: 1,
+      callCount: 1,
+      estimatedInputTokens,
+      inputBudgetTokens: budget.messageBudgetTokens,
+    };
+  }
+
+  log('info', 'Using staged summarization compaction', {
+    compactionMode: 'staged',
+    estimatedInputTokens,
+    contextTokens: budget.contextTokens,
+    fixedOverheadTokens: budget.fixedOverheadTokens,
+    outputReserveTokens: budget.outputReserveTokens,
+    inputBudgetTokens: budget.messageBudgetTokens,
+    chunkCount: plan.chunks.length,
+    chunkTokenEstimates: plan.chunkTokenEstimates,
+  });
+
+  const chunkSummaries: BaseMessage[] = [];
+  let usage: Partial<UsageMetadata> | undefined;
+  let fallbackResult: SummarizationCallResult['fallbackResult'] = 'primary';
+  let callCount = 0;
+  for (let i = 0; i < plan.chunks.length; i++) {
+    const chunk = plan.chunks[i] as BaseMessage[];
+    const result = await executeSummarizationWithFallback({
+      agentContext,
+      messages: chunk,
+      clientConfig: {
+        ...clientConfig,
+        promptText: CHUNK_SUMMARIZATION_PROMPT,
+        updatePromptText: CHUNK_SUMMARIZATION_PROMPT,
+      },
+      summarizeConfig: traceConfig(summarizeConfig, `chunk_${i + 1}`),
+      usePromptCache,
+      log,
+      priorSummaryText: '',
+    });
+    callCount += 1;
+    usage = combineUsage(usage, result.usage);
+    if (result.fallbackResult === 'fallback') {
+      fallbackResult = 'fallback';
+    }
+    if (result.text === '') {
+      return {
+        ...result,
+        usage,
+        mode: 'staged',
+        chunkCount: plan.chunks.length,
+        callCount,
+        estimatedInputTokens,
+        inputBudgetTokens: budget.messageBudgetTokens,
+      };
+    }
+    chunkSummaries.push(
+      new HumanMessage(
+        `<bounded-checkpoint index="${i + 1}">\n${result.text}\n</bounded-checkpoint>`
+      )
+    );
+  }
+
+  const synthesisTokens = estimateMessagesTokens(
+    chunkSummaries,
+    agentContext.tokenCounter
+  );
+  if (synthesisTokens > budget.messageBudgetTokens) {
+    return {
+      text: '',
+      usage,
+      fallbackResult: 'failed',
+      error: `Synthesis input requires ${synthesisTokens} tokens but the summarizer input budget is ${budget.messageBudgetTokens}`,
+      mode: 'staged',
+      chunkCount: plan.chunks.length,
+      callCount,
+      estimatedInputTokens,
+      inputBudgetTokens: budget.messageBudgetTokens,
+    };
+  }
+
+  const synthesis = await executeSummarizationWithFallback({
+    agentContext,
+    messages: chunkSummaries,
+    clientConfig: {
+      ...clientConfig,
+      promptText: SYNTHESIS_SUMMARIZATION_PROMPT,
+      updatePromptText: SYNTHESIS_SUMMARIZATION_PROMPT,
+    },
+    summarizeConfig: traceConfig(summarizeConfig, 'synthesis'),
+    stepId,
+    usePromptCache: false,
+    log,
+    priorSummaryText,
+  });
+  callCount += 1;
+  usage = combineUsage(usage, synthesis.usage);
+  if (synthesis.fallbackResult === 'fallback') {
+    fallbackResult = 'fallback';
+  }
+
+  return {
+    ...synthesis,
+    usage,
+    fallbackResult:
+      synthesis.fallbackResult === 'failed' ? 'failed' : fallbackResult,
+    mode: 'staged',
+    chunkCount: plan.chunks.length,
+    callCount,
+    estimatedInputTokens,
+    inputBudgetTokens: budget.messageBudgetTokens,
+  };
 }
 
 /** Dispatches run step completion, ON_SUMMARIZE_COMPLETE, and rebuilds token map. */
@@ -932,36 +1177,50 @@ export function createSummarizeNode({
 
     const summarizeConfig: RunnableConfig | undefined = config
       ? {
-        ...config,
-        metadata: {
-          ...config.metadata,
-          agent_id: request.agentId,
-          summarization_provider: clientConfig.provider,
-          summarization_model: clientConfig.modelName,
-        },
-      }
+          ...config,
+          metadata: {
+            ...config.metadata,
+            agent_id: request.agentId,
+            summarization_provider: clientConfig.provider,
+            summarization_model: clientConfig.modelName,
+          },
+        }
       : undefined;
 
-    const { text: rawText, usage: summaryUsage } =
-      await executeSummarizationWithFallback({
-        agentContext,
-        messages: messagesToRefine,
-        clientConfig,
-        summarizeConfig,
-        stepId,
-        usePromptCache: isSelfSummarizeModel && hasPromptCache,
-        log,
-      });
+    const preparedResult = await executePreparedSummarization({
+      agentContext,
+      messages: messagesToRefine,
+      clientConfig,
+      summarizeConfig,
+      stepId,
+      usePromptCache: isSelfSummarizeModel && hasPromptCache,
+      log,
+    });
+    const { text: rawText, usage: summaryUsage } = preparedResult;
+
+    log(rawText === '' ? 'warn' : 'info', 'Summarization compaction outcome', {
+      compactionMode: preparedResult.mode,
+      estimatedInputTokens: preparedResult.estimatedInputTokens,
+      inputBudgetTokens: preparedResult.inputBudgetTokens,
+      providerReportedInputTokens: preparedResult.providerReportedInputTokens,
+      providerReportedMaxTokens: preparedResult.providerReportedMaxTokens,
+      chunkCount: preparedResult.chunkCount,
+      summarizationCallCount: preparedResult.callCount,
+      fallbackResult: preparedResult.fallbackResult,
+      failureReason: preparedResult.error,
+    });
 
     if (!rawText) {
-      agentContext.markSummarizationTriggered(0);
+      agentContext.markSummarizationTriggered(state.messages.length);
       if (runnableConfig) {
         await safeDispatchCustomEvent(
           GraphEvents.ON_SUMMARIZE_COMPLETE,
           {
             id: stepId,
             agentId: request.agentId,
-            error: 'Summarization produced empty output',
+            error:
+              preparedResult.error ??
+              'Summarization failed without replacing conversation history',
           } satisfies t.SummarizeCompleteEvent,
           runnableConfig
         );
@@ -987,11 +1246,11 @@ export function createSummarizeNode({
       summaryVersion: agentContext.summaryVersion,
       ...(summaryUsage != null
         ? {
-          input_tokens: summaryUsage.input_tokens,
-          output_tokens: summaryUsage.output_tokens,
-          cache_read: summaryUsage.input_token_details?.cache_read,
-          cache_creation: summaryUsage.input_token_details?.cache_creation,
-        }
+            input_tokens: summaryUsage.input_tokens,
+            output_tokens: summaryUsage.output_tokens,
+            cache_read: summaryUsage.input_token_details?.cache_read,
+            cache_creation: summaryUsage.input_token_details?.cache_creation,
+          }
         : {}),
     });
 
@@ -1268,9 +1527,9 @@ async function summarizeWithCacheHit({
     output_tokens: usage?.output_tokens,
     ...(cacheDetails?.cache_read != null || cacheDetails?.cache_creation != null
       ? {
-        'input_token_details.cache_read': cacheDetails.cache_read,
-        'input_token_details.cache_creation': cacheDetails.cache_creation,
-      }
+          'input_token_details.cache_read': cacheDetails.cache_read,
+          'input_token_details.cache_creation': cacheDetails.cache_creation,
+        }
       : {}),
   });
   return { text, usage };

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -275,11 +275,17 @@ function buildSummarizationClientConfig(
     clientOptions.modelName = modelName;
   }
 
+  const outputTokensKey = getMaxOutputTokensKey(provider);
+  const inheritedOutputTokens = Number(clientOptions[outputTokensKey]);
   const effectiveMaxSummaryTokens =
-    paramMaxSummaryTokens ?? summarizationConfig?.maxSummaryTokens;
+    paramMaxSummaryTokens ??
+    summarizationConfig?.maxSummaryTokens ??
+    (Number.isFinite(inheritedOutputTokens) && inheritedOutputTokens > 0
+      ? inheritedOutputTokens
+      : undefined);
 
   if (effectiveMaxSummaryTokens != null) {
-    clientOptions[getMaxOutputTokensKey(provider)] = effectiveMaxSummaryTokens;
+    clientOptions[outputTokensKey] = effectiveMaxSummaryTokens;
   }
 
   return {
@@ -724,7 +730,11 @@ async function executePreparedSummarization(params: {
   const instructionTokens = Math.max(...instructionEstimates);
   const budget = createSummarizationInputBudget({
     maxContextTokens,
-    fixedOverheadTokens: agentContext.instructionTokens + instructionTokens,
+    fixedOverheadTokens:
+      agentContext.systemMessageTokens +
+      agentContext.dynamicInstructionTokens +
+      agentContext.toolSchemaTokens +
+      instructionTokens,
     maxSummaryTokens: clientConfig.effectiveMaxSummaryTokens,
     reserveRatio: agentContext.summarizationConfig?.reserveRatio,
     calibrationRatio,
@@ -1258,17 +1268,9 @@ export function createSummarizeNode({
       await graph.dispatchRunStepCompleted(
         stepId,
         {
-          type: 'summary',
-          summary: {
-            ...placeholderSummary,
-            content: [
-              {
-                type: ContentTypes.TEXT,
-                text: `Summarization failed; conversation history was preserved. ${failureReason}`,
-              },
-            ],
-          },
-        } satisfies t.SummaryCompleted,
+          type: 'summary_error',
+          error: failureReason,
+        } satisfies t.SummaryFailed,
         runnableConfig
       );
       if (runnableConfig) {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -330,7 +330,9 @@ function buildSummarizationClientConfig(
   const constructorDefaultOutputTokens =
     provider === Providers.ANTHROPIC
       ? getAnthropicDefaultMaxOutputTokens(
-          String(clientOptions.model ?? modelName ?? '')
+          String(
+            clientOptions.model ?? clientOptions.modelName ?? modelName ?? ''
+          )
         )
       : undefined;
   const effectiveMaxSummaryTokens =

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -774,6 +774,8 @@ async function executePreparedSummarization(params: {
   const chunkSummaries: BaseMessage[] = [];
   let usage: Partial<UsageMetadata> | undefined;
   let fallbackResult: SummarizationCallResult['fallbackResult'] = 'primary';
+  let providerReportedInputTokens: number | undefined;
+  let providerReportedMaxTokens: number | undefined;
   let callCount = 0;
   for (let i = 0; i < plan.chunks.length; i++) {
     const chunk = plan.chunks[i] as BaseMessage[];
@@ -795,6 +797,10 @@ async function executePreparedSummarization(params: {
     if (result.fallbackResult === 'fallback') {
       fallbackResult = 'fallback';
     }
+    providerReportedInputTokens =
+      result.providerReportedInputTokens ?? providerReportedInputTokens;
+    providerReportedMaxTokens =
+      result.providerReportedMaxTokens ?? providerReportedMaxTokens;
     if (result.text === '') {
       return {
         ...result,
@@ -850,12 +856,18 @@ async function executePreparedSummarization(params: {
   if (synthesis.fallbackResult === 'fallback') {
     fallbackResult = 'fallback';
   }
+  providerReportedInputTokens =
+    synthesis.providerReportedInputTokens ?? providerReportedInputTokens;
+  providerReportedMaxTokens =
+    synthesis.providerReportedMaxTokens ?? providerReportedMaxTokens;
 
   return {
     ...synthesis,
     usage,
     fallbackResult:
       synthesis.fallbackResult === 'failed' ? 'failed' : fallbackResult,
+    providerReportedInputTokens,
+    providerReportedMaxTokens,
     mode: 'staged',
     chunkCount: plan.chunks.length,
     callCount,
@@ -1206,6 +1218,8 @@ export function createSummarizeNode({
       providerReportedMaxTokens: preparedResult.providerReportedMaxTokens,
       chunkCount: preparedResult.chunkCount,
       summarizationCallCount: preparedResult.callCount,
+      providerAttemptLimit:
+        preparedResult.callCount * (MAX_FALLBACK_PROVIDERS + 1),
       fallbackResult: preparedResult.fallbackResult,
       failureReason: preparedResult.error,
     });

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -10,7 +10,14 @@ import type { AgentContext } from '@/agents/AgentContext';
 import type { HookRegistry } from '@/hooks';
 import type { OnChunk } from '@/llm/invoke';
 import type * as t from '@/types';
-import { ContentTypes, GraphEvents, StepTypes, Providers } from '@/common';
+import {
+  ANTHROPIC_TOOL_TOKEN_MULTIPLIER,
+  ContentTypes,
+  DEFAULT_TOOL_TOKEN_MULTIPLIER,
+  GraphEvents,
+  StepTypes,
+  Providers,
+} from '@/common';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import { attemptInvoke, tryFallbackProviders } from '@/llm/invoke';
 import { createRemoveAllMessage } from '@/messages/reducer';
@@ -240,6 +247,36 @@ interface SummarizationClientConfig {
   maxContextTokens?: number;
   promptText: string;
   updatePromptText: string;
+}
+
+function getToolSchemaMultiplier(provider: string, model: unknown): number {
+  const isAnthropic =
+    provider !== Providers.BEDROCK &&
+    (provider === Providers.ANTHROPIC ||
+      /anthropic|claude/i.test(String(model)));
+  return isAnthropic
+    ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER
+    : DEFAULT_TOOL_TOKEN_MULTIPLIER;
+}
+
+export function getSummarizationToolSchemaTokens(
+  agentContext: AgentContext,
+  clientConfig: Pick<SummarizationClientConfig, 'provider' | 'clientOptions'>
+): number {
+  if (agentContext.toolSchemaTokens <= 0) {
+    return 0;
+  }
+  const agentMultiplier = getToolSchemaMultiplier(
+    agentContext.provider as string,
+    (agentContext.clientOptions as Record<string, unknown> | undefined)?.model
+  );
+  const summarizerMultiplier = getToolSchemaMultiplier(
+    clientConfig.provider,
+    clientConfig.clientOptions.model
+  );
+  return Math.ceil(
+    (agentContext.toolSchemaTokens / agentMultiplier) * summarizerMultiplier
+  );
 }
 
 /** Assembles the summarization model's client options from agent and config. */
@@ -728,12 +765,16 @@ async function executePreparedSummarization(params: {
     )
   );
   const instructionTokens = Math.max(...instructionEstimates);
+  const summarizerToolSchemaTokens = getSummarizationToolSchemaTokens(
+    agentContext,
+    clientConfig
+  );
   const budget = createSummarizationInputBudget({
     maxContextTokens,
     fixedOverheadTokens:
       agentContext.systemMessageTokens +
       agentContext.dynamicInstructionTokens +
-      agentContext.toolSchemaTokens +
+      summarizerToolSchemaTokens +
       instructionTokens,
     maxSummaryTokens: clientConfig.effectiveMaxSummaryTokens,
     reserveRatio: agentContext.summarizationConfig?.reserveRatio,

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -778,6 +778,11 @@ async function executePreparedSummarization(params: {
     log,
   } = params;
   const priorSummaryText = agentContext.getSummaryText()?.trim() ?? '';
+  const effectiveConfiguredPrompt =
+    priorSummaryText === ''
+      ? clientConfig.promptText
+      : clientConfig.updatePromptText;
+  const synthesisInstruction = `${SYNTHESIS_SUMMARIZATION_PROMPT}\n\nApply these configured checkpoint requirements:\n${effectiveConfiguredPrompt}`;
   const configuredContextTokens = clientConfig.maxContextTokens;
   const maxContextTokens =
     configuredContextTokens != null &&
@@ -833,7 +838,7 @@ async function executePreparedSummarization(params: {
     ),
     CHUNK_SUMMARIZATION_PROMPT,
     buildSummarizationInstruction(
-      SYNTHESIS_SUMMARIZATION_PROMPT,
+      synthesisInstruction,
       undefined,
       priorSummaryText
     ),
@@ -967,7 +972,7 @@ async function executePreparedSummarization(params: {
     );
   }
 
-  const synthesisPrompt = `${chunkSummaries.join('\n\n')}\n\n${SYNTHESIS_SUMMARIZATION_PROMPT}`;
+  const synthesisPrompt = `${chunkSummaries.join('\n\n')}\n\n${synthesisInstruction}`;
   const synthesisCheckpointTokens = estimateMessageTokens(
     new HumanMessage(chunkSummaries.join('\n\n')),
     summarizerTokenCounter

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -33,6 +33,7 @@ import { initializeModel } from '@/llm/init';
 import { extractErrorMessage } from '@/utils/errors';
 import { getChunkContent } from '@/stream';
 import { executeHooks } from '@/hooks';
+import { createTokenCounter, encodingForModel } from '@/utils/tokens';
 
 const SUMMARIZATION_PARAM_KEYS = new Set(['maxSummaryTokens']);
 
@@ -257,6 +258,13 @@ function getToolSchemaMultiplier(provider: string, model: unknown): number {
   return isAnthropic
     ? ANTHROPIC_TOOL_TOKEN_MULTIPLIER
     : DEFAULT_TOOL_TOKEN_MULTIPLIER;
+}
+
+function getSummarizationEncoding(provider: string, model: unknown) {
+  if (provider === Providers.ANTHROPIC) {
+    return encodingForModel('claude');
+  }
+  return encodingForModel(String(model ?? ''));
 }
 
 export function getSummarizationToolSchemaTokens(
@@ -740,6 +748,31 @@ async function executePreparedSummarization(params: {
     configuredContextTokens > 0
       ? configuredContextTokens
       : agentContext.maxContextTokens;
+  const summarizerEncoding = getSummarizationEncoding(
+    clientConfig.provider,
+    clientConfig.clientOptions.model ?? clientConfig.modelName
+  );
+  const agentEncoding = getSummarizationEncoding(
+    agentContext.provider as string,
+    (agentContext.clientOptions as Record<string, unknown> | undefined)?.model
+  );
+  let summarizerTokenCounter = agentContext.tokenCounter;
+  if (
+    clientConfig.provider !== (agentContext.provider as string) ||
+    summarizerEncoding !== agentEncoding
+  ) {
+    try {
+      summarizerTokenCounter = await createTokenCounter(summarizerEncoding);
+    } catch (error) {
+      summarizerTokenCounter = undefined;
+      log('warn', 'Unable to initialize the summarizer tokenizer', {
+        provider: clientConfig.provider,
+        model: clientConfig.clientOptions.model,
+        encoding: summarizerEncoding,
+        error: extractErrorMessage(error),
+      });
+    }
+  }
   const calibrationRatio =
     clientConfig.provider === (agentContext.provider as string) &&
     Number.isFinite(agentContext.calibrationRatio) &&
@@ -759,10 +792,7 @@ async function executePreparedSummarization(params: {
       priorSummaryText
     ),
   ].map((instruction) =>
-    estimateMessageTokens(
-      new HumanMessage(instruction),
-      agentContext.tokenCounter
-    )
+    estimateMessageTokens(new HumanMessage(instruction), summarizerTokenCounter)
   );
   const instructionTokens = Math.max(...instructionEstimates);
   const summarizerToolSchemaTokens = getSummarizationToolSchemaTokens(
@@ -783,7 +813,7 @@ async function executePreparedSummarization(params: {
   const chunkResult = planSummarizationChunks({
     messages,
     messageBudgetTokens: budget.messageBudgetTokens,
-    tokenCounter: agentContext.tokenCounter,
+    tokenCounter: summarizerTokenCounter,
   });
   if (chunkResult.plan == null) {
     const estimatedInputTokens = Math.ceil(
@@ -890,7 +920,7 @@ async function executePreparedSummarization(params: {
   const synthesisPrompt = `${chunkSummaries.join('\n\n')}\n\n${SYNTHESIS_SUMMARIZATION_PROMPT}`;
   const synthesisCheckpointTokens = estimateMessageTokens(
     new HumanMessage(chunkSummaries.join('\n\n')),
-    agentContext.tokenCounter
+    summarizerTokenCounter
   );
   if (synthesisCheckpointTokens > budget.messageBudgetTokens) {
     return {
@@ -1080,22 +1110,29 @@ export function createSummarizeNode({
       return { summarizationRequest: undefined };
     }
 
-    const configuredSummarizerMax =
-      agentContext.summarizationConfig?.maxContextTokens;
+    const clientConfig = buildSummarizationClientConfig(
+      agentContext,
+      agentContext.summarizationConfig
+    );
+    const configuredSummarizerMax = clientConfig.maxContextTokens;
     const maxCtx =
       configuredSummarizerMax != null &&
       Number.isFinite(configuredSummarizerMax) &&
       configuredSummarizerMax > 0
         ? configuredSummarizerMax
         : (agentContext.maxContextTokens ?? 0);
-    if (maxCtx > 0 && agentContext.instructionTokens >= maxCtx) {
+    const preflightInstructionTokens =
+      agentContext.systemMessageTokens +
+      agentContext.dynamicInstructionTokens +
+      getSummarizationToolSchemaTokens(agentContext, clientConfig);
+    if (maxCtx > 0 && preflightInstructionTokens >= maxCtx) {
       emitAgentLog(
         config,
         'warn',
         'summarize',
         'Summarization skipped, instructions exceed context budget. Reduce the number of tools or increase maxContextTokens.',
         {
-          instructionTokens: agentContext.instructionTokens,
+          instructionTokens: preflightInstructionTokens,
           maxContextTokens: maxCtx,
           breakdown: agentContext.formatTokenBudgetBreakdown(),
         },
@@ -1169,11 +1206,6 @@ export function createSummarizeNode({
       agentContext.markSummarizationTriggered(state.messages.length);
       return { summarizationRequest: undefined };
     }
-
-    const clientConfig = buildSummarizationClientConfig(
-      agentContext,
-      agentContext.summarizationConfig
-    );
 
     const stepKey = `summarize-${request.agentId}`;
     const [stepId, stepIndex] = generateStepId(stepKey);

--- a/src/types/stream.ts
+++ b/src/types/stream.ts
@@ -113,7 +113,15 @@ export type SummaryCompleted = {
   summary: SummaryContentBlock;
 };
 
-export type StepCompleted = ToolCallCompleted | SummaryCompleted;
+export type SummaryFailed = {
+  type: 'summary_error';
+  error: string;
+};
+
+export type StepCompleted =
+  | ToolCallCompleted
+  | SummaryCompleted
+  | SummaryFailed;
 
 export type MessageCreationDetails = {
   type: StepTypes.MESSAGE_CREATION;

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -37,6 +37,8 @@ export type RetainRecentConfig = {
 export type SummarizationConfig = {
   provider?: Providers;
   model?: string;
+  /** Context window of the selected summarizer model. Defaults to the agent context window. */
+  maxContextTokens?: number;
   parameters?: Record<string, unknown>;
   prompt?: string;
   updatePrompt?: string;


### PR DESCRIPTION
## Summary

I bounded summarization requests so oversized conversations are compacted without exceeding the selected model's input window or replacing history with a metadata-only stub.

- Calculate the effective summarizer input budget after instruction/tool-schema overhead and output-token reserve.
- Partition oversized histories at complete message and tool-call/result boundaries.
- Summarize at most eight bounded chunks and synthesize them through a separately bounded request.
- Preserve the original user objective, recent unconsumed exchanges, and original history when any chunk or synthesis attempt fails.
- Limit fallback providers and emit structured full/staged, token, chunk, call, provider-overflow, and fallback telemetry.
- Parse Bedrock's exact `prompt is too long: X tokens > Y maximum` response for provider-reported token telemetry.
- Document the bounded compaction and recoverable-failure behavior.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
- [x] Documentation update

## Testing

- Ran `jest src/summarization/__tests__/input.test.ts src/summarization/__tests__/node.test.ts --runInBand` with a temporary Mistral compatibility mapping against the available shared dependency tree: 32 tests passed.
- Ran `tsc --noEmit`; touched files typecheck cleanly. The shared dependency tree reports pre-existing version-skew diagnostics in `src/llm/openrouter/index.ts` and `src/utils/logging.ts`, so CI will validate with the branch's clean lockfile install.
- Ran Prettier on every touched TypeScript/Markdown file and `git diff --check`.

### **Test Configuration**:

- Node.js v24.16.0
- Jest run serially against the focused summarization planner and node tests

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have made pertinent documentation changes
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local focused unit tests pass with my changes
