### PR TITLE
🪚 feat: Compact Conversation History on Demand

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -123,6 +123,7 @@ export class AgentContext {
       useLegacyContent,
       discoveredTools,
       summarizationEnabled,
+      summarizeOnly,
       summarizationConfig,
       compactionSemanticIndex,
       initialSummary,
@@ -158,6 +159,7 @@ export class AgentContext {
       useLegacyContent,
       discoveredTools,
       summarizationEnabled,
+      summarizeOnly,
       summarizationConfig,
       compactionSemanticIndex,
       contextPruningConfig,
@@ -383,6 +385,10 @@ export class AgentContext {
   useLegacyContent: boolean = false;
   /** Enables graph-level summarization for this agent */
   summarizationEnabled?: boolean;
+  /** Summarize-only run: request a summary on the first model step and end after it */
+  summarizeOnly?: boolean;
+  /** Whether the summarize-only run has already issued its one request */
+  private _manualSummarizationRequested: boolean = false;
   /** Summarization runtime settings used by graph pruning hooks */
   summarizationConfig?: t.SummarizationConfig;
   /** Host-supplied advisory guidance consumed only when compaction runs. */
@@ -480,6 +486,7 @@ export class AgentContext {
     useLegacyContent,
     discoveredTools,
     summarizationEnabled,
+    summarizeOnly,
     summarizationConfig,
     compactionSemanticIndex,
     contextPruningConfig,
@@ -508,6 +515,7 @@ export class AgentContext {
     useLegacyContent?: boolean;
     discoveredTools?: string[];
     summarizationEnabled?: boolean;
+    summarizeOnly?: boolean;
     summarizationConfig?: t.SummarizationConfig;
     compactionSemanticIndex?: t.CompactionSemanticIndex;
     contextPruningConfig?: t.ContextPruningConfig;
@@ -549,6 +557,7 @@ export class AgentContext {
 
     this.useLegacyContent = useLegacyContent ?? false;
     this.summarizationEnabled = summarizationEnabled;
+    this.summarizeOnly = summarizeOnly;
     this.summarizationConfig = summarizationConfig;
     if (compactionSemanticIndex != null) {
       this.compactionSemanticIndex = snapshotCompactionSemanticIndex(
@@ -1268,6 +1277,7 @@ export class AgentContext {
     this.summaryPrecedesMessages = this.durableSummaryPrecedesMessages;
     this._lastSummarizationMsgCount = 0;
     this._summarizationFailures = 0;
+    this._manualSummarizationRequested = false;
     this.lastCallUsage = undefined;
     this.totalTokensFresh = false;
     this.restoreContextBudgetAfterOverflow();
@@ -1615,6 +1625,20 @@ export class AgentContext {
    */
   markSummarizationTriggered(msgCount: number): void {
     this._lastSummarizationMsgCount = msgCount;
+  }
+
+  /**
+   * Claims the single summarization request a summarize-only run makes.
+   * True exactly once per run, on the first model step; the step that gets
+   * `false` is the one after the summary, which reports usage and ends
+   * without a model call. Always false when `summarizeOnly` is off.
+   */
+  claimManualSummarization(): boolean {
+    if (this.summarizeOnly !== true || this._manualSummarizationRequested) {
+      return false;
+    }
+    this._manualSummarizationRequested = true;
+    return true;
   }
 
   /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3237,35 +3237,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         agentContext.markToolsAsDiscovered(discoveredNames);
       }
 
-      /**
-       * Anthropic prompt-cache breakpoint on the tool definitions.
-       *
-       * Without this, the (often static) tool inventory shows up as
-       * fresh input on every turn — measured at ~28k tokens/turn for
-       * the local engine's coding-tool bundle, dominating per-turn
-       * cost even when message-level caching is on.
-       *
-       * Strategy: partition tools into [static, deferred] and stamp
-       * `cache_control: ephemeral` on the last static tool.
-       * Discovered deferred tools that arrive across turns sit *after*
-       * the breakpoint and don't invalidate the prefix.
-       */
-      const toolsForBinding = this.getPreparedToolsForBinding(agentContext);
-
-      let model =
-        this.overrideModel ??
-        initializeModel({
-          tools: toolsForBinding,
-          provider: agentContext.provider,
-          clientOptions: agentContext.clientOptions,
-        });
-
-      if (agentContext.systemRunnable) {
-        model = agentContext.systemRunnable
-          .pipe(model as Runnable)
-          .withConfig({ runName: AGENT_MODEL_CALL_RUN_NAME });
-      }
-
       if (agentContext.tokenCalculationPromise) {
         await agentContext.tokenCalculationPromise;
       }
@@ -3499,6 +3470,39 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         if (summarizeOnlyStep != null) {
           return summarizeOnlyStep;
         }
+      }
+
+      /**
+       * Anthropic prompt-cache breakpoint on the tool definitions.
+       *
+       * Without this, the (often static) tool inventory shows up as
+       * fresh input on every turn — measured at ~28k tokens/turn for
+       * the local engine's coding-tool bundle, dominating per-turn
+       * cost even when message-level caching is on.
+       *
+       * Strategy: partition tools into [static, deferred] and stamp
+       * `cache_control: ephemeral` on the last static tool.
+       * Discovered deferred tools that arrive across turns sit *after*
+       * the breakpoint and don't invalidate the prefix.
+       *
+       * Built only once a model call is certain: a summarize-only step
+       * returns above without one, and must not fail on a primary model
+       * it never invokes.
+       */
+      const toolsForBinding = this.getPreparedToolsForBinding(agentContext);
+
+      let model =
+        this.overrideModel ??
+        initializeModel({
+          tools: toolsForBinding,
+          provider: agentContext.provider,
+          clientOptions: agentContext.clientOptions,
+        });
+
+      if (agentContext.systemRunnable) {
+        model = agentContext.systemRunnable
+          .pipe(model as Runnable)
+          .withConfig({ runName: AGENT_MODEL_CALL_RUN_NAME });
       }
 
       let finalMessages = messagesToUse;
@@ -5521,6 +5525,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           return result;
         },
         default: () => [],
+      }),
+      /** Surfaced from the agent subgraph on a summarize-only run. */
+      manualSummary: Annotation<string | undefined>({
+        reducer: (_: string | undefined, b: string | undefined) => b,
+        default: () => undefined,
       }),
       runStepState: this.createRunStepStateAnnotation(),
     });

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -1468,8 +1468,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   outputTruncatedIncomplete = false;
   /**
    * The agent a summarize-only run summarizes with. Set from the first agent
-   * input that opted in; while set, every other agent's model step is a
-   * no-op and the workflow drains to END after the summary.
+   * input that opted in; while set, the model step after the summary routes
+   * to END, and a multi-agent workflow compiles to this agent alone.
    */
   summarizeOnlyAgentId?: string;
   /**

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3148,6 +3148,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           agentId: agentId || agentContext.agentId,
           reason: 'manual',
         },
+        /** A checkpointed thread may still hold the previous compaction's
+         *  summary; only the one this run produces may be reported. */
+        manualSummary: '',
       };
     }
     if (contextUsage != null) {
@@ -3215,18 +3218,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * `processStream` call starts clean.
        */
       if (this.preemptHaltReason != null) {
-        return { messages: [] };
-      }
-
-      /**
-       * A summarize-only run ends at the agent that summarizes. A chained or
-       * fanned-out successor entered through the workflow's static routing
-       * must not spend a model call on the compacted history.
-       */
-      if (
-        this.summarizeOnlyAgentId != null &&
-        this.summarizeOnlyAgentId !== agentId
-      ) {
         return { messages: [] };
       }
 
@@ -5251,7 +5242,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       this.config = config;
       this.restoreRunStepResumeState(state.runStepState);
       const result = await invoke();
-      return { ...result, runStepState: this.createRunStepResumeState() };
+      /** An ordinary run on a checkpointed thread inherits the last
+       *  compaction's summary in state; it is not this run's output. */
+      const clearsManualSummary =
+        this.summarizeOnlyAgentId == null &&
+        typeof state.manualSummary === 'string' &&
+        state.manualSummary.length > 0;
+      return {
+        ...result,
+        ...(clearsManualSummary ? { manualSummary: '' } : {}),
+        runStepState: this.createRunStepResumeState(),
+      };
     };
 
     const routeMessage = (

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -162,7 +162,10 @@ import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
-import { shouldTriggerSummarization } from '@/summarization';
+import {
+  ManualSummarizationSkippedError,
+  shouldTriggerSummarization,
+} from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
@@ -1464,6 +1467,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
    */
   outputTruncatedIncomplete = false;
   /**
+   * The agent a summarize-only run summarizes with. Set from the first agent
+   * input that opted in; while set, every other agent's model step is a
+   * no-op and the workflow drains to END after the summary.
+   */
+  summarizeOnlyAgentId?: string;
+  /**
    * `stopReason` from a `PreemptBoundary` hook that halted the turn.
    *
    * Clearing the registry halt is what keeps the sealed turn alive, but the
@@ -1551,6 +1560,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         indexTokenCountMap,
         toolExecution
       );
+      if (agentConfig.summarizeOnly === true) {
+        this.summarizeOnlyAgentId ??= agentContext.agentId;
+      }
       if (calibrationRatio != null && calibrationRatio > 0) {
         agentContext.calibrationRatio = calibrationRatio;
       }
@@ -3113,15 +3125,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     const meta = { runId: this.runId, agentId };
     if (agentContext.claimManualSummarization()) {
       if (agentContext.summarizationEnabled !== true) {
-        emitAgentLog(
-          config,
-          'warn',
-          'graph',
-          'Summarize-only run skipped — summarization is not enabled',
-          undefined,
-          meta
+        throw new ManualSummarizationSkippedError(
+          'disabled',
+          'Compaction skipped: summarization is not enabled for this agent'
         );
-        return { messages: [] };
       }
       emitAgentLog(
         config,
@@ -3208,6 +3215,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * `processStream` call starts clean.
        */
       if (this.preemptHaltReason != null) {
+        return { messages: [] };
+      }
+
+      /**
+       * A summarize-only run ends at the agent that summarizes. A chained or
+       * fanned-out successor entered through the workflow's static routing
+       * must not spend a model call on the compacted history.
+       */
+      if (
+        this.summarizeOnlyAgentId != null &&
+        this.summarizeOnlyAgentId !== agentId
+      ) {
         return { messages: [] };
       }
 
@@ -5249,7 +5268,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
       /** A summarize-only run never calls the model, so the step after the
        *  summary has nothing to route: the summary itself is the result. */
-      if (agentContext.summarizeOnly === true) {
+      if (this.summarizeOnlyAgentId != null) {
         return END;
       }
       const decision = toolsCondition(
@@ -5288,6 +5307,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           _: t.SummarizationNodeInput | undefined,
           b: t.SummarizationNodeInput | undefined
         ) => b,
+        default: () => undefined,
+      }),
+      manualSummary: Annotation<string | undefined>({
+        reducer: (_: string | undefined, b: string | undefined) => b,
         default: () => undefined,
       }),
       runStepState: this.createRunStepStateAnnotation(),

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -169,8 +169,8 @@ import {
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
+import { createRemoveAllMessage, messagesStateReducer  } from '@/messages/reducer';
 import { getTruncationStopReason } from '@/llm/truncation';
-import { messagesStateReducer } from '@/messages/reducer';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
 import { createFakeStreamingLLM } from '@/llm/fake';
@@ -1585,7 +1585,30 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       this.agentContexts.set(agentConfig.agentId, agentContext);
     }
 
-    this.defaultAgentId = agents[0].agentId;
+    /** The run's agent: root trace identity and Langfuse routing follow it,
+     *  so a summarize-only run is attributed to the agent that summarizes. */
+    this.defaultAgentId = this.summarizeOnlyAgentId ?? agents[0].agentId;
+  }
+
+  /**
+   * A compaction applies its remove-all inside the agent subgraph, so the
+   * subgraph's result carries only the retained tail, and an outer reducer
+   * would merge that tail back into the history it already holds. Re-issuing
+   * the remove-all across the boundary keeps a checkpointed outer state as
+   * compacted as the subgraph's. A run that produced no summary changed
+   * nothing and passes through.
+   */
+  protected propagateManualCompaction<
+    S extends { messages: BaseMessage[]; manualSummary?: string },
+  >(result: S): S {
+    if (
+      this.summarizeOnlyAgentId == null ||
+      result.manualSummary == null ||
+      result.manualSummary.length === 0
+    ) {
+      return result;
+    }
+    return { ...result, messages: [createRemoveAllMessage(), ...result.messages] };
   }
 
   /** Rotates the Langfuse identities that must never cross fresh executions. */
@@ -5534,13 +5557,20 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }),
       runStepState: this.createRunStepStateAnnotation(),
     });
+    const compactingAgentNode = async (
+      state: t.AgentSubgraphState,
+      config?: RunnableConfig
+    ): Promise<Partial<t.AgentSubgraphState>> =>
+      this.propagateManualCompaction(await agentNode.invoke(state, config));
     const workflow = new StateGraph(StateAnnotation)
       .addNode(
         this.defaultAgentId,
-        agentNode as Runnable<
-          t.AgentSubgraphState,
-          Partial<t.AgentSubgraphState>
-        >,
+        this.summarizeOnlyAgentId != null
+          ? compactingAgentNode
+          : (agentNode as Runnable<
+              t.AgentSubgraphState,
+              Partial<t.AgentSubgraphState>
+            >),
         { ends: [END] }
       )
       .addEdge(START, this.defaultAgentId);

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3086,6 +3086,81 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     });
   }
 
+  /**
+   * The two model steps of a summarize-only run, neither of which calls the
+   * model. The first requests the summary outright — no trigger consulted,
+   * because the user asked for it — and the second, entered after the
+   * summarize node, dispatches the post-summary usage snapshot (the host's
+   * gauge and summary baseline read it) and ends the run. Returns `null`
+   * for every other run so the ordinary step proceeds.
+   */
+  private async summarizeOnlyStep({
+    agentContext,
+    agentId,
+    messageCount,
+    contextUsage,
+    config,
+  }: {
+    agentContext: AgentContext;
+    agentId: string;
+    messageCount: number;
+    contextUsage: t.ContextUsageEvent | null;
+    config: RunnableConfig;
+  }): Promise<Partial<t.AgentSubgraphState> | null> {
+    if (agentContext.summarizeOnly !== true) {
+      return null;
+    }
+    const meta = { runId: this.runId, agentId };
+    if (agentContext.claimManualSummarization()) {
+      if (agentContext.summarizationEnabled !== true) {
+        emitAgentLog(
+          config,
+          'warn',
+          'graph',
+          'Summarize-only run skipped — summarization is not enabled',
+          undefined,
+          meta
+        );
+        return { messages: [] };
+      }
+      emitAgentLog(
+        config,
+        'info',
+        'graph',
+        'Manual summarization requested',
+        {
+          totalMessages: messageCount,
+          summaryVersion: agentContext.summaryVersion + 1,
+        },
+        meta
+      );
+      agentContext.markSummarizationTriggered(messageCount);
+      return {
+        summarizationRequest: {
+          remainingContextTokens: contextUsage?.remainingContextTokens ?? 0,
+          agentId: agentId || agentContext.agentId,
+          reason: 'manual',
+        },
+      };
+    }
+    if (contextUsage != null) {
+      await safeDispatchCustomEvent(
+        GraphEvents.ON_CONTEXT_USAGE,
+        contextUsage,
+        config
+      );
+    }
+    emitAgentLog(
+      config,
+      'debug',
+      'graph',
+      'Summarize-only run complete — ending without a model call',
+      { summaryVersion: agentContext.summaryVersion },
+      meta
+    );
+    return { messages: [] };
+  }
+
   createCallModel(agentId = 'default') {
     return async (
       state: t.AgentSubgraphState,
@@ -3309,6 +3384,17 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         };
         syncBudgetDerivedFields(contextUsage);
 
+        const summarizeOnlyStep = await this.summarizeOnlyStep({
+          agentContext,
+          agentId,
+          messageCount: messages.length,
+          contextUsage,
+          config,
+        });
+        if (summarizeOnlyStep != null) {
+          return summarizeOnlyStep;
+        }
+
         const hasPrunedMessages =
           agentContext.summarizationEnabled === true &&
           Array.isArray(messagesToRefine) &&
@@ -3380,6 +3466,19 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               { runId: this.runId, agentId }
             );
           }
+        }
+      } else {
+        /** No pruner (no token counter or budget): the summarize-only run
+         *  still has to request its summary and stop, just without usage. */
+        const summarizeOnlyStep = await this.summarizeOnlyStep({
+          agentContext,
+          agentId,
+          messageCount: messages.length,
+          contextUsage: null,
+          config,
+        });
+        if (summarizeOnlyStep != null) {
+          return summarizeOnlyStep;
         }
       }
 
@@ -5147,6 +5246,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
       if (state.summarizationRequest != null) {
         return summarizeNode;
+      }
+      /** A summarize-only run never calls the model, so the step after the
+       *  summary has nothing to route: the summary itself is the result. */
+      if (agentContext.summarizeOnly === true) {
+        return END;
       }
       const decision = toolsCondition(
         state as t.BaseGraphState,

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1267,6 +1267,11 @@ export class MultiAgentGraph extends StandardGraph {
         reducer: (_current, update) => update,
         default: () => undefined,
       }),
+      /** Surfaced from the summarizing agent's subgraph on a summarize-only run. */
+      manualSummary: Annotation<string | undefined>({
+        reducer: (_current, update) => update,
+        default: () => undefined,
+      }),
       runStepState: this.createRunStepStateAnnotation(),
     });
 

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1520,6 +1520,7 @@ export class MultiAgentGraph extends StandardGraph {
         } else {
           result = await agentSubgraph.invoke(state, memberConfig);
         }
+        result = this.propagateManualCompaction(result);
 
         if (this.resultAgentId === agentId) {
           result = {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1286,14 +1286,29 @@ export class MultiAgentGraph extends StandardGraph {
       builder.addEdge(source, destination);
     };
 
+    /**
+     * A summarize-only run compiles to the opted-in agent alone: no other
+     * node, no handoff or direct edge, START → agent → END. Anything else
+     * would run the summarizer twice (once from START, once through its
+     * predecessor) or append routing prompts to the checkpoint it just
+     * produced.
+     */
+    const summarizeOnlyAgentId = this.summarizeOnlyAgentId;
+    const agentIds =
+      summarizeOnlyAgentId != null
+        ? [summarizeOnlyAgentId]
+        : [...this.agentContexts.keys()];
+    const handoffEdges = summarizeOnlyAgentId != null ? [] : this.handoffEdges;
+    const directEdges = summarizeOnlyAgentId != null ? [] : this.directEdges;
+
     // Add all agents as complete subgraphs
-    for (const [agentId] of this.agentContexts) {
+    for (const agentId of agentIds) {
       // Get all possible destinations for this agent
       const handoffDestinations = new Set<string>();
       const directDestinations = new Set<string>();
 
       // Check handoff edges for destinations
-      for (const edge of this.handoffEdges) {
+      for (const edge of handoffEdges) {
         const sources = Array.isArray(edge.from) ? edge.from : [edge.from];
         if (sources.includes(agentId) === true) {
           const dests = Array.isArray(edge.to) ? edge.to : [edge.to];
@@ -1302,7 +1317,7 @@ export class MultiAgentGraph extends StandardGraph {
       }
 
       // Check direct edges for destinations
-      for (const edge of this.directEdges) {
+      for (const edge of directEdges) {
         const sources = Array.isArray(edge.from) ? edge.from : [edge.from];
         if (sources.includes(agentId) === true) {
           const dests = Array.isArray(edge.to) ? edge.to : [edge.to];
@@ -1565,15 +1580,8 @@ export class MultiAgentGraph extends StandardGraph {
       });
     }
 
-    /** A summarize-only run also starts at the agent that opted in: one
-     *  reachable only through a handoff would otherwise never run, since its
-     *  predecessors are no-ops. The workflow's own entry points stay, as the
-     *  graph must keep every node reachable; they end without a model call. */
     const startingNodes =
-      this.summarizeOnlyAgentId != null &&
-      !this.startingNodes.has(this.summarizeOnlyAgentId)
-        ? [...this.startingNodes, this.summarizeOnlyAgentId]
-        : this.startingNodes;
+      summarizeOnlyAgentId != null ? [summarizeOnlyAgentId] : this.startingNodes;
     for (const startNode of startingNodes) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       /** @ts-ignore */
@@ -1586,7 +1594,7 @@ export class MultiAgentGraph extends StandardGraph {
      */
     const edgesByDestination = new Map<string, t.GraphEdge[]>();
 
-    for (const edge of this.directEdges) {
+    for (const edge of directEdges) {
       const destinations = Array.isArray(edge.to) ? edge.to : [edge.to];
       for (const destination of destinations) {
         if (!edgesByDestination.has(destination)) {

--- a/src/graphs/MultiAgentGraph.ts
+++ b/src/graphs/MultiAgentGraph.ts
@@ -1565,8 +1565,16 @@ export class MultiAgentGraph extends StandardGraph {
       });
     }
 
-    // Add starting edges for all starting nodes
-    for (const startNode of this.startingNodes) {
+    /** A summarize-only run also starts at the agent that opted in: one
+     *  reachable only through a handoff would otherwise never run, since its
+     *  predecessors are no-ops. The workflow's own entry points stay, as the
+     *  graph must keep every node reachable; they end without a model call. */
+    const startingNodes =
+      this.summarizeOnlyAgentId != null &&
+      !this.startingNodes.has(this.summarizeOnlyAgentId)
+        ? [...this.startingNodes, this.summarizeOnlyAgentId]
+        : this.startingNodes;
+    for (const startNode of startingNodes) {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       /** @ts-ignore */
       builder.addEdge(START, startNode);

--- a/src/graphs/__tests__/Graph.summarizeOnly.test.ts
+++ b/src/graphs/__tests__/Graph.summarizeOnly.test.ts
@@ -1,0 +1,242 @@
+import { Runnable } from '@langchain/core/runnables';
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  AIMessageChunk,
+  HumanMessage,
+  AIMessage,
+} from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type * as t from '@/types';
+import { GraphEvents, Providers } from '@/common';
+import * as init from '@/llm/init';
+import { Run } from '@/run';
+
+const tokenCounter: t.TokenCounter = () => 10;
+
+/** Answers every call with the same text and remembers what it was sent. */
+class RecordingModel extends Runnable<BaseMessage[], AIMessageChunk> {
+  lc_namespace = ['tests'];
+  readonly calls: BaseMessage[][] = [];
+
+  constructor(private readonly reply: string) {
+    super();
+  }
+
+  async invoke(messages: BaseMessage[]): Promise<AIMessageChunk> {
+    this.calls.push(messages);
+    return new AIMessageChunk({ content: this.reply });
+  }
+}
+
+/** A finished conversation: the last message is the assistant's reply. */
+function buildHistory(turns: number): BaseMessage[] {
+  const messages: BaseMessage[] = [];
+  for (let i = 0; i < turns; i++) {
+    messages.push(new HumanMessage(`question ${i}`));
+    messages.push(new AIMessage(`answer ${i}`));
+  }
+  return messages;
+}
+
+const streamConfig = {
+  configurable: { thread_id: 'summarize-only' },
+  streamMode: 'values' as const,
+  version: 'v2' as const,
+};
+
+interface Harness {
+  run: Run<t.IState>;
+  agentModel: RecordingModel;
+  summarizer: RecordingModel;
+  snapshots: t.ContextUsageEvent[];
+  completions: t.SummarizeCompleteEvent[];
+  restore: () => void;
+}
+
+async function createHarness(options: {
+  runId: string;
+  summarizeOnly?: boolean;
+  summarizationEnabled?: boolean;
+  summarizationConfig?: t.SummarizationConfig;
+  withBudget?: boolean;
+}): Promise<Harness> {
+  const snapshots: t.ContextUsageEvent[] = [];
+  const completions: t.SummarizeCompleteEvent[] = [];
+  const withBudget = options.withBudget !== false;
+  const run = await Run.create<t.IState>({
+    runId: options.runId,
+    graphConfig: {
+      type: 'standard',
+      llmConfig: {
+        provider: Providers.ANTHROPIC,
+        disableStreaming: true,
+        streamUsage: false,
+      },
+      ...(withBudget ? { maxContextTokens: 100_000 } : {}),
+      summarizationEnabled: options.summarizationEnabled ?? true,
+      summarizeOnly: options.summarizeOnly ?? true,
+      summarizationConfig: options.summarizationConfig,
+    },
+    returnContent: true,
+    skipCleanup: true,
+    ...(withBudget ? { tokenCounter } : {}),
+    customHandlers: {
+      [GraphEvents.ON_CONTEXT_USAGE]: {
+        handle: (_event: string, data: t.StreamEventData): void => {
+          snapshots.push(data as t.ContextUsageEvent);
+        },
+      },
+      [GraphEvents.ON_SUMMARIZE_COMPLETE]: {
+        handle: (_event: string, data: t.StreamEventData): void => {
+          completions.push(data as t.SummarizeCompleteEvent);
+        },
+      },
+    },
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph to be initialized');
+  }
+  const agentModel = new RecordingModel('the agent must not answer');
+  run.Graph.overrideModel = agentModel;
+  const summarizer = new RecordingModel('CHECKPOINT: everything so far');
+  const spy = jest
+    .spyOn(init, 'initializeModel')
+    .mockReturnValue(
+      summarizer as unknown as ReturnType<typeof init.initializeModel>
+    );
+  return {
+    run,
+    agentModel,
+    summarizer,
+    snapshots,
+    completions,
+    restore: () => spy.mockRestore(),
+  };
+}
+
+describe('summarize-only runs', () => {
+  it('summarizes the whole history and ends without a model call', async () => {
+    const harness = await createHarness({ runId: 'summarize-only-basic' });
+    try {
+      const history = buildHistory(3);
+      await harness.run.processStream({ messages: history }, streamConfig);
+
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(1);
+      /** Every history message plus the summarization instruction. */
+      expect(harness.summarizer.calls[0]).toHaveLength(history.length + 1);
+
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.completions[0].summary?.content?.[0]).toMatchObject({
+        text: 'CHECKPOINT: everything so far',
+      });
+
+      /** Exactly one snapshot: the post-summary state the host persists. */
+      expect(harness.snapshots).toHaveLength(1);
+      expect(harness.snapshots[0].breakdown.summaryTokens).toBeGreaterThan(0);
+      expect(harness.snapshots[0].breakdown.messageCount).toBe(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('keeps only an explicitly configured recency window', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-retain',
+      summarizationConfig: { retainRecent: { turns: 1 } },
+    });
+    try {
+      const history = buildHistory(3);
+      await harness.run.processStream({ messages: history }, streamConfig);
+
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(1);
+      /** The last turn (two messages) stays out of the summary. */
+      expect(harness.summarizer.calls[0]).toHaveLength(history.length - 2 + 1);
+      expect(harness.snapshots).toHaveLength(1);
+      expect(harness.snapshots[0].breakdown.messageCount).toBe(2);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('ends immediately when summarization is not enabled', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-disabled',
+      summarizationEnabled: false,
+    });
+    try {
+      await harness.run.processStream(
+        { messages: buildHistory(2) },
+        streamConfig
+      );
+
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(0);
+      expect(harness.completions).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('requests the summary even without a pruning budget', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-no-budget',
+      withBudget: false,
+    });
+    try {
+      await harness.run.processStream(
+        { messages: buildHistory(2) },
+        streamConfig
+      );
+
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(1);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.snapshots).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('re-arms for the next run on the same graph', async () => {
+    const harness = await createHarness({ runId: 'summarize-only-rearm' });
+    try {
+      await harness.run.processStream(
+        { messages: buildHistory(2) },
+        streamConfig
+      );
+      await harness.run.processStream(
+        { messages: buildHistory(4) },
+        streamConfig
+      );
+
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(2);
+      expect(harness.completions).toHaveLength(2);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('leaves ordinary runs on the trigger path', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-off',
+      summarizeOnly: false,
+    });
+    try {
+      const content = await harness.run.processStream(
+        { messages: [...buildHistory(2), new HumanMessage('one more')] },
+        streamConfig
+      );
+
+      expect(harness.agentModel.calls).toHaveLength(1);
+      expect(harness.summarizer.calls).toHaveLength(0);
+      expect(content).toEqual([
+        { type: 'text', text: 'the agent must not answer' },
+      ]);
+    } finally {
+      harness.restore();
+    }
+  });
+});

--- a/src/graphs/__tests__/Graph.summarizeOnly.test.ts
+++ b/src/graphs/__tests__/Graph.summarizeOnly.test.ts
@@ -67,8 +67,8 @@ interface HarnessOptions {
   summarizationConfig?: t.SummarizationConfig;
   withBudget?: boolean;
   summarizerFailure?: Error;
-  /** A second agent reached by a direct edge from the summarizing one. */
-  successorAgent?: boolean;
+  /** Two agents, `first` and `second`; which one opted in and how they connect. */
+  multiAgent?: { summarizer: 'first' | 'second'; edgeType: 'direct' | 'handoff' };
 }
 
 async function createHarness(options: HarnessOptions): Promise<Harness> {
@@ -86,25 +86,32 @@ async function createHarness(options: HarnessOptions): Promise<Harness> {
     summarizeOnly: options.summarizeOnly ?? true,
     summarizationConfig: options.summarizationConfig,
   };
+  const plainAgent = {
+    provider: Providers.ANTHROPIC,
+    clientOptions: llmConfig,
+    ...(withBudget ? { maxContextTokens: 100_000 } : {}),
+  };
+  const multi = options.multiAgent;
   const graphConfig: t.RunConfig['graphConfig'] =
-    options.successorAgent === true
+    multi != null
       ? {
         type: 'multi-agent',
         agents: [
           {
             agentId: 'first',
-            provider: Providers.ANTHROPIC,
-            clientOptions: llmConfig,
-            ...agentFields,
+            ...plainAgent,
+            ...(multi.summarizer === 'first' ? agentFields : {}),
           },
           {
             agentId: 'second',
-            provider: Providers.ANTHROPIC,
-            clientOptions: llmConfig,
-            ...(withBudget ? { maxContextTokens: 100_000 } : {}),
+            ...plainAgent,
+            ...(multi.summarizer === 'second' ? agentFields : {}),
           },
         ],
-        edges: [{ from: ['first'], to: ['second'], edgeType: 'direct' }],
+        edges:
+            multi.edgeType === 'direct'
+              ? [{ from: ['first'], to: ['second'], edgeType: 'direct' }]
+              : [{ from: 'first', to: 'second', edgeType: 'handoff' }],
       }
       : {
         type: 'standard',
@@ -141,9 +148,7 @@ async function createHarness(options: HarnessOptions): Promise<Harness> {
   );
   const spy = jest
     .spyOn(init, 'initializeModel')
-    .mockReturnValue(
-      summarizer as unknown as ReturnType<typeof init.initializeModel>
-    );
+    .mockReturnValue(summarizer);
   return {
     run,
     agentModel,
@@ -317,10 +322,30 @@ describe('summarize-only runs', () => {
     }
   });
 
+  it('runs a summarizer reachable only through a handoff', async () => {
+    /** The summarizing agent is not one of the workflow's entry points, and
+     *  its predecessor never calls the model to hand off, so the run has to
+     *  start at the agent that opted in. */
+    const harness = await createHarness({
+      runId: 'summarize-only-handoff-target',
+      multiAgent: { summarizer: 'second', edgeType: 'handoff' },
+    });
+    try {
+      await harness.run.processStream({ messages: buildHistory(2) }, streamConfig);
+
+      expect(harness.summarizer.calls).toHaveLength(1);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.completions[0].agentId).toBe('second');
+      expect(harness.agentModel.calls).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
   it('never lets a chained successor agent call the model', async () => {
     const harness = await createHarness({
       runId: 'summarize-only-successor',
-      successorAgent: true,
+      multiAgent: { summarizer: 'first', edgeType: 'direct' },
     });
     try {
       await harness.run.processStream(

--- a/src/graphs/__tests__/Graph.summarizeOnly.test.ts
+++ b/src/graphs/__tests__/Graph.summarizeOnly.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
+import { ManualSummarizationSkippedError } from '@/summarization';
 import { GraphEvents, Providers } from '@/common';
 import * as init from '@/llm/init';
 import { Run } from '@/run';
@@ -18,12 +19,18 @@ class RecordingModel extends Runnable<BaseMessage[], AIMessageChunk> {
   lc_namespace = ['tests'];
   readonly calls: BaseMessage[][] = [];
 
-  constructor(private readonly reply: string) {
+  constructor(
+    private readonly reply: string,
+    private readonly failure?: Error
+  ) {
     super();
   }
 
   async invoke(messages: BaseMessage[]): Promise<AIMessageChunk> {
     this.calls.push(messages);
+    if (this.failure != null) {
+      throw this.failure;
+    }
     return new AIMessageChunk({ content: this.reply });
   }
 }
@@ -53,30 +60,60 @@ interface Harness {
   restore: () => void;
 }
 
-async function createHarness(options: {
+interface HarnessOptions {
   runId: string;
   summarizeOnly?: boolean;
   summarizationEnabled?: boolean;
   summarizationConfig?: t.SummarizationConfig;
   withBudget?: boolean;
-}): Promise<Harness> {
+  summarizerFailure?: Error;
+  /** A second agent reached by a direct edge from the summarizing one. */
+  successorAgent?: boolean;
+}
+
+async function createHarness(options: HarnessOptions): Promise<Harness> {
   const snapshots: t.ContextUsageEvent[] = [];
   const completions: t.SummarizeCompleteEvent[] = [];
   const withBudget = options.withBudget !== false;
+  const llmConfig = {
+    provider: Providers.ANTHROPIC,
+    disableStreaming: true,
+    streamUsage: false,
+  };
+  const agentFields = {
+    ...(withBudget ? { maxContextTokens: 100_000 } : {}),
+    summarizationEnabled: options.summarizationEnabled ?? true,
+    summarizeOnly: options.summarizeOnly ?? true,
+    summarizationConfig: options.summarizationConfig,
+  };
+  const graphConfig: t.RunConfig['graphConfig'] =
+    options.successorAgent === true
+      ? {
+        type: 'multi-agent',
+        agents: [
+          {
+            agentId: 'first',
+            provider: Providers.ANTHROPIC,
+            clientOptions: llmConfig,
+            ...agentFields,
+          },
+          {
+            agentId: 'second',
+            provider: Providers.ANTHROPIC,
+            clientOptions: llmConfig,
+            ...(withBudget ? { maxContextTokens: 100_000 } : {}),
+          },
+        ],
+        edges: [{ from: ['first'], to: ['second'], edgeType: 'direct' }],
+      }
+      : {
+        type: 'standard',
+        llmConfig,
+        ...agentFields,
+      };
   const run = await Run.create<t.IState>({
     runId: options.runId,
-    graphConfig: {
-      type: 'standard',
-      llmConfig: {
-        provider: Providers.ANTHROPIC,
-        disableStreaming: true,
-        streamUsage: false,
-      },
-      ...(withBudget ? { maxContextTokens: 100_000 } : {}),
-      summarizationEnabled: options.summarizationEnabled ?? true,
-      summarizeOnly: options.summarizeOnly ?? true,
-      summarizationConfig: options.summarizationConfig,
-    },
+    graphConfig,
     returnContent: true,
     skipCleanup: true,
     ...(withBudget ? { tokenCounter } : {}),
@@ -98,7 +135,10 @@ async function createHarness(options: {
   }
   const agentModel = new RecordingModel('the agent must not answer');
   run.Graph.overrideModel = agentModel;
-  const summarizer = new RecordingModel('CHECKPOINT: everything so far');
+  const summarizer = new RecordingModel(
+    'CHECKPOINT: everything so far',
+    options.summarizerFailure
+  );
   const spy = jest
     .spyOn(init, 'initializeModel')
     .mockReturnValue(
@@ -140,7 +180,7 @@ describe('summarize-only runs', () => {
     }
   });
 
-  it('keeps only an explicitly configured recency window', async () => {
+  it('keeps an explicitly configured recency window', async () => {
     const harness = await createHarness({
       runId: 'summarize-only-retain',
       summarizationConfig: { retainRecent: { turns: 1 } },
@@ -149,7 +189,6 @@ describe('summarize-only runs', () => {
       const history = buildHistory(3);
       await harness.run.processStream({ messages: history }, streamConfig);
 
-      expect(harness.agentModel.calls).toHaveLength(0);
       expect(harness.summarizer.calls).toHaveLength(1);
       /** The last turn (two messages) stays out of the summary. */
       expect(harness.summarizer.calls[0]).toHaveLength(history.length - 2 + 1);
@@ -160,20 +199,79 @@ describe('summarize-only runs', () => {
     }
   });
 
-  it('ends immediately when summarization is not enabled', async () => {
+  it('keeps the default turn window when the host configured only a token cap', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-retain-tokens',
+      summarizationConfig: { retainRecent: { tokens: 1_000_000 } },
+    });
+    try {
+      const history = buildHistory(4);
+      await harness.run.processStream({ messages: history }, streamConfig);
+
+      expect(harness.summarizer.calls).toHaveLength(1);
+      /** Two default turns (four messages) retained, the rest summarized. */
+      expect(harness.summarizer.calls[0]).toHaveLength(history.length - 4 + 1);
+      expect(harness.snapshots[0].breakdown.messageCount).toBe(4);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('rejects when the configured window already covers the whole conversation', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-nothing',
+      summarizationConfig: { retainRecent: { turns: 5 } },
+    });
+    try {
+      await expect(
+        harness.run.processStream({ messages: buildHistory(2) }, streamConfig)
+      ).rejects.toMatchObject({
+        name: 'ManualSummarizationSkippedError',
+        reason: 'nothing_to_summarize',
+      });
+      expect(harness.summarizer.calls).toHaveLength(0);
+      expect(harness.agentModel.calls).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('rejects when summarization is not enabled', async () => {
     const harness = await createHarness({
       runId: 'summarize-only-disabled',
       summarizationEnabled: false,
     });
     try {
+      await expect(
+        harness.run.processStream({ messages: buildHistory(2) }, streamConfig)
+      ).rejects.toBeInstanceOf(ManualSummarizationSkippedError);
+      expect(harness.agentModel.calls).toHaveLength(0);
+      expect(harness.summarizer.calls).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('keeps the history when every summarizer call fails', async () => {
+    /** With no provider able to summarize, the node would otherwise commit
+     *  the metadata stub as the checkpoint and remove the whole history. */
+    const harness = await createHarness({
+      runId: 'summarize-only-provider-failure',
+      summarizerFailure: new Error('503 summarizer unavailable'),
+    });
+    try {
       await harness.run.processStream(
-        { messages: buildHistory(2) },
+        { messages: buildHistory(3) },
         streamConfig
       );
 
       expect(harness.agentModel.calls).toHaveLength(0);
-      expect(harness.summarizer.calls).toHaveLength(0);
-      expect(harness.completions).toHaveLength(0);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.completions[0].summary).toBeUndefined();
+      expect(harness.completions[0].error).toMatch(/preserved/);
+      expect(
+        harness.run.Graph?.agentContexts.get('default')?.getSummaryText()
+      ).toBeUndefined();
     } finally {
       harness.restore();
     }
@@ -214,6 +312,25 @@ describe('summarize-only runs', () => {
       expect(harness.agentModel.calls).toHaveLength(0);
       expect(harness.summarizer.calls).toHaveLength(2);
       expect(harness.completions).toHaveLength(2);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('never lets a chained successor agent call the model', async () => {
+    const harness = await createHarness({
+      runId: 'summarize-only-successor',
+      successorAgent: true,
+    });
+    try {
+      await harness.run.processStream(
+        { messages: buildHistory(2) },
+        streamConfig
+      );
+
+      expect(harness.summarizer.calls).toHaveLength(1);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.agentModel.calls).toHaveLength(0);
     } finally {
       harness.restore();
     }

--- a/src/graphs/__tests__/Graph.summarizeOnly.test.ts
+++ b/src/graphs/__tests__/Graph.summarizeOnly.test.ts
@@ -11,6 +11,7 @@ import type {
   HookCallback,
   PreCompactHookInput,
   PreCompactHookOutput,
+  StopHookOutput,
 } from '@/hooks/types';
 import type * as t from '@/types';
 import { ManualSummarizationSkippedError } from '@/summarization';
@@ -351,6 +352,8 @@ describe('summarize-only runs', () => {
       expect(harness.completions).toHaveLength(1);
       expect(harness.completions[0].agentId).toBe('second');
       expect(harness.agentModel.calls).toHaveLength(0);
+      /** Root trace identity and Langfuse routing follow the run's agent. */
+      expect(harness.run.Graph?.defaultAgentId).toBe('second');
     } finally {
       harness.restore();
     }
@@ -398,14 +401,26 @@ describe('summarize-only runs', () => {
     /** The state channel outlives the run on a checkpointed thread, and a
      *  later ordinary run or a failed compaction must not report it. */
     const checkpointer = new MemorySaver();
-    const summaryOf = async (): Promise<string | undefined> => {
+    const channelsOf = async (): Promise<{
+      manualSummary?: string;
+      messages?: BaseMessage[];
+    }> => {
       const tuple = await checkpointer.getTuple(streamConfig);
-      return tuple?.checkpoint.channel_values.manualSummary as string | undefined;
+      return (tuple?.checkpoint.channel_values ?? {}) as {
+        manualSummary?: string;
+        messages?: BaseMessage[];
+      };
     };
+    const summaryOf = async (): Promise<string | undefined> =>
+      (await channelsOf()).manualSummary;
     const compaction = await createHarness({ runId: 'summarize-only-ckpt-a', checkpointer });
     try {
       await compaction.run.processStream({ messages: buildHistory(2) }, streamConfig);
-      expect(await summaryOf()).toBe('CHECKPOINT: everything so far');
+      const channels = await channelsOf();
+      expect(channels.manualSummary).toBe('CHECKPOINT: everything so far');
+      /** The outer state is as compacted as the subgraph's: the remove-all
+       *  crossed the node boundary instead of merging the tail back. */
+      expect(channels.messages).toHaveLength(0);
     } finally {
       compaction.restore();
     }
@@ -421,6 +436,8 @@ describe('summarize-only runs', () => {
         streamConfig
       );
       expect(ordinary.agentModel.calls).toHaveLength(1);
+      /** The model sees the compacted thread, not the summarized head. */
+      expect(ordinary.agentModel.calls[0]).toHaveLength(1);
       expect(await summaryOf()).toBe('');
     } finally {
       ordinary.restore();
@@ -437,6 +454,30 @@ describe('summarize-only runs', () => {
       expect(await summaryOf()).toBe('');
     } finally {
       failing.restore();
+    }
+  });
+
+  it('admits no stop continuation once the summary exists', async () => {
+    /** A blocking Stop hook would otherwise start another graph segment,
+     *  which has no claim left to spend and ends without a model call,
+     *  until the continuation budget turns the compaction into an error. */
+    const hooks = new HookRegistry();
+    let stops = 0;
+    const hook: HookCallback<'Stop'> = async (): Promise<StopHookOutput> => {
+      stops += 1;
+      return { decision: 'block', additionalContext: 'Answer the user now.' };
+    };
+    hooks.register('Stop', { hooks: [hook] });
+    const harness = await createHarness({ runId: 'summarize-only-stop-hook', hooks });
+    try {
+      await harness.run.processStream({ messages: buildHistory(2) }, streamConfig);
+
+      expect(stops).toBe(1);
+      expect(harness.summarizer.calls).toHaveLength(1);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.agentModel.calls).toHaveLength(0);
+    } finally {
+      harness.restore();
     }
   });
 

--- a/src/graphs/__tests__/Graph.summarizeOnly.test.ts
+++ b/src/graphs/__tests__/Graph.summarizeOnly.test.ts
@@ -1,4 +1,5 @@
 import { Runnable } from '@langchain/core/runnables';
+import { MemorySaver } from '@langchain/langgraph';
 import { describe, expect, it, jest } from '@jest/globals';
 import {
   AIMessageChunk,
@@ -6,8 +7,14 @@ import {
   AIMessage,
 } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  HookCallback,
+  PreCompactHookInput,
+  PreCompactHookOutput,
+} from '@/hooks/types';
 import type * as t from '@/types';
 import { ManualSummarizationSkippedError } from '@/summarization';
+import { HookRegistry } from '@/hooks/HookRegistry';
 import { GraphEvents, Providers } from '@/common';
 import * as init from '@/llm/init';
 import { Run } from '@/run';
@@ -69,6 +76,9 @@ interface HarnessOptions {
   summarizerFailure?: Error;
   /** Two agents, `first` and `second`; which one opted in and how they connect. */
   multiAgent?: { summarizer: 'first' | 'second'; edgeType: 'direct' | 'handoff' };
+  /** Shared across harnesses to replay a checkpointed thread. */
+  checkpointer?: MemorySaver;
+  hooks?: HookRegistry;
 }
 
 async function createHarness(options: HarnessOptions): Promise<Harness> {
@@ -118,9 +128,13 @@ async function createHarness(options: HarnessOptions): Promise<Harness> {
         llmConfig,
         ...agentFields,
       };
+  if (options.checkpointer != null) {
+    graphConfig.compileOptions = { checkpointer: options.checkpointer };
+  }
   const run = await Run.create<t.IState>({
     runId: options.runId,
     graphConfig,
+    hooks: options.hooks,
     returnContent: true,
     skipCleanup: true,
     ...(withBudget ? { tokenCounter } : {}),
@@ -339,6 +353,90 @@ describe('summarize-only runs', () => {
       expect(harness.agentModel.calls).toHaveLength(0);
     } finally {
       harness.restore();
+    }
+  });
+
+  it('compiles a direct-edge target to the summarizer alone', async () => {
+    /** With the ordinary routing kept, the target would run once from START
+     *  and again when its predecessor completed. */
+    const harness = await createHarness({
+      runId: 'summarize-only-direct-target',
+      multiAgent: { summarizer: 'second', edgeType: 'direct' },
+    });
+    try {
+      await harness.run.processStream({ messages: buildHistory(2) }, streamConfig);
+
+      expect(harness.summarizer.calls).toHaveLength(1);
+      expect(harness.completions).toHaveLength(1);
+      expect(harness.snapshots).toHaveLength(1);
+      expect(harness.agentModel.calls).toHaveLength(0);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('reports a manual trigger to PreCompact hooks', async () => {
+    const hooks = new HookRegistry();
+    let captured: PreCompactHookInput | undefined;
+    const hook: HookCallback<'PreCompact'> = async (input): Promise<PreCompactHookOutput> => {
+      captured = input;
+      return {};
+    };
+    hooks.register('PreCompact', { hooks: [hook] });
+    const harness = await createHarness({ runId: 'summarize-only-hook', hooks });
+    try {
+      await harness.run.processStream({ messages: buildHistory(2) }, streamConfig);
+
+      expect(captured?.trigger).toBe('manual');
+      expect(captured?.messagesBeforeCount).toBe(4);
+    } finally {
+      harness.restore();
+    }
+  });
+
+  it('clears a checkpointed summary once a later run starts', async () => {
+    /** The state channel outlives the run on a checkpointed thread, and a
+     *  later ordinary run or a failed compaction must not report it. */
+    const checkpointer = new MemorySaver();
+    const summaryOf = async (): Promise<string | undefined> => {
+      const tuple = await checkpointer.getTuple(streamConfig);
+      return tuple?.checkpoint.channel_values.manualSummary as string | undefined;
+    };
+    const compaction = await createHarness({ runId: 'summarize-only-ckpt-a', checkpointer });
+    try {
+      await compaction.run.processStream({ messages: buildHistory(2) }, streamConfig);
+      expect(await summaryOf()).toBe('CHECKPOINT: everything so far');
+    } finally {
+      compaction.restore();
+    }
+
+    const ordinary = await createHarness({
+      runId: 'summarize-only-ckpt-b',
+      summarizeOnly: false,
+      checkpointer,
+    });
+    try {
+      await ordinary.run.processStream(
+        { messages: [new HumanMessage('a later question')] },
+        streamConfig
+      );
+      expect(ordinary.agentModel.calls).toHaveLength(1);
+      expect(await summaryOf()).toBe('');
+    } finally {
+      ordinary.restore();
+    }
+
+    const failing = await createHarness({
+      runId: 'summarize-only-ckpt-c',
+      checkpointer,
+      summarizerFailure: new Error('503 summarizer unavailable'),
+    });
+    try {
+      await failing.run.processStream({ messages: buildHistory(1) }, streamConfig);
+      expect(failing.completions[0].error).toMatch(/preserved/);
+      expect(await summaryOf()).toBe('');
+    } finally {
+      failing.restore();
     }
   });
 

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -252,13 +252,16 @@ export interface PreCompactHookInput extends BaseHookInput {
   /**
    * What triggered compaction. Matches `SummarizationTrigger.type` from the
    * agent's summarization config. `'default'` means no trigger was
-   * configured and compaction fired because messages were pruned.
+   * configured and compaction fired because messages were pruned;
+   * `'manual'` means the host asked for the summary outright and no trigger
+   * was evaluated.
    */
   trigger:
     | 'token_ratio'
     | 'remaining_tokens'
     | 'messages_to_refine'
     | 'default'
+    | 'manual'
     | (string & {});
 }
 

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -547,8 +547,10 @@ function shapeConversationPayload(span: MutableSpan): void {
     'user'
   );
   const output = parseAttributeValue(span.attributes[outputKey]);
+  /** A summarize-only run's summary is its answer; any assistant message
+   *  still in state is an older reply the run retained, not its output. */
   const answer =
-    findLastMessageText(output, 'assistant') ?? getManualSummary(output);
+    getManualSummary(output) ?? findLastMessageText(output, 'assistant');
   /** A generation that IS the trace root — a bare `model.invoke` with no
    *  wrapping chain, i.e. the activity-label path — is also the only
    *  observation carrying its own prompt: reducing its observation input

--- a/src/langfuseTraceShaping.ts
+++ b/src/langfuseTraceShaping.ts
@@ -246,6 +246,18 @@ function findLastMessageText(value: unknown, role: string): string | undefined {
   return undefined;
 }
 
+/**
+ * A summarize-only run answers with its summary, carried in state as
+ * `manualSummary`, rather than with an assistant message.
+ */
+function getManualSummary(value: unknown): string | undefined {
+  if (!isRecord(value) || typeof value.manualSummary !== 'string') {
+    return undefined;
+  }
+  const text = value.manualSummary.trim();
+  return text === '' ? undefined : text;
+}
+
 function normalizeToolCall(value: unknown): SerializedToolCall | undefined {
   if (!isRecord(value)) {
     return undefined;
@@ -534,10 +546,9 @@ function shapeConversationPayload(span: MutableSpan): void {
     parseAttributeValue(span.attributes[inputKey]),
     'user'
   );
-  const answer = findLastMessageText(
-    parseAttributeValue(span.attributes[outputKey]),
-    'assistant'
-  );
+  const output = parseAttributeValue(span.attributes[outputKey]);
+  const answer =
+    findLastMessageText(output, 'assistant') ?? getManualSummary(output);
   /** A generation that IS the trace root — a bare `model.invoke` with no
    *  wrapping chain, i.e. the activity-label path — is also the only
    *  observation carrying its own prompt: reducing its observation input

--- a/src/run.ts
+++ b/src/run.ts
@@ -1584,11 +1584,17 @@ export class Run<_T extends t.BaseGraphState> {
           }).catch((): undefined => undefined);
         }
 
+        /** A summarize-only run is complete once its summary exists: there
+         *  is no assistant reply for a Stop hook to demand, and its one
+         *  summarization claim is spent, so it admits no continuation. */
+        const continuationAdmissible = graph.summarizeOnlyAgentId == null;
         if (this.hookRegistry?.hasHookFor('StopFinalize', this.id) === true) {
           const stopInjected =
             stopResult == null ? [] : materializeStopContinuation(stopResult);
           const continuationPrevented =
-            stopReason != null || stopResult?.preventContinuation === true;
+            !continuationAdmissible ||
+            stopReason != null ||
+            stopResult?.preventContinuation === true;
           const finalized = await executeHooks({
             registry: this.hookRegistry,
             input: {
@@ -1622,7 +1628,9 @@ export class Run<_T extends t.BaseGraphState> {
         }
 
         const requestsContinuation =
-          stopReason == null && stopResult?.stopDecision === 'block';
+          continuationAdmissible &&
+          stopReason == null &&
+          stopResult?.stopDecision === 'block';
         if (requestsContinuation && stopResult != null) {
           const injected = materializeStopContinuation(stopResult);
           if (injected.length > 0) {

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -779,3 +779,37 @@ describe('shapeLangfuseSpan', () => {
     expect(span.attributes[DEPRECATED_TRACE_INPUT]).toBeUndefined();
   });
 });
+
+describe('shapeLangfuseSpan summarize-only output', () => {
+  it('reports the manual summary as the root output when no assistant replied', () => {
+    /** A summarize-only run ends with the retained tail (or nothing) in
+     *  state and no assistant message; the summary is its answer. */
+    const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+      [INPUT]: JSON.stringify({
+        messages: [{ type: 'human', content: 'Compact this conversation' }],
+      }),
+      [OUTPUT]: JSON.stringify({
+        messages: [],
+        manualSummary: 'CHECKPOINT: the user asked about ClickHouse.',
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[OUTPUT]).toBe(
+      'CHECKPOINT: the user asked about ClickHouse.'
+    );
+  });
+
+  it('prefers a real assistant reply over the summary channel', () => {
+    const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+      [INPUT]: JSON.stringify({ messages: [{ type: 'human', content: 'hi' }] }),
+      [OUTPUT]: JSON.stringify({
+        messages: [{ type: 'ai', content: 'A real answer.' }],
+        manualSummary: 'stale summary',
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[OUTPUT]).toBe('A real answer.');
+  });
+});

--- a/src/specs/langfuse-trace-shaping.test.ts
+++ b/src/specs/langfuse-trace-shaping.test.ts
@@ -800,13 +800,28 @@ describe('shapeLangfuseSpan summarize-only output', () => {
     );
   });
 
-  it('prefers a real assistant reply over the summary channel', () => {
+  it('prefers the summary over an older reply the run retained', () => {
+    /** With an explicit recency window the tail stays in state, so the last
+     *  assistant message is history, not the compaction's result. */
+    const span = createSpan('LibreChat Agent', {
+      [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
+      [INPUT]: JSON.stringify({ messages: [{ type: 'human', content: 'hi' }] }),
+      [OUTPUT]: JSON.stringify({
+        messages: [{ type: 'ai', content: 'An older retained reply.' }],
+        manualSummary: 'CHECKPOINT: the compaction result.',
+      }),
+    });
+    shapeLangfuseSpan(span);
+    expect(span.attributes[OUTPUT]).toBe('CHECKPOINT: the compaction result.');
+  });
+
+  it('ignores an empty summary channel', () => {
     const span = createSpan('LibreChat Agent', {
       [TRACE_TAGS]: JSON.stringify(['librechat', 'agent']),
       [INPUT]: JSON.stringify({ messages: [{ type: 'human', content: 'hi' }] }),
       [OUTPUT]: JSON.stringify({
         messages: [{ type: 'ai', content: 'A real answer.' }],
-        manualSummary: 'stale summary',
+        manualSummary: '   ',
       }),
     });
     shapeLangfuseSpan(span);

--- a/src/summarization/index.ts
+++ b/src/summarization/index.ts
@@ -9,7 +9,9 @@ export {
   buildSummarizationInstruction,
   buildSummaryCarrierText,
   separateSummarizationParameters,
+  ManualSummarizationSkippedError,
 } from './shared';
+export type { ManualSummarizationSkipReason } from './shared';
 
 const VALID_TRIGGER_TYPES = [
   'token_ratio',

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -14,6 +14,7 @@ import {
   buildSummaryCarrierText,
   separateSummarizationParameters,
   buildSummarizationInstruction,
+  ManualSummarizationSkippedError,
 } from './shared';
 import {
   addTailCacheControl,
@@ -1026,6 +1027,14 @@ function findStreamLimitAbortReason(
   return undefined;
 }
 
+/** Wording for the history-preserved log and completion, by request reason. */
+const PRESERVATION_REASONS: Partial<
+  Record<NonNullable<t.SummarizationNodeInput['reason']>, string>
+> = {
+  overflow: 'overflow recovery',
+  manual: 'manual compaction',
+};
+
 export function createSummarizeNode({
   agentContext,
   graph: adapterGraph,
@@ -1037,7 +1046,11 @@ export function createSummarizeNode({
       summarizationRequest?: t.SummarizationNodeInput;
     },
     config?: RunnableConfig
-  ): Promise<{ summarizationRequest: undefined; messages?: BaseMessage[] }> => {
+  ): Promise<{
+    summarizationRequest: undefined;
+    messages?: BaseMessage[];
+    manualSummary?: string;
+  }> => {
     /** The breaker signal is captured at node ENTRY, before dispatchRunStep,
      * ON_SUMMARIZE_START, or PreCompact awaits: a sibling's trip plus a
      * prompt next run can reset the controller during one of those awaits,
@@ -1114,6 +1127,12 @@ export function createSummarizeNode({
      * its recursion budget dispatching empty summary steps.
      */
     if (agentContext.summarizationExhausted) {
+      if (request.reason === 'manual') {
+        throw new ManualSummarizationSkippedError(
+          'exhausted',
+          'Compaction skipped: consecutive summarization attempts produced no usable summary'
+        );
+      }
       emitAgentLog(
         config,
         'warn',
@@ -1131,6 +1150,12 @@ export function createSummarizeNode({
 
     const maxCtx = agentContext.maxContextTokens ?? 0;
     if (maxCtx > 0 && agentContext.instructionTokens >= maxCtx) {
+      if (request.reason === 'manual') {
+        throw new ManualSummarizationSkippedError(
+          'instructions_exceed_budget',
+          'Compaction skipped: instructions and tool definitions exceed the context budget'
+        );
+      }
       emitAgentLog(
         config,
         'warn',
@@ -1169,12 +1194,13 @@ export function createSummarizeNode({
     const retainRecent = agentContext.summarizationConfig?.retainRecent;
     /**
      * A manual summary is the user asking for the whole history to become a
-     * checkpoint, so the default recency window does not apply to it: only
-     * a `retainRecent` the host configured explicitly keeps a tail.
+     * checkpoint, so the default recency window does not apply to it. A
+     * `retainRecent` the host configured explicitly still keeps its tail,
+     * with the ordinary turn default when it only sets a token cap.
      */
     const retainTurns =
-      request.reason === 'manual'
-        ? (retainRecent?.turns ?? 0)
+      request.reason === 'manual' && retainRecent == null
+        ? 0
         : (retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS);
     const recencyTokenCounter =
       agentContext.contextPressureTokenCounts?.count ??
@@ -1207,6 +1233,12 @@ export function createSummarizeNode({
     const messagesToRetain = state.messages.slice(tailStartIndex);
 
     if (messagesToRefine.length === 0) {
+      if (request.reason === 'manual') {
+        throw new ManualSummarizationSkippedError(
+          'nothing_to_summarize',
+          'Nothing to compact: the retained recent turns cover the whole conversation'
+        );
+      }
       /**
        * Recency window covers the entire conversation — there is no
        * older content to summarize.  Skipping prevents the model from
@@ -1407,19 +1439,21 @@ export function createSummarizeNode({
     /**
      * The metadata stub describes the history rather than summarizing it, so
      * committing it means removing the head and keeping nothing of what it
-     * said. That trade is never worth making to paper over an overflow: the
-     * recovery would "succeed" only by destroying the conversation it was
-     * supposed to preserve. Leave state untouched and let the provider error
-     * surface instead.
+     * said. That trade is never worth making to paper over an overflow, and
+     * never for a manual compaction, which would replace the whole history
+     * with a message count: the recovery would "succeed" only by destroying
+     * the conversation it was supposed to preserve. Leave state untouched
+     * and let the provider error surface instead.
      */
     if (
       usedMetadataStub === true &&
-      (request.reason === 'overflow' || usedIntraTurnFallback)
+      (request.reason === 'overflow' ||
+        request.reason === 'manual' ||
+        usedIntraTurnFallback)
     ) {
       const preservationReason =
-        request.reason === 'overflow'
-          ? 'overflow recovery'
-          : 'intra-turn compaction';
+        PRESERVATION_REASONS[request.reason ?? 'trigger'] ??
+        'intra-turn compaction';
       log(
         'warn',
         `Summarization failed during ${preservationReason}; keeping history rather than replacing it with a metadata stub`
@@ -1579,6 +1613,8 @@ export function createSummarizeNode({
         messagesToRetain.length > 0
           ? [createRemoveAllMessage(), ...messagesToRetain]
           : [createRemoveAllMessage()],
+      /** The run's result, for trace roots that otherwise see no reply. */
+      ...(request.reason === 'manual' ? { manualSummary: summaryText } : {}),
     };
   };
 }

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1331,7 +1331,10 @@ export function createSummarizeNode({
           threadId,
           agentId: request.agentId,
           messagesBeforeCount: messagesToRefine.length,
-          trigger: agentContext.summarizationConfig?.trigger?.type ?? 'default',
+          trigger:
+            request.reason === 'manual'
+              ? 'manual'
+              : (agentContext.summarizationConfig?.trigger?.type ?? 'default'),
         },
         sessionId,
       }).catch(() => {

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1167,6 +1167,15 @@ export function createSummarizeNode({
     const runnableConfig = config ?? graph.config;
 
     const retainRecent = agentContext.summarizationConfig?.retainRecent;
+    /**
+     * A manual summary is the user asking for the whole history to become a
+     * checkpoint, so the default recency window does not apply to it: only
+     * a `retainRecent` the host configured explicitly keeps a tail.
+     */
+    const retainTurns =
+      request.reason === 'manual'
+        ? (retainRecent?.turns ?? 0)
+        : (retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS);
     const recencyTokenCounter =
       agentContext.contextPressureTokenCounts?.count ??
       agentContext.tokenCounter;
@@ -1175,7 +1184,7 @@ export function createSummarizeNode({
       tailStartIndex,
       usedIntraTurnFallback,
     } = splitAtRecencyBoundary(restoredMessages, {
-      turns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+      turns: retainTurns,
       tokens: retainRecent?.tokens,
       tokenCounter: recencyTokenCounter,
       intraTurnTokens: resolveIntraTurnRetainTokens({
@@ -1213,7 +1222,7 @@ export function createSummarizeNode({
         'Summarization skipped — recency window retains all messages',
         {
           messagesRetained: messagesToRetain.length,
-          retainTurns: retainRecent?.turns ?? DEFAULT_RETAIN_RECENT_TURNS,
+          retainTurns,
         },
         { runId: graph.runId, agentId: request.agentId }
       );

--- a/src/summarization/shared.ts
+++ b/src/summarization/shared.ts
@@ -128,3 +128,26 @@ export function buildSummarizationInstruction(
   }
   return parts.join('');
 }
+
+/** Why a summarize-only run could not attempt its summary. */
+export type ManualSummarizationSkipReason =
+  | 'disabled'
+  | 'exhausted'
+  | 'instructions_exceed_budget'
+  | 'nothing_to_summarize';
+
+/**
+ * A summarize-only run asked for a summary the graph could not attempt.
+ * Thrown rather than ending the run quietly: the summary is the whole result
+ * of such a run, so a host left with neither a summary nor an error would
+ * have nothing to show the user.
+ */
+export class ManualSummarizationSkippedError extends Error {
+  readonly reason: ManualSummarizationSkipReason;
+
+  constructor(reason: ManualSummarizationSkipReason, message: string) {
+    super(message);
+    this.name = 'ManualSummarizationSkippedError';
+    this.reason = reason;
+  }
+}

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -84,7 +84,8 @@ export type BaseGraphState = {
   /**
    * The summary a summarize-only run produced. Kept in state because such a
    * run has no assistant reply: trace roots report it as the run's output
-   * instead of the retained tail or the raw state.
+   * instead of the retained tail or the raw state. Empty once any later run
+   * on the same checkpointed thread starts, so it never outlives its run.
    */
   manualSummary?: string;
 };

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -921,9 +921,9 @@ interface AgentInputFields {
    * is the whole response. Requires `summarizationEnabled`: a run that cannot
    * attempt the summary rejects with `ManualSummarizationSkippedError`
    * rather than ending with nothing, and one whose provider calls all fail
-   * keeps the history and reports the failure on the summary step. In a
-   * multi-agent graph only the agent that opted in runs; every successor is
-   * a no-op.
+   * keeps the history and reports the failure on the summary step. A
+   * multi-agent workflow compiles to the agent that opted in alone; no other
+   * agent runs.
    */
   summarizeOnly?: boolean;
   summarizationConfig?: SummarizationConfig;

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -906,6 +906,15 @@ interface AgentInputFields {
    */
   discoveredTools?: string[];
   summarizationEnabled?: boolean;
+  /**
+   * Runs this agent as a summarize-only pass: the first model step requests
+   * summarization outright instead of consulting the trigger, and the step
+   * after the summary emits its context snapshot and ends the run without a
+   * model call. Hosts use it for user-initiated compaction, where the summary
+   * is the whole response. Requires `summarizationEnabled`; with it off the
+   * run ends immediately and produces nothing.
+   */
+  summarizeOnly?: boolean;
   summarizationConfig?: SummarizationConfig;
   /**
    * Optional host-supplied, user-visible guidance for compaction. The SDK

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -81,6 +81,12 @@ export type SystemCallbacks = {
 export type BaseGraphState = {
   messages: BaseMessage[];
   runStepState?: RunStepResumeState;
+  /**
+   * The summary a summarize-only run produced. Kept in state because such a
+   * run has no assistant reply: trace roots report it as the run's output
+   * instead of the retained tail or the raw state.
+   */
+  manualSummary?: string;
 };
 
 export type AgentSubgraphState = BaseGraphState & {
@@ -911,8 +917,12 @@ interface AgentInputFields {
    * summarization outright instead of consulting the trigger, and the step
    * after the summary emits its context snapshot and ends the run without a
    * model call. Hosts use it for user-initiated compaction, where the summary
-   * is the whole response. Requires `summarizationEnabled`; with it off the
-   * run ends immediately and produces nothing.
+   * is the whole response. Requires `summarizationEnabled`: a run that cannot
+   * attempt the summary rejects with `ManualSummarizationSkippedError`
+   * rather than ending with nothing, and one whose provider calls all fail
+   * keeps the history and reports the failure on the summary step. In a
+   * multi-agent graph only the agent that opted in runs; every successor is
+   * a no-op.
    */
   summarizeOnly?: boolean;
   summarizationConfig?: SummarizationConfig;

--- a/src/types/summarize.ts
+++ b/src/types/summarize.ts
@@ -127,8 +127,11 @@ export interface SummarizationNodeInput {
    *   is compacting to recover. When summarization is not enabled, this
    *   variant performs no model call — the corrected budget alone is what the
    *   retry needs.
+   * - `manual`: the host asked for a summary outright (a summarize-only run).
+   *   The recency window is not applied unless the host configured
+   *   `retainRecent` explicitly, so the summary replaces the whole history.
    */
-  reason?: 'trigger' | 'overflow';
+  reason?: 'trigger' | 'overflow' | 'manual';
   /**
    * Whether an overflow recovery may spend a summarization model call.
    *


### PR DESCRIPTION
## Summary

Adds a `summarizeOnly` agent input for host-initiated compaction. A summarize-only run requests summarization outright on its first model step instead of consulting the configured trigger, and the step after the summary dispatches the post-summary `ON_CONTEXT_USAGE` snapshot and ends the run without ever calling the model. The summary run step and its completion events are exactly what the automatic detour already emits, so a host that persists those today gets manual compaction with no new event contract.

Two rules specific to a summary the user asked for:

- The request carries `reason: 'manual'`, and the summarize node does not apply the default recency window to it: the whole history becomes the checkpoint unless the host configured `retainRecent` explicitly, in which case that tail is kept.
- With summarization not enabled, the run ends immediately with no model work.

The claim is reset per run, so a graph can be reused for a second compaction. Everything else (trigger path, overflow recovery, ordinary runs) is untouched; the new code returns early for every run that did not opt in.

Consumer: LibreChat's manual "Compact context" action (replaces the approach in danny-avila/LibreChat#15089).

## Testing

`src/graphs/__tests__/Graph.summarizeOnly.test.ts` runs real `Run` graphs with a recording agent model (asserted never called) and a stubbed summarizer, and covers: the whole history summarized with a single post-summary snapshot, an explicit `retainRecent` window kept, summarization disabled, no pruning budget, re-arming across two runs on one graph, and an ordinary run left on the trigger path.

```
jest src/graphs/__tests__/Graph.summarizeOnly.test.ts   6 passed
jest src/summarization src/graphs/__tests__/Graph.contextOverflow.test.ts src/agents
  253 passed, 1 failed (pre-existing on main: "projects unsafe tool-call args", toJSON count 12 vs 0)
tsc --noEmit -p tsconfig.json   clean
eslint on changed files          clean
```
