### PR TITLE
🪙 feat: Account for Retained Tool Context Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,26 +156,6 @@ const customHandlers = composeEventHandlers(
 );
 ```
 
-## Context Usage Accounting
-
-`ON_CONTEXT_USAGE` snapshots and `projectAgentContextUsage` projections expose
-optional retained-tool estimates on `TokenBudgetBreakdown`:
-
-- `toolMessageTokens` includes retained tool/function results and assistant
-  messages containing only tool invocations and whitespace. It is a **subset
-  of `messageTokens`**, not an additional context-budget category.
-- `toolMessageTokenCounts` attributes only result-message tokens by tool name;
-  assistant invocation overhead is not assigned to individual tools.
-- `toolTokenCounts` continues to describe tool **schemas**, not tool results.
-
-These counts are calibrated estimates, not provider-reported per-tool billing.
-Provider prompt usage reconciles the overall context total; hosts that reconcile
-that total should proportionally rescale the tool share rather than add it.
-With a counter, no retained tool exchange produces a known zero total. Without
-a counter, the optional fields remain absent. Assistant text, reasoning, and
-media remain in the conversation share. Pre-send projection does not mutate the
-supplied message history.
-
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -156,6 +156,26 @@ const customHandlers = composeEventHandlers(
 );
 ```
 
+## Context Usage Accounting
+
+`ON_CONTEXT_USAGE` snapshots and `projectAgentContextUsage` projections expose
+optional retained-tool estimates on `TokenBudgetBreakdown`:
+
+- `toolMessageTokens` includes retained tool/function results and assistant
+  messages containing only tool invocations and whitespace. It is a **subset
+  of `messageTokens`**, not an additional context-budget category.
+- `toolMessageTokenCounts` attributes only result-message tokens by tool name;
+  assistant invocation overhead is not assigned to individual tools.
+- `toolTokenCounts` continues to describe tool **schemas**, not tool results.
+
+These counts are calibrated estimates, not provider-reported per-tool billing.
+Provider prompt usage reconciles the overall context total; hosts that reconcile
+that total should proportionally rescale the tool share rather than add it.
+With a counter, no retained tool exchange produces a known zero total. Without
+a counter, the optional fields remain absent. Assistant text, reasoning, and
+media remain in the conversation share. Pre-send projection does not mutate the
+supplied message history.
+
 ## Development
 
 ```bash

--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -1767,8 +1767,9 @@ export class AgentContext {
         const recounted: Record<string, number> = {};
         for (let i = 0; i < messages.length; i++) {
           const localCount = this.tokenCounter(messages[i]);
-          const conservativeFloor =
-            this.providerProjectionRecountFloors?.get(messages[i]);
+          const conservativeFloor = this.providerProjectionRecountFloors?.get(
+            messages[i]
+          );
           recounted[i] =
             conservativeFloor == null
               ? localCount
@@ -2112,7 +2113,11 @@ export class AgentContext {
       remainingContextTokens,
       calibrationRatio,
     };
-    syncBudgetDerivedFields(usage);
+    syncBudgetDerivedFields(
+      usage,
+      context,
+      this.contextPressureTokenCounts?.count ?? tokenCounter
+    );
     return usage;
   }
 

--- a/src/agents/__tests__/AgentContext.test.ts
+++ b/src/agents/__tests__/AgentContext.test.ts
@@ -2107,7 +2107,9 @@ describe('AgentContext', () => {
       const first = [new HumanMessage('a'), tool];
       context.getProviderProjectedMessages(first);
       context.preserveOriginalToolContent(new Map([[1, 'original result']]));
-      expect(context.pendingOriginalToolContent?.get(1)).toBe('original result');
+      expect(context.pendingOriginalToolContent?.get(1)).toBe(
+        'original result'
+      );
 
       const shifted = [new HumanMessage('inserted'), ...first];
       context.getProviderProjectedMessages(shifted);
@@ -2115,7 +2117,9 @@ describe('AgentContext', () => {
 
       context.preserveOriginalToolContent(new Map([[2, 'original result']]));
       context.getProviderProjectedMessages([...shifted, new AIMessage('done')]);
-      expect(context.pendingOriginalToolContent?.get(2)).toBe('original result');
+      expect(context.pendingOriginalToolContent?.get(2)).toBe(
+        'original result'
+      );
     });
   });
 
@@ -2968,6 +2972,59 @@ describe('AgentContext', () => {
       expect(messages[2]).toBe(originalRef);
       expect((messages[2] as unknown as ToolMessage).content).toBe(
         originalContent
+      );
+    });
+    it('reports retained tool shares without mutating canonical history', () => {
+      const ctx = createBasicContext({ tokenCounter: countByChars });
+      ctx.maxContextTokens = 1_000;
+      ctx.maxToolResultChars = 200;
+
+      const toolCallId = 'projection-tool-call';
+      const originalResult = `result:${'x'.repeat(20_000)}`;
+      const toolCall = new AIMessage({
+        content: ' ',
+        tool_calls: [
+          {
+            id: toolCallId,
+            name: 'lookup',
+            args: { query: 'retained context' },
+          },
+        ],
+      });
+      const toolResult = new ToolMessage({
+        content: originalResult,
+        tool_call_id: toolCallId,
+        name: 'lookup',
+      });
+      const messages: Array<AIMessage | HumanMessage | ToolMessage> = [
+        new HumanMessage('question'),
+        toolCall,
+        toolResult,
+        new AIMessage('final answer'),
+      ];
+
+      const usage = ctx.projectContextUsage(messages);
+
+      expect(usage).not.toBeNull();
+      expect(messages[1]).toBe(toolCall);
+      expect(messages[2]).toBe(toolResult);
+      expect(toolResult.content).toBe(originalResult);
+
+      const toolMessageTokenCounts = usage!.breakdown.toolMessageTokenCounts;
+      expect(toolMessageTokenCounts).toBeDefined();
+      expect(Object.getPrototypeOf(toolMessageTokenCounts!)).toBeNull();
+      expect(toolMessageTokenCounts!.lookup).toBeGreaterThan(0);
+      expect(toolMessageTokenCounts!.lookup).toBeLessThan(
+        originalResult.length
+      );
+      expect(usage!.breakdown.toolMessageTokens).toBeGreaterThan(
+        toolMessageTokenCounts!.lookup
+      );
+      expect(usage!.breakdown.toolMessageTokens).toBe(
+        toolMessageTokenCounts!.lookup + countByChars(toolCall)
+      );
+      expect(usage!.breakdown.toolMessageTokens).toBeLessThan(
+        originalResult.length
       );
     });
 

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -146,7 +146,10 @@ import {
   findCallback,
   type CallbackEntry,
 } from '@/utils/callbacks';
-import { PreparedSubagents, PreparedSubagentError } from '@/tools/preparedSubagents';
+import {
+  PreparedSubagents,
+  PreparedSubagentError,
+} from '@/tools/preparedSubagents';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
@@ -1242,7 +1245,10 @@ export abstract class Graph<
   }> = new Set();
   private _subagentExecutors = new Set<SubagentExecutor>();
   readonly preparedSubagents = new PreparedSubagents();
-  protected readonly subagentToolNodes = new Map<string, CustomToolNode<t.BaseGraphState>>();
+  protected readonly subagentToolNodes = new Map<
+    string,
+    CustomToolNode<t.BaseGraphState>
+  >();
   public getOrCreateFileCheckpointer(): t.LocalFileCheckpointer | undefined {
     // Return the cached instance unconditionally if one exists. The
     // toolExecution check below decides whether to *create* a new
@@ -1404,13 +1410,15 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   ): StreamLimitExceededError | PreparedSubagentError | undefined {
     if (
       breakerSignal.aborted &&
-      (breakerSignal.reason instanceof StreamLimitExceededError || breakerSignal.reason instanceof PreparedSubagentError)
+      (breakerSignal.reason instanceof StreamLimitExceededError ||
+        breakerSignal.reason instanceof PreparedSubagentError)
     ) {
       return breakerSignal.reason;
     }
     if (
       this.signal?.aborted === true &&
-      (this.signal.reason instanceof StreamLimitExceededError || this.signal.reason instanceof PreparedSubagentError)
+      (this.signal.reason instanceof StreamLimitExceededError ||
+        this.signal.reason instanceof PreparedSubagentError)
     ) {
       return this.signal.reason;
     }
@@ -1957,8 +1965,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.nextContentIndex = state.nextIndex;
     this.runStepStateRevision = state.revision;
     this.stopContinuationCount = state.stopContinuationCount ?? 0;
-    this.stopContinuationExecutionId =
-      state.stopContinuationExecutionId ?? '';
+    this.stopContinuationExecutionId = state.stopContinuationExecutionId ?? '';
     this.streamSegment = state.streamSegment ?? 0;
     for (const { toolCallId, stepId } of state.toolCallSteps) {
       this.toolCallStepIds.set(toolCallId, stepId);
@@ -4006,7 +4013,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               finalProjection.projectedMessageTokens
           );
         }
-        syncBudgetDerivedFields(contextUsage);
+        syncBudgetDerivedFields(
+          contextUsage,
+          finalMessages,
+          agentContext.contextPressureTokenCounts?.count ??
+            agentContext.tokenCounter
+        );
         /** Awaited so async host handlers receive the pre-invoke snapshot
          *  before any model deltas are emitted */
         await safeDispatchCustomEvent(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4017,7 +4017,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           contextUsage,
           finalMessages,
           agentContext.contextPressureTokenCounts?.count ??
-            agentContext.tokenCounter
+            agentContext.tokenCounter,
+          config
         );
         /** Awaited so async host handlers receive the pre-invoke snapshot
          *  before any model deltas are emitted */

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -1,11 +1,16 @@
+import { RunnableLambda } from '@langchain/core/runnables';
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import {
   AIMessage,
   FunctionMessage,
   HumanMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { AgentLogEvent } from '@/types';
 import type * as t from '@/types';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { GraphEvents } from '@/common';
 import { toLangChainContent } from './langchain';
 import { syncBudgetDerivedFields } from './budget';
 
@@ -110,6 +115,67 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     );
     expect(usage.breakdown.toolMessageTokens).toBe(20);
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
+  });
+
+  it('counts v1 standard-content tool_call invocations', () => {
+    const usage = snapshot();
+    const invocation = new AIMessage({
+      content: toLangChainContent([
+        { type: 'tool_call', id: 'standard', name: 'file_search', args: {} },
+      ]),
+      response_metadata: { output_version: 'v1' },
+    });
+
+    syncBudgetDerivedFields(
+      usage,
+      [invocation, toolResult('standard')],
+      () => 10
+    );
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ file_search: 10 });
+  });
+
+  it('attributes the nested tool_call content shape', () => {
+    const usage = snapshot();
+    const invocation = new AIMessage({
+      content: toLangChainContent([
+        {
+          type: 'tool_call',
+          tool_call: { type: 'tool_call', id: 'nested', name: 'lookup' },
+        },
+      ]),
+    });
+
+    syncBudgetDerivedFields(
+      usage,
+      [invocation, toolResult('nested')],
+      () => 10
+    );
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
+  });
+
+  it('keeps a mirrored structured name over an inline standard block', () => {
+    const usage = snapshot();
+    const invocation = new AIMessage({
+      content: toLangChainContent([
+        { type: 'tool_call', id: 'mirrored', name: 'inline_name', args: {} },
+      ]),
+      tool_calls: [{ id: 'mirrored', name: 'structured_name', args: {} }],
+    });
+
+    syncBudgetDerivedFields(
+      usage,
+      [invocation, toolResult('mirrored')],
+      () => 10
+    );
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      structured_name: 10,
+    });
   });
 
   it('attributes structured, raw, inline, and legacy results with explicit precedence', () => {
@@ -280,26 +346,71 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(unavailable.breakdown.toolMessageTokens).toBeUndefined();
   });
 
-  it('rejects unsafe counter values and aggregate overflow', () => {
-    for (const value of [
-      Number.NaN,
-      Number.POSITIVE_INFINITY,
-      -1,
-      0.5,
-      Number.MAX_SAFE_INTEGER + 1,
-    ]) {
-      expect(() =>
-        syncBudgetDerivedFields(snapshot(), [toolResult('a')], () => value)
-      ).toThrow(RangeError);
-    }
+  it('drops the tool share on unsafe counts instead of failing the call', async () => {
+    const logs: AgentLogEvent[] = [];
+    const logHandler = BaseCallbackHandler.fromMethods({
+      handleCustomEvent: (eventName: string, data: unknown): void => {
+        if (eventName === GraphEvents.ON_AGENT_LOG) {
+          logs.push(data as AgentLogEvent);
+        }
+      },
+    });
 
-    expect(() =>
-      syncBudgetDerivedFields(
-        snapshot(),
-        [toolResult('a'), toolResult('b')],
-        () => Number.MAX_SAFE_INTEGER
-      )
-    ).toThrow(RangeError);
+    await RunnableLambda.from(
+      (_input: unknown, config?: RunnableConfig): void => {
+        for (const value of [
+          Number.NaN,
+          Number.POSITIVE_INFINITY,
+          -1,
+          0.5,
+          Number.MAX_SAFE_INTEGER + 1,
+        ]) {
+          const usage = snapshot();
+          expect(() =>
+            syncBudgetDerivedFields(
+              usage,
+              [toolResult('a')],
+              () => value,
+              config
+            )
+          ).not.toThrow();
+          expect(usage.breakdown.toolMessageTokens).toBeUndefined();
+          expect(usage.breakdown.toolMessageTokenCounts).toBeUndefined();
+          /** Every other derived field still reconciles. */
+          expect(usage.breakdown.instructionTokens).toBe(100);
+          expect(usage.breakdown.messageTokens).toBe(1_000);
+        }
+
+        const overflow = snapshot();
+        expect(() =>
+          syncBudgetDerivedFields(
+            overflow,
+            [toolResult('a'), toolResult('b')],
+            () => Number.MAX_SAFE_INTEGER,
+            config
+          )
+        ).not.toThrow();
+        expect(overflow.breakdown.toolMessageTokens).toBeUndefined();
+
+        const unclampable = snapshot();
+        unclampable.breakdown.messageTokens = Number.NaN;
+        unclampable.effectiveInstructionTokens = undefined;
+        expect(() =>
+          syncBudgetDerivedFields(
+            unclampable,
+            [toolResult('a')],
+            () => 10,
+            config
+          )
+        ).not.toThrow();
+        expect(unclampable.breakdown.toolMessageTokens).toBeUndefined();
+        expect(unclampable.breakdown.toolMessageTokenCounts).toBeUndefined();
+      }
+    ).invoke({}, { callbacks: [logHandler] });
+
+    expect(logs).toHaveLength(1);
+    expect(logs[0].level).toBe('warn');
+    expect(logs[0].message).toContain('Tool-message context share unavailable');
   });
 
   it('reuses exact cached counts and invalidates them after token-relevant mutation', () => {

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -2,6 +2,7 @@ import { RunnableLambda } from '@langchain/core/runnables';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import {
   AIMessage,
+  ChatMessage,
   FunctionMessage,
   HumanMessage,
   ToolMessage,
@@ -176,6 +177,37 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({
       structured_name: 10,
     });
+  });
+
+  it('counts generic assistant messages carrying a legacy call', () => {
+    const usage = snapshot();
+    const invocation = new ChatMessage({
+      role: 'assistant',
+      content: '',
+      additional_kwargs: {
+        function_call: { name: 'legacy_lookup', arguments: '{}' },
+      },
+    });
+
+    syncBudgetDerivedFields(
+      usage,
+      [invocation, new FunctionMessage({ content: 'result', name: '' })],
+      () => 10
+    );
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      legacy_lookup: 10,
+    });
+  });
+
+  it('leaves non-assistant generic messages in the conversation share', () => {
+    const usage = snapshot();
+    const bystander = new ChatMessage({ role: 'user', content: 'aside' });
+
+    syncBudgetDerivedFields(usage, [bystander, toolResult('a')], () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
   });
 
   it('attributes structured, raw, inline, and legacy results with explicit precedence', () => {
@@ -355,6 +387,14 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
         }
       },
     });
+
+    /** A config-less caller (the pre-send projection) has no channel to warn
+     *  through, so it must not consume the live path's one warning. */
+    const projected = snapshot();
+    expect(() =>
+      syncBudgetDerivedFields(projected, [toolResult('a')], () => Number.NaN)
+    ).not.toThrow();
+    expect(projected.breakdown.toolMessageTokens).toBeUndefined();
 
     await RunnableLambda.from(
       (_input: unknown, config?: RunnableConfig): void => {

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -1,0 +1,330 @@
+import {
+  AIMessage,
+  FunctionMessage,
+  HumanMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
+import type * as t from '@/types';
+import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { toLangChainContent } from './langchain';
+import { syncBudgetDerivedFields } from './budget';
+
+function snapshot(
+  messageTokens = 1_000,
+  calibrationRatio = 1
+): t.ContextUsageEvent {
+  return {
+    breakdown: {
+      maxContextTokens: 1_100,
+      instructionTokens: 100,
+      systemMessageTokens: 0,
+      dynamicInstructionTokens: 0,
+      toolSchemaTokens: 0,
+      summaryTokens: 0,
+      toolCount: 0,
+      messageCount: 0,
+      messageTokens,
+      availableForMessages: 1_000,
+    },
+    contextBudget: 1_100,
+    effectiveInstructionTokens: 100,
+    remainingContextTokens: 1_000 - messageTokens,
+    calibrationRatio,
+  };
+}
+
+function toolResult(id: string, name?: string): ToolMessage {
+  return new ToolMessage({
+    content: 'result',
+    tool_call_id: id,
+    ...(name != null ? { name } : {}),
+  });
+}
+
+describe('syncBudgetDerivedFields tool-message accounting', () => {
+  it('counts retained results and tool-only invocations without double-counting mirrored calls', () => {
+    const usage = snapshot();
+    const messages = [
+      new HumanMessage('question'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'a', name: 'read_file', args: {} }],
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'a',
+              type: 'function',
+              function: { name: 'read_file', arguments: '{}' },
+            },
+          ],
+        },
+      }),
+      toolResult('a'),
+      new AIMessage('answer'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ read_file: 10 });
+  });
+
+  it.each([
+    { type: 'text', text: 'explaining the result' },
+    { type: 'thinking', thinking: 'private reasoning' },
+    {
+      type: 'image_url',
+      image_url: { url: 'https://example.com/image.png' },
+    },
+  ])('keeps $type assistant content in the conversation share', (part) => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          part,
+          { type: 'tool_use', id: 'mixed-call', name: 'read_file', input: {} },
+        ]),
+        tool_calls: [{ id: 'mixed-call', name: 'read_file', args: {} }],
+      }),
+      toolResult('mixed-call'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ read_file: 10 });
+  });
+
+  it('counts whitespace-only inline invocations without structured calls', () => {
+    const usage = snapshot();
+    const invocation = new AIMessage({
+      content: toLangChainContent([
+        { type: 'text', text: ' \n\t' },
+        { type: 'tool_use', id: 'inline', name: 'lookup', input: {} },
+      ]),
+    });
+    syncBudgetDerivedFields(
+      usage,
+      [invocation, toolResult('inline')],
+      () => 10
+    );
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
+  });
+
+  it('attributes structured, raw, inline, and legacy results with explicit precedence', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'tool_use',
+            id: 'inline',
+            name: 'inline_tool',
+            input: {},
+          },
+        ]),
+        tool_calls: [{ id: 'structured', name: 'structured_tool', args: {} }],
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'raw',
+              type: 'function',
+              function: { name: 'raw_tool', arguments: '{}' },
+            },
+          ],
+        },
+      }),
+      toolResult('structured'),
+      toolResult('raw', 'ignored_result_name'),
+      toolResult('inline'),
+      toolResult('unmatched', 'explicit_tool'),
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: { name: 'legacy_tool', arguments: '{}' },
+        },
+      }),
+      new FunctionMessage({
+        content: 'explicit legacy result',
+        name: 'function_explicit',
+      }),
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: { name: 'legacy_tool', arguments: '{}' },
+        },
+      }),
+      new FunctionMessage({ content: 'legacy result', name: '' }),
+      new ToolMessage({ content: 'unknown result', tool_call_id: '' }),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(100);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      structured_tool: 10,
+      raw_tool: 10,
+      inline_tool: 10,
+      explicit_tool: 10,
+      function_explicit: 10,
+      legacy_tool: 10,
+      unknown_tool: 10,
+    });
+  });
+
+  it('does not guess a name for an ID-less result from an unrelated call', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'unrelated', name: 'unrelated_tool', args: {} }],
+      }),
+      new ToolMessage({ content: 'result', tool_call_id: '' }),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      unknown_tool: 10,
+    });
+  });
+
+  it('preserves prototype-sensitive tool names through JSON serialization', () => {
+    const usage = snapshot();
+    syncBudgetDerivedFields(
+      usage,
+      [
+        toolResult('a', '__proto__'),
+        toolResult('b', 'constructor'),
+        toolResult('c', 'toString'),
+      ],
+      () => 10
+    );
+
+    const counts = JSON.parse(JSON.stringify(usage)).breakdown
+      .toolMessageTokenCounts as Record<string, number>;
+    expect(Object.hasOwn(counts, '__proto__')).toBe(true);
+    expect(counts.__proto__).toBe(10);
+    expect(counts.constructor).toBe(10);
+    expect(counts.toString).toBe(10);
+  });
+
+  it('calibrates result shares while retaining invocation overhead when clamping', () => {
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'invoke', name: 'search', args: {} }],
+      }),
+      toolResult('a', 'search'),
+      toolResult('b', 'search'),
+      toolResult('c', 'search'),
+    ];
+
+    const unclamped = snapshot(10, 1.5);
+    syncBudgetDerivedFields(unclamped, messages, () => 1);
+    expect(unclamped.breakdown.toolMessageTokens).toBe(6);
+    expect(unclamped.breakdown.toolMessageTokenCounts).toEqual({ search: 5 });
+
+    const clamped = snapshot(4, 1.5);
+    syncBudgetDerivedFields(clamped, messages, () => 1);
+    expect(clamped.breakdown.toolMessageTokens).toBe(4);
+    expect(
+      Object.values(clamped.breakdown.toolMessageTokenCounts ?? {}).reduce(
+        (sum, count) => sum + count,
+        0
+      )
+    ).toBe(3);
+  });
+
+  it('apportions fractional counts across tools rather than rounding each independently', () => {
+    const usage = snapshot(10, 1.5);
+    syncBudgetDerivedFields(
+      usage,
+      [
+        toolResult('a', 'first'),
+        toolResult('b', 'second'),
+        toolResult('c', 'third'),
+      ],
+      () => 1
+    );
+    expect(usage.breakdown.toolMessageTokens).toBe(5);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      first: 2,
+      second: 2,
+      third: 1,
+    });
+    usage.remainingContextTokens = 998;
+    syncBudgetDerivedFields(usage);
+    expect(usage.breakdown.toolMessageTokens).toBe(2);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      first: 1,
+      second: 1,
+      third: 0,
+    });
+  });
+
+  it('distinguishes a known zero share from an unavailable counter', () => {
+    const known = snapshot();
+    syncBudgetDerivedFields(known, [new HumanMessage('hello')], () => 10);
+    expect(known.breakdown.toolMessageTokens).toBe(0);
+    expect(known.breakdown.toolMessageTokenCounts).toBeUndefined();
+
+    const zero = snapshot();
+    syncBudgetDerivedFields(zero, [toolResult('a')], () => 0);
+    expect(zero.breakdown.toolMessageTokens).toBe(0);
+    expect(zero.breakdown.toolMessageTokenCounts).toBeUndefined();
+
+    const unavailable = snapshot();
+    syncBudgetDerivedFields(unavailable, [toolResult('a')]);
+    expect(unavailable.breakdown.toolMessageTokens).toBeUndefined();
+  });
+
+  it('rejects unsafe counter values and aggregate overflow', () => {
+    for (const value of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      -1,
+      0.5,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      expect(() =>
+        syncBudgetDerivedFields(snapshot(), [toolResult('a')], () => value)
+      ).toThrow(RangeError);
+    }
+
+    expect(() =>
+      syncBudgetDerivedFields(
+        snapshot(),
+        [toolResult('a'), toolResult('b')],
+        () => Number.MAX_SAFE_INTEGER
+      )
+    ).toThrow(RangeError);
+  });
+
+  it('reuses exact cached counts and invalidates them after token-relevant mutation', () => {
+    let counterCalls = 0;
+    const tokenCounter: t.TokenCounter = (message) => {
+      counterCalls += 1;
+      return typeof message.content === 'string' ? message.content.length : 0;
+    };
+    const cachedCounter = createExactTokenCountCache(tokenCounter);
+    const result = toolResult('cached', 'lookup');
+
+    const first = snapshot();
+    syncBudgetDerivedFields(first, [result], cachedCounter.count);
+    expect(first.breakdown.toolMessageTokens).toBe(6);
+    expect(counterCalls).toBe(1);
+
+    const second = snapshot();
+    syncBudgetDerivedFields(second, [result], cachedCounter.count);
+    expect(second.breakdown.toolMessageTokens).toBe(6);
+    expect(counterCalls).toBe(1);
+
+    result.content = 'changed result';
+    const third = snapshot();
+    syncBudgetDerivedFields(third, [result], cachedCounter.count);
+    expect(third.breakdown.toolMessageTokens).toBe(14);
+    expect(counterCalls).toBe(2);
+  });
+});

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -1,32 +1,202 @@
+import type {
+  AIMessage,
+  BaseMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 import type * as t from '@/types';
+import { apportionTokenCounts } from '@/utils/tokens';
 
-/**
- * Reconciles a context-usage breakdown's instruction/available/message fields
- * from the pruner's budget metrics. `messageTokens` and `availableForMessages`
- * are DERIVED from `contextBudget` / `effectiveInstructionTokens` /
- * `remainingContextTokens` rather than summed from the index map — that map is
- * keyed by pre-prune indices, so summing it over the kept context would missum.
- * Shared by the live snapshot path (`Graph.createCallModel`) and the pre-send
- * projection (`AgentContext.projectContextUsage`) so both yield identical numbers.
- */
-export function syncBudgetDerivedFields(usage: t.ContextUsageEvent): void {
+type NamedToolCall = {
+  id?: string;
+  name?: string;
+  function?: { name?: string };
+};
+
+function safeCount(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new RangeError('Invalid tool context token count');
+  }
+  return value;
+}
+
+/** Counts retained tool exchanges without serializing arguments or result content.
+ * Mixed text/reasoning/media assistant messages remain in the conversation share. */
+function computeToolMessageUsage(
+  context: readonly BaseMessage[],
+  tokenCounter: t.TokenCounter,
+  calibrationRatio = 1
+): Pick<
+  t.TokenBudgetBreakdown,
+  'toolMessageTokens' | 'toolMessageTokenCounts'
+> {
+  const names = new Map<string, string>();
+  const counts: Record<string, number> = Object.create(null);
+  let legacyName: string | undefined;
+  let total = 0;
+  let resultTotal = 0;
+  const rememberCall = (call: NamedToolCall): void => {
+    const name =
+      call.name != null && call.name.length > 0
+        ? call.name
+        : call.function?.name;
+    if (
+      typeof call.id === 'string' &&
+      typeof name === 'string' &&
+      name.length > 0
+    ) {
+      names.set(call.id, name);
+    }
+  };
+
+  for (const message of context) {
+    const type = message.getType();
+    const isResult = type === 'tool' || type === 'function';
+    if (type === 'ai') {
+      const ai = message as AIMessage;
+      const calls = ai.tool_calls;
+      const rawCalls = ai.additional_kwargs.tool_calls;
+      if (rawCalls != null) {
+        for (const call of rawCalls) {
+          rememberCall(call);
+        }
+      }
+      if (calls != null) {
+        for (const call of calls) {
+          rememberCall(call);
+        }
+      }
+      legacyName = ai.additional_kwargs.function_call?.name;
+      let hasCalls =
+        (calls?.length ?? 0) > 0 ||
+        (rawCalls?.length ?? 0) > 0 ||
+        (legacyName != null && legacyName.length > 0);
+      let toolOnly = true;
+      if (typeof ai.content === 'string') {
+        toolOnly = !/\S/u.test(ai.content);
+      } else {
+        const content: ReadonlyArray<
+          string | Exclude<AIMessage['content'], string>[number]
+        > = ai.content;
+        for (const part of content) {
+          if (typeof part === 'string') {
+            toolOnly &&= !/\S/u.test(part);
+          } else if (part.type === 'tool_use') {
+            hasCalls = true;
+            if (
+              typeof part.id === 'string' &&
+              typeof part.name === 'string' &&
+              !names.has(part.id)
+            ) {
+              rememberCall({ id: part.id, name: part.name });
+            }
+          } else {
+            toolOnly &&=
+              part.type === 'text' &&
+              typeof part.text === 'string' &&
+              !/\S/u.test(part.text);
+          }
+        }
+      }
+      if (!hasCalls || !toolOnly) {
+        continue;
+      }
+    } else if (!isResult) {
+      legacyName = undefined;
+      continue;
+    }
+
+    const tokens = safeCount(tokenCounter(message));
+    total = safeCount(total + tokens);
+    if (!isResult) {
+      continue;
+    }
+    const id =
+      type === 'tool' ? (message as ToolMessage).tool_call_id : undefined;
+    const pendingName =
+      type === 'function' && legacyName != null && legacyName.length > 0
+        ? legacyName
+        : undefined;
+    const name =
+      (id != null ? names.get(id) : undefined) ??
+      (message.name != null && message.name.length > 0
+        ? message.name
+        : pendingName) ??
+      'unknown_tool';
+    if (type === 'function') {
+      legacyName = undefined;
+    }
+    if (tokens > 0) {
+      counts[name] = safeCount((counts[name] ?? 0) + tokens);
+      resultTotal = safeCount(resultTotal + tokens);
+    }
+  }
+
+  const ratio =
+    Number.isFinite(calibrationRatio) && calibrationRatio > 0
+      ? calibrationRatio
+      : 1;
+  const toolMessageTokens = safeCount(Math.round(total * ratio));
+  const resultTokens = Math.min(
+    toolMessageTokens,
+    safeCount(Math.round(resultTotal * ratio))
+  );
+  return {
+    toolMessageTokens,
+    toolMessageTokenCounts:
+      resultTotal > 0 && resultTokens > 0
+        ? apportionTokenCounts(counts, ratio, resultTokens)
+        : undefined,
+  };
+}
+
+/** Reconciles derived budget fields and, when supplied, the retained tool share.
+ * The index map is keyed before pruning, so it cannot index the retained context.
+ * Callers may pass the existing exact token cache's counter, never a stale index lookup. */
+export function syncBudgetDerivedFields(
+  usage: t.ContextUsageEvent,
+  context?: readonly BaseMessage[],
+  tokenCounter?: t.TokenCounter
+): void {
   const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
-  if (effectiveInstructionTokens == null) {
+  if (effectiveInstructionTokens != null) {
+    breakdown.instructionTokens = effectiveInstructionTokens;
+    if (contextBudget != null) {
+      breakdown.availableForMessages = Math.max(
+        0,
+        contextBudget - effectiveInstructionTokens
+      );
+      if (usage.remainingContextTokens != null) {
+        breakdown.messageTokens = Math.max(
+          0,
+          contextBudget -
+            effectiveInstructionTokens -
+            usage.remainingContextTokens
+        );
+      }
+    }
+  }
+  if (context != null && tokenCounter != null) {
+    Object.assign(
+      breakdown,
+      computeToolMessageUsage(context, tokenCounter, usage.calibrationRatio)
+    );
+  }
+  if (breakdown.toolMessageTokens == null) {
     return;
   }
-  breakdown.instructionTokens = effectiveInstructionTokens;
-  if (contextBudget == null) {
-    return;
+  const total = safeCount(breakdown.toolMessageTokens);
+  const clamped = Math.min(total, safeCount(breakdown.messageTokens));
+  if (clamped !== total && breakdown.toolMessageTokenCounts != null) {
+    let resultTotal = 0;
+    for (const count of Object.values(breakdown.toolMessageTokenCounts)) {
+      resultTotal = safeCount(resultTotal + safeCount(count));
+    }
+    const factor = total > 0 ? clamped / total : 0;
+    const target = Math.min(clamped, Math.round(resultTotal * factor));
+    breakdown.toolMessageTokenCounts =
+      target > 0
+        ? apportionTokenCounts(breakdown.toolMessageTokenCounts, factor, target)
+        : undefined;
   }
-  breakdown.availableForMessages = Math.max(
-    0,
-    contextBudget - effectiveInstructionTokens
-  );
-  if (usage.remainingContextTokens == null) {
-    return;
-  }
-  breakdown.messageTokens = Math.max(
-    0,
-    contextBudget - effectiveInstructionTokens - usage.remainingContextTokens
-  );
+  breakdown.toolMessageTokens = clamped;
 }

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -1,6 +1,7 @@
 import type {
   AIMessage,
   BaseMessage,
+  ChatMessage,
   ToolMessage,
 } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
@@ -36,12 +37,14 @@ function safeCount(value: number): number {
 let warnedUnavailableToolShare = false;
 
 /** Warns once per process: an unusable counter is a permanent host-integration
- *  fault, while the share is dropped on every affected call regardless. */
+ *  fault, while the share is dropped on every affected call regardless. The
+ *  latch is spent only when a config can carry the event, so a config-less
+ *  caller (the pre-send projection) cannot swallow the live path's one warning. */
 function warnUnavailableToolShare(
   config: RunnableConfig | undefined,
   error: unknown
 ): void {
-  if (warnedUnavailableToolShare) {
+  if (warnedUnavailableToolShare || config == null) {
     return;
   }
   warnedUnavailableToolShare = true;
@@ -52,6 +55,15 @@ function warnUnavailableToolShare(
     'Tool-message context share unavailable: the token counter must return safe, non-negative integers',
     { error: error instanceof Error ? error.message : String(error) }
   );
+}
+
+/** A `ChatMessage` carrying `role: 'assistant'` reports its type as `generic`,
+ *  a shape the OpenAI role converter and the default token counter both accept. */
+function isAssistantMessage(message: BaseMessage, type: string): boolean {
+  if (type === 'ai') {
+    return true;
+  }
+  return type === 'generic' && (message as ChatMessage).role === 'assistant';
 }
 
 /** Counts retained tool exchanges without serializing arguments or result content.
@@ -94,7 +106,7 @@ function computeToolMessageUsage(
   for (const message of context) {
     const type = message.getType();
     const isResult = type === 'tool' || type === 'function';
-    if (type === 'ai') {
+    if (isAssistantMessage(message, type)) {
       const ai = message as AIMessage;
       const calls = ai.tool_calls;
       const rawCalls = ai.additional_kwargs.tool_calls;

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -3,8 +3,10 @@ import type {
   BaseMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
 import type * as t from '@/types';
 import { apportionTokenCounts } from '@/utils/tokens';
+import { emitAgentLog } from '@/utils/events';
 
 type NamedToolCall = {
   id?: string;
@@ -12,11 +14,44 @@ type NamedToolCall = {
   function?: { name?: string };
 };
 
+/** Inline tool-call content: an Anthropic `tool_use` block, the v1 standard
+ *  `tool_call` block (`{ id, name }` at top level, which `@langchain/aws`
+ *  serializes to a Converse toolUse), and this repo's `ToolCallContent`
+ *  (`{ tool_call: { id, name } }`). */
+type InlineToolCallBlock = {
+  id?: string;
+  name?: string;
+  tool_call?: { id?: string; name?: string };
+};
+
+/** Rejects counts a subset claim cannot be derived from. Callers must degrade
+ *  rather than propagate: this runs on the live pre-invoke path. */
 function safeCount(value: number): number {
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new RangeError('Invalid tool context token count');
   }
   return value;
+}
+
+let warnedUnavailableToolShare = false;
+
+/** Warns once per process: an unusable counter is a permanent host-integration
+ *  fault, while the share is dropped on every affected call regardless. */
+function warnUnavailableToolShare(
+  config: RunnableConfig | undefined,
+  error: unknown
+): void {
+  if (warnedUnavailableToolShare) {
+    return;
+  }
+  warnedUnavailableToolShare = true;
+  emitAgentLog(
+    config,
+    'warn',
+    'budget',
+    'Tool-message context share unavailable: the token counter must return safe, non-negative integers',
+    { error: error instanceof Error ? error.message : String(error) }
+  );
 }
 
 /** Counts retained tool exchanges without serializing arguments or result content.
@@ -46,6 +81,14 @@ function computeToolMessageUsage(
     ) {
       names.set(call.id, name);
     }
+  };
+  const rememberInlineCall = (block: InlineToolCallBlock): void => {
+    const nested = block.tool_call;
+    const id = nested?.id ?? block.id;
+    if (typeof id !== 'string' || names.has(id)) {
+      return;
+    }
+    rememberCall({ id, name: nested?.name ?? block.name });
   };
 
   for (const message of context) {
@@ -80,15 +123,9 @@ function computeToolMessageUsage(
         for (const part of content) {
           if (typeof part === 'string') {
             toolOnly &&= !/\S/u.test(part);
-          } else if (part.type === 'tool_use') {
+          } else if (part.type === 'tool_use' || part.type === 'tool_call') {
             hasCalls = true;
-            if (
-              typeof part.id === 'string' &&
-              typeof part.name === 'string' &&
-              !names.has(part.id)
-            ) {
-              rememberCall({ id: part.id, name: part.name });
-            }
+            rememberInlineCall(part as InlineToolCallBlock);
           } else {
             toolOnly &&=
               part.type === 'text' &&
@@ -149,32 +186,14 @@ function computeToolMessageUsage(
   };
 }
 
-/** Reconciles derived budget fields and, when supplied, the retained tool share.
- * The index map is keyed before pruning, so it cannot index the retained context.
- * Callers may pass the existing exact token cache's counter, never a stale index lookup. */
-export function syncBudgetDerivedFields(
+/** Applies the retained tool share and clamps it to the conversation total it
+ * is a subset of. Throws when a count cannot support that claim. */
+function syncToolMessageShare(
   usage: t.ContextUsageEvent,
   context?: readonly BaseMessage[],
   tokenCounter?: t.TokenCounter
 ): void {
-  const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
-  if (effectiveInstructionTokens != null) {
-    breakdown.instructionTokens = effectiveInstructionTokens;
-    if (contextBudget != null) {
-      breakdown.availableForMessages = Math.max(
-        0,
-        contextBudget - effectiveInstructionTokens
-      );
-      if (usage.remainingContextTokens != null) {
-        breakdown.messageTokens = Math.max(
-          0,
-          contextBudget -
-            effectiveInstructionTokens -
-            usage.remainingContextTokens
-        );
-      }
-    }
-  }
+  const { breakdown } = usage;
   if (context != null && tokenCounter != null) {
     Object.assign(
       breakdown,
@@ -199,4 +218,42 @@ export function syncBudgetDerivedFields(
         : undefined;
   }
   breakdown.toolMessageTokens = clamped;
+}
+
+/** Reconciles derived budget fields and, when supplied, the retained tool share.
+ * The index map is keyed before pruning, so it cannot index the retained context.
+ * Callers may pass the existing exact token cache's counter, never a stale index lookup.
+ * Runs on the live pre-invoke path, so an unusable count drops the tool share
+ * (warned once) instead of failing the model call it only measures. */
+export function syncBudgetDerivedFields(
+  usage: t.ContextUsageEvent,
+  context?: readonly BaseMessage[],
+  tokenCounter?: t.TokenCounter,
+  config?: RunnableConfig
+): void {
+  const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
+  if (effectiveInstructionTokens != null) {
+    breakdown.instructionTokens = effectiveInstructionTokens;
+    if (contextBudget != null) {
+      breakdown.availableForMessages = Math.max(
+        0,
+        contextBudget - effectiveInstructionTokens
+      );
+      if (usage.remainingContextTokens != null) {
+        breakdown.messageTokens = Math.max(
+          0,
+          contextBudget -
+            effectiveInstructionTokens -
+            usage.remainingContextTokens
+        );
+      }
+    }
+  }
+  try {
+    syncToolMessageShare(usage, context, tokenCounter);
+  } catch (error) {
+    warnUnavailableToolShare(config, error);
+    delete breakdown.toolMessageTokens;
+    delete breakdown.toolMessageTokenCounts;
+  }
 }

--- a/src/specs/context-usage-event.test.ts
+++ b/src/specs/context-usage-event.test.ts
@@ -1,7 +1,25 @@
-import { HumanMessage, BaseMessage } from '@langchain/core/messages';
+import { z } from 'zod';
+import { DynamicStructuredTool } from '@langchain/core/tools';
+import { AIMessage, HumanMessage, BaseMessage } from '@langchain/core/messages';
+import type { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager';
+import type { ChatGenerationChunk } from '@langchain/core/outputs';
 import type * as t from '@/types';
 import { GraphEvents, Providers } from '@/common';
+import { FakeChatModel } from '@/llm/fake';
 import { Run } from '@/run';
+
+class CapturingFakeChatModel extends FakeChatModel {
+  readonly invocations: BaseMessage[][] = [];
+
+  override async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this['ParsedCallOptions'],
+    runManager?: CallbackManagerForLLMRun
+  ): AsyncGenerator<ChatGenerationChunk> {
+    this.invocations.push(messages);
+    yield* super._streamResponseChunks(messages, options, runManager);
+  }
+}
 
 const charCounter: t.TokenCounter = (msg: BaseMessage): number => {
   const content = msg.content;
@@ -84,6 +102,102 @@ describe('ON_CONTEXT_USAGE event', () => {
         (event.effectiveInstructionTokens as number) -
         (event.remainingContextTokens as number)
     );
+  });
+  it('accounts for the retained exchange in the final provider-facing snapshot', async () => {
+    const received: t.ContextUsageEvent[] = [];
+    const retainedResult = `tool-result:${'x'.repeat(10_000)}`;
+    const lookup = new DynamicStructuredTool({
+      name: 'lookup',
+      description: 'Returns a deterministic retained result.',
+      schema: z.object({ query: z.string() }),
+      func: async () => retainedResult,
+    });
+    const toolCall = {
+      id: 'lookup-call',
+      name: 'lookup',
+      args: { query: 'retained context' },
+      type: 'tool_call' as const,
+    };
+    const model = new CapturingFakeChatModel({
+      responses: ['', 'done'],
+      toolCalls: [toolCall],
+    });
+
+    const run = await Run.create<t.IState>({
+      runId: 'test-context-usage-event-tool-loop',
+      graphConfig: {
+        type: 'standard',
+        llmConfig,
+        instructions: 'Use lookup, then answer briefly.',
+        maxContextTokens: 2_000,
+        maxToolResultChars: 240,
+        tools: [lookup],
+      },
+      returnContent: true,
+      skipCleanup: true,
+      customHandlers: {
+        [GraphEvents.ON_CONTEXT_USAGE]: {
+          handle: (_event, data): void => {
+            if (data != null && 'breakdown' in data) {
+              received.push(data);
+            }
+          },
+        },
+      },
+      tokenCounter: charCounter,
+      indexTokenCountMap: {},
+    });
+
+    run.Graph!.overrideModel = model;
+    await run.processStream(
+      { messages: [new HumanMessage('Look this up.')] },
+      {
+        ...streamConfig,
+        configurable: { thread_id: 'context-usage-event-tool-loop' },
+      }
+    );
+
+    expect(model.invocations).toHaveLength(2);
+    expect(received).toHaveLength(2);
+    expect(received[0].breakdown.toolMessageTokens).toBe(0);
+    expect(received[0].breakdown.toolMessageTokenCounts).toBeUndefined();
+
+    const finalProviderMessages = model.invocations[1];
+    const retainedToolMessages = finalProviderMessages.filter((message) => {
+      if (message.getType() === 'tool') {
+        return true;
+      }
+      if (message.getType() !== 'ai') {
+        return false;
+      }
+      const aiMessage = message as AIMessage;
+      return (
+        (aiMessage.tool_calls?.length ?? 0) > 0 &&
+        typeof aiMessage.content === 'string' &&
+        !/\S/u.test(aiMessage.content)
+      );
+    });
+    const providerToolTokens = retainedToolMessages.reduce(
+      (total, message) => total + charCounter(message),
+      0
+    );
+    const finalEvent = received[1];
+    const retainedToolResult = retainedToolMessages.find(
+      (message) => message.getType() === 'tool'
+    );
+    expect(retainedToolResult).toBeDefined();
+    const resultTokenCount = charCounter(retainedToolResult!);
+    expect(String(retainedToolResult?.content).length).toBeLessThan(
+      retainedResult.length
+    );
+    expect(finalEvent.breakdown.toolMessageTokens).toBe(providerToolTokens);
+    expect(resultTokenCount).toBeGreaterThan(0);
+    expect(finalEvent.breakdown.toolMessageTokens).toBeGreaterThan(
+      resultTokenCount
+    );
+    expect(finalEvent.breakdown.toolMessageTokenCounts).toEqual({
+      lookup: resultTokenCount,
+    });
   });
 
   it('does not dispatch when no tokenCounter is configured', async () => {

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -475,6 +475,10 @@ export type TokenBudgetBreakdown = {
   toolTokenCounts?: Record<string, number>;
   /** Names of counted tools that are deferred (`defer_loading`) and discovered. */
   deferredToolNames?: string[];
+  /** Calibrated retained tool results plus tool-only assistant messages; subset of messageTokens, not an additional budget category. */
+  toolMessageTokens?: number;
+  /** Per-tool result-message share; excludes assistant invocation overhead. */
+  toolMessageTokenCounts?: Record<string, number>;
 };
 
 export type EventStreamOptions = {


### PR DESCRIPTION
## Summary

Port the source implementation from LibreChat's pinned `@librechat/agents@3.7.17` patch into the upstream SDK. No LibreChat UI, Docker, patch-package installation hooks, or hand-patched generated runtime files are included.

- Add optional `toolMessageTokens` and `toolMessageTokenCounts` to `TokenBudgetBreakdown`. These are calibrated retained-context estimates, not provider-reported per-tool billing. Tool schema counts remain in `toolTokenCounts`.
- Extend `syncBudgetDerivedFields(usage, context?, tokenCounter?)` to count retained tool/function results and tool-only assistant invocations in one message scan, then calibrate and clamp the tool share as a subset of `messageTokens`.
- Recognize structured calls, raw OpenAI calls, inline `tool_use`, and legacy `function_call`. Attribute results by call ID, result name, then pending legacy function name where applicable; unmatched results use `unknown_tool` without guessing unrelated ID-less calls.
- Preserve invocation overhead outside per-tool result shares, use null-prototype records and existing token apportionment, distinguish known zero from unavailable counters, and reject unsafe counts.
- Use the existing exact-token-cache counter with pruned pre-send projections and final provider-facing messages at the live pre-invoke emission boundary. The early summarization path does not calculate a discarded tool breakdown.
- Add SDK-local regression coverage. Projection preserves caller-owned history.

## Verification

- `npm test -- --runInBand src/messages/budget.test.ts src/specs/context-usage-event.test.ts src/agents/__tests__/AgentContext.test.ts src/agents/__tests__/projection.test.ts langfuse deterministic-trace-id`: **15 suites, 339 tests passed**.
- `npx tsc --noEmit`: passed.
- `npm run build`: CJS, ESM, and declarations passed.
- Built CJS and ESM public exports passed runtime smoke checks for calibration, prototype-sensitive attribution, and clamping.
- Real-tokenizer `projectAgentContextUsage` smoke: tool share 21 of 41 message tokens, with 10 attributed to the result; caller history unchanged.
- Repeated 100 snapshots of 1,000 retained tool messages: 1,000 tokenizer calls before mutation, exactly one additional call after changing one result.
- Changed TypeScript files pass ESLint with `--max-warnings 0`. Repository-wide lint has zero errors and 78 existing warnings; every remaining warning is in a file verified unchanged from HEAD.

No external provider calls, real Langfuse project inspection, or production infrastructure were exercised. Temporary smoke scaffolding was removed.