### PR TITLE
🧱 refactor: Centralize Provider Tool Message Taxonomy

### DIFF
--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -328,6 +328,31 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     });
   });
 
+  it.each(['model', 'ai', 'supervisor'])(
+    'treats a generic %s-role message as the model turn, as Google does',
+    (role) => {
+      const usage = snapshot();
+      const invocation = new ChatMessage({
+        role,
+        content: '',
+        additional_kwargs: {
+          function_call: { name: 'gemini_lookup', arguments: '{}' },
+        },
+      });
+
+      syncBudgetDerivedFields(
+        usage,
+        [invocation, new FunctionMessage({ content: 'result', name: '' })],
+        () => 10
+      );
+
+      expect(usage.breakdown.toolMessageTokens).toBe(20);
+      expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+        gemini_lookup: 10,
+      });
+    }
+  );
+
   it('leaves non-assistant generic messages in the conversation share', () => {
     const usage = snapshot();
     const bystander = new ChatMessage({ role: 'user', content: 'aside' });
@@ -489,6 +514,68 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     });
   });
 
+  it('rounds an approximate counter instead of dropping the share', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'approx', name: 'lookup', args: {} }],
+      }),
+      toolResult('approx'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 12.5);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(26);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 13 });
+  });
+
+  it('attributes a reused call id to the call it currently answers', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'reused', name: 'first_tool', args: {} }],
+      }),
+      toolResult('reused'),
+      new HumanMessage('next'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'reused', name: 'second_tool', args: {} }],
+      }),
+      toolResult('reused'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      first_tool: 10,
+      second_tool: 10,
+    });
+  });
+
+  it('forgets an unanswered call at the next user turn', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'dangling', name: 'abandoned_tool', args: {} }],
+      }),
+      new HumanMessage('never mind, do this instead'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'dangling', name: 'current_tool', args: {} }],
+      }),
+      toolResult('dangling'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({
+      current_tool: 10,
+    });
+  });
+
   it('distinguishes a known zero share from an unavailable counter', () => {
     const known = snapshot();
     syncBudgetDerivedFields(known, [new HumanMessage('hello')], () => 10);
@@ -529,7 +616,6 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
           Number.NaN,
           Number.POSITIVE_INFINITY,
           -1,
-          0.5,
           Number.MAX_SAFE_INTEGER + 1,
         ]) {
           const usage = snapshot();

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -215,6 +215,27 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ local_tool: 10 });
   });
 
+  it('counts a Google code-execution exchange as a tool-only invocation', () => {
+    const usage = snapshot();
+    const turn = new AIMessage({
+      content: toLangChainContent([
+        {
+          type: 'executableCode',
+          executableCode: { language: 'PYTHON', code: 'print(1)' },
+        },
+        {
+          type: 'codeExecutionResult',
+          codeExecutionResult: { outcome: 'OUTCOME_OK', output: '1' },
+        },
+      ]),
+    });
+
+    syncBudgetDerivedFields(usage, [turn, new AIMessage('answer')], () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
+    expect(usage.breakdown.toolMessageTokenCounts).toBeUndefined();
+  });
+
   it('attributes a user turn made only of tool results', () => {
     const usage = snapshot();
     const messages = [

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -626,8 +626,23 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
     syncBudgetDerivedFields(usage, messages, () => 12.5);
 
-    expect(usage.breakdown.toolMessageTokens).toBe(26);
+    expect(usage.breakdown.toolMessageTokens).toBe(25);
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 13 });
+  });
+
+  it('keeps sub-token amounts through aggregation like the pruning path', () => {
+    const usage = snapshot();
+    const messages = [
+      toolResult('a', 'lookup'),
+      toolResult('b', 'lookup'),
+      toolResult('c', 'lookup'),
+      toolResult('d', 'lookup'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 0.25);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(1);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 1 });
   });
 
   it('attributes a reused call id to the call it currently answers', () => {

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -77,7 +77,6 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
   it.each([
     { type: 'text', text: 'explaining the result' },
-    { type: 'thinking', thinking: 'private reasoning' },
     {
       type: 'image_url',
       image_url: { url: 'https://example.com/image.png' },
@@ -99,6 +98,129 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
     expect(usage.breakdown.toolMessageTokens).toBe(10);
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ read_file: 10 });
+  });
+
+  it.each([
+    { type: 'thinking', thinking: 'private reasoning', signature: 'sig' },
+    { type: 'redacted_thinking', data: 'opaque' },
+    { type: 'reasoning_content', reasoningText: { text: 'bedrock' } },
+    { type: 'reasoning', reasoning: 'google' },
+    { type: 'think', think: 'librechat' },
+  ])('keeps $type reasoning with the tool-only turn it precedes', (part) => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          part,
+          { type: 'tool_use', id: 'reasoned', name: 'read_file', input: {} },
+        ]),
+        tool_calls: [{ id: 'reasoned', name: 'read_file', args: {} }],
+      }),
+      toolResult('reasoned'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ read_file: 10 });
+  });
+
+  it('counts an Anthropic server-tool turn as a tool-only invocation', () => {
+    const usage = snapshot();
+    const turn = new AIMessage({
+      content: toLangChainContent([
+        {
+          type: 'server_tool_use',
+          id: 'srvtoolu_1',
+          name: 'web_search',
+          input: { query: 'retained' },
+        },
+        {
+          type: 'web_search_tool_result',
+          tool_use_id: 'srvtoolu_1',
+          content: {
+            type: 'web_search_tool_result_error',
+            error_code: 'max_uses_exceeded',
+          },
+        },
+      ]),
+    });
+
+    syncBudgetDerivedFields(usage, [turn, new AIMessage('answer')], () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
+    expect(usage.breakdown.toolMessageTokenCounts).toBeUndefined();
+  });
+
+  it('counts an MCP connector turn as a tool-only invocation', () => {
+    const usage = snapshot();
+    const turn = new AIMessage({
+      content: toLangChainContent([
+        {
+          type: 'mcp_tool_use',
+          id: 'mcptoolu_1',
+          name: 'search',
+          input: {},
+          server_name: 'docs',
+        },
+        {
+          type: 'mcp_tool_result',
+          tool_use_id: 'mcptoolu_1',
+          content: 'found',
+          is_error: false,
+        },
+      ]),
+    });
+
+    syncBudgetDerivedFields(usage, [turn], () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
+  });
+
+  it('attributes a user turn made only of tool results', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          { id: 'split-a', name: 'lookup', args: {} },
+          { id: 'split-b', name: 'lookup', args: {} },
+        ],
+      }),
+      new HumanMessage({
+        content: toLangChainContent([
+          { type: 'tool_result', tool_use_id: 'split-a', content: 'first' },
+          { type: 'tool_result', tool_use_id: 'split-b', content: 'second' },
+        ]),
+      }),
+      new HumanMessage({
+        content: toLangChainContent([
+          { type: 'tool_result', tool_use_id: 'split-a', content: 'again' },
+          { type: 'text', text: 'and my question' },
+        ]),
+      }),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
+  });
+
+  it('counts generic tool-role results', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'generic-result', name: 'lookup', args: {} }],
+      }),
+      new ChatMessage({ role: 'tool', content: 'result', name: 'lookup' }),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(20);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
   });
 
   it('counts whitespace-only inline invocations without structured calls', () => {
@@ -143,7 +265,12 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
       content: toLangChainContent([
         {
           type: 'tool_call',
-          tool_call: { type: 'tool_call', id: 'nested', name: 'lookup' },
+          tool_call: {
+            type: 'tool_call',
+            id: 'nested',
+            name: 'lookup',
+            args: {},
+          },
         },
       ]),
     });
@@ -158,7 +285,7 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
   });
 
-  it('keeps a mirrored structured name over an inline standard block', () => {
+  it('does not guess between conflicting names for one call id', () => {
     const usage = snapshot();
     const invocation = new AIMessage({
       content: toLangChainContent([
@@ -175,7 +302,7 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
     expect(usage.breakdown.toolMessageTokens).toBe(20);
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({
-      structured_name: 10,
+      unknown_tool: 10,
     });
   });
 

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -11,7 +11,12 @@ import type { RunnableConfig } from '@langchain/core/runnables';
 import type { AgentLogEvent } from '@/types';
 import type * as t from '@/types';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { stampSyntheticProviderMessage } from './provenance';
 import { GraphEvents } from '@/common';
+import {
+  compactSyntheticProviderContextMessage,
+  foldToolBlocksForToollessAgent,
+} from './format';
 import { toLangChainContent } from './langchain';
 import { syncBudgetDerivedFields } from './budget';
 
@@ -177,6 +182,39 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(usage.breakdown.toolMessageTokens).toBe(10);
   });
 
+  it('consumes an inline provider result so its id can be reused later', () => {
+    const usage = snapshot();
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'mcp_tool_use',
+            id: 'shared-id',
+            name: 'connector_search',
+            input: {},
+            server_name: 'docs',
+          },
+          {
+            type: 'mcp_tool_result',
+            tool_use_id: 'shared-id',
+            content: 'found',
+            is_error: false,
+          },
+        ]),
+      }),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'shared-id', name: 'local_tool', args: {} }],
+      }),
+      toolResult('shared-id'),
+    ];
+
+    syncBudgetDerivedFields(usage, messages, () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(30);
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ local_tool: 10 });
+  });
+
   it('attributes a user turn made only of tool results', () => {
     const usage = snapshot();
     const messages = [
@@ -205,6 +243,47 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
     expect(usage.breakdown.toolMessageTokens).toBe(20);
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 10 });
+  });
+
+  it('counts tool history a tool-less destination received folded into a user turn', () => {
+    const folded = foldToolBlocksForToollessAgent([
+      new HumanMessage('question'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'folded', name: 'lookup', args: { q: 'x' } }],
+      }),
+      new ToolMessage({
+        content: 'r'.repeat(400),
+        tool_call_id: 'folded',
+        name: 'lookup',
+      }),
+      new AIMessage('done'),
+    ]);
+    expect(folded).toHaveLength(3);
+
+    const usage = snapshot();
+    syncBudgetDerivedFields(usage, folded, () => 10);
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
+    expect(usage.breakdown.toolMessageTokenCounts).toBeUndefined();
+
+    const compacted = folded.map((message) =>
+      message.getType() === 'human' && message !== folded[0]
+        ? compactSyntheticProviderContextMessage(message as HumanMessage, 80)
+        : message
+    );
+    expect(compacted[1]).not.toBe(folded[1]);
+    const afterCompaction = snapshot();
+    syncBudgetDerivedFields(afterCompaction, compacted, () => 10);
+    expect(afterCompaction.breakdown.toolMessageTokens).toBe(10);
+  });
+
+  it('leaves a synthetic user turn without tool lineage in the conversation share', () => {
+    const usage = snapshot();
+    const cue = stampSyntheticProviderMessage(new HumanMessage('handoff cue'));
+
+    syncBudgetDerivedFields(usage, [cue, toolResult('a')], () => 10);
+
+    expect(usage.breakdown.toolMessageTokens).toBe(10);
   });
 
   it('counts generic tool-role results', () => {

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -37,13 +37,24 @@ function safeCount(value: number): number {
 }
 
 /** Accepts what the `TokenCounter` contract allows, an approximate `number`
- *  such as `length / 4`, by rounding it, and rejects only what no subset claim
- *  can be derived from: NaN, infinities, negatives and values past the safe range. */
-function toCount(value: number): number {
-  if (!Number.isFinite(value) || value < 0) {
+ *  such as `length / 4`, unrounded, so sub-token amounts survive aggregation the
+ *  way they do on the pruning path. Rejects only what no subset claim can be
+ *  derived from: NaN, infinities, negatives and values past the safe range. */
+function toRawCount(value: number): number {
+  if (
+    !Number.isFinite(value) ||
+    value < 0 ||
+    value > Number.MAX_SAFE_INTEGER
+  ) {
     throw new RangeError('Invalid tool context token count');
   }
-  return safeCount(Math.round(value));
+  return value;
+}
+
+/** A total that arrived already aggregated (the breakdown's own fields) is
+ *  rounded once and must then be a safe integer. */
+function toCount(value: number): number {
+  return safeCount(Math.round(toRawCount(value)));
 }
 
 let warnedUnavailableToolShare = false;
@@ -261,13 +272,13 @@ function computeToolMessageUsage(
   let total = 0;
   let resultTotal = 0;
   const countResult = (message: BaseMessage, name: string): void => {
-    const tokens = toCount(tokenCounter(message));
-    total = safeCount(total + tokens);
+    const tokens = toRawCount(tokenCounter(message));
+    total = toRawCount(total + tokens);
     if (tokens === 0) {
       return;
     }
-    counts[name] = safeCount((counts[name] ?? 0) + tokens);
-    resultTotal = safeCount(resultTotal + tokens);
+    counts[name] = toRawCount((counts[name] ?? 0) + tokens);
+    resultTotal = toRawCount(resultTotal + tokens);
   };
 
   for (const message of context) {
@@ -276,7 +287,7 @@ function computeToolMessageUsage(
       const scan = scanInvocation(message, calls);
       pendingLegacyName = readLegacyFunctionName(message);
       if (scan.recognizedCalls > 0 && scan.toolOnly) {
-        total = safeCount(total + toCount(tokenCounter(message)));
+        total = toRawCount(total + toRawCount(tokenCounter(message)));
       }
       continue;
     }
@@ -289,7 +300,7 @@ function computeToolMessageUsage(
       continue;
     }
     if (role === 'user' && isFoldedToolHistory(message)) {
-      total = safeCount(total + toCount(tokenCounter(message)));
+      total = toRawCount(total + toRawCount(tokenCounter(message)));
       continue;
     }
     const userResultName =
@@ -308,11 +319,8 @@ function computeToolMessageUsage(
     Number.isFinite(calibrationRatio) && calibrationRatio > 0
       ? calibrationRatio
       : 1;
-  const toolMessageTokens = safeCount(Math.round(total * ratio));
-  const resultTokens = Math.min(
-    toolMessageTokens,
-    safeCount(Math.round(resultTotal * ratio))
-  );
+  const toolMessageTokens = toCount(total * ratio);
+  const resultTokens = Math.min(toolMessageTokens, toCount(resultTotal * ratio));
   return {
     toolMessageTokens,
     toolMessageTokenCounts:

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -1,29 +1,28 @@
 import type {
-  AIMessage,
   BaseMessage,
-  ChatMessage,
-  ToolMessage,
+  MessageContentComplex,
 } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type {
+  ProviderToolCallIndex,
+  ProviderToolResultPartDescriptor,
+} from './toolResultTypes';
 import type * as t from '@/types';
+import {
+  appendProviderMessageToolCalls,
+  appendProviderToolCallDescriptor,
+  getProviderMessageRole,
+  getProviderToolCallPartDescriptor,
+  getProviderToolMessageResultDescriptor,
+  getProviderToolResultPartDescriptor,
+} from './toolResultTypes';
 import { apportionTokenCounts } from '@/utils/tokens';
+import { isReasoningContentBlock } from './core';
 import { emitAgentLog } from '@/utils/events';
+import { ContentTypes } from '@/common';
 
-type NamedToolCall = {
-  id?: string;
-  name?: string;
-  function?: { name?: string };
-};
-
-/** Inline tool-call content: an Anthropic `tool_use` block, the v1 standard
- *  `tool_call` block (`{ id, name }` at top level, which `@langchain/aws`
- *  serializes to a Converse toolUse), and this repo's `ToolCallContent`
- *  (`{ tool_call: { id, name } }`). */
-type InlineToolCallBlock = {
-  id?: string;
-  name?: string;
-  tool_call?: { id?: string; name?: string };
-};
+const UNKNOWN_TOOL = 'unknown_tool';
+const BLANK_TEXT = /^\s*$/u;
 
 /** Rejects counts a subset claim cannot be derived from. Callers must degrade
  *  rather than propagate: this runs on the live pre-invoke path. */
@@ -57,17 +56,131 @@ function warnUnavailableToolShare(
   );
 }
 
-/** A `ChatMessage` carrying `role: 'assistant'` reports its type as `generic`,
- *  a shape the OpenAI role converter and the default token counter both accept. */
-function isAssistantMessage(message: BaseMessage, type: string): boolean {
-  if (type === 'ai') {
-    return true;
-  }
-  return type === 'generic' && (message as ChatMessage).role === 'assistant';
+/** `isReasoningContentBlock` matches every provider reasoning block by prefix
+ *  but deliberately excludes LibreChat's `think`, which this gauge must treat
+ *  the same way: reasoning attached to the turn, not visible conversation. */
+function isReasoningPart(part: MessageContentComplex): boolean {
+  return part.type === ContentTypes.THINK || isReasoningContentBlock(part);
 }
 
-/** Counts retained tool exchanges without serializing arguments or result content.
- * Mixed text/reasoning/media assistant messages remain in the conversation share. */
+function isBlankTextPart(part: string | MessageContentComplex): boolean {
+  if (typeof part === 'string') {
+    return BLANK_TEXT.test(part);
+  }
+  return (
+    part.type === ContentTypes.TEXT &&
+    typeof part.text === 'string' &&
+    BLANK_TEXT.test(part.text)
+  );
+}
+
+function readLegacyFunctionName(message: BaseMessage): string | undefined {
+  const name = message.additional_kwargs.function_call?.name;
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}
+
+function getPairedToolName(
+  descriptor: ProviderToolResultPartDescriptor,
+  calls: ProviderToolCallIndex
+): string | undefined {
+  return descriptor.toolCallId == null
+    ? undefined
+    : calls.get(descriptor.toolCallId)?.descriptor.name;
+}
+
+interface InvocationScan {
+  readonly recognizedCalls: number;
+  readonly toolOnly: boolean;
+}
+
+/**
+ * Registers an assistant turn's calls and decides whether the turn is
+ * tool-only. Tool-only means every part is blank text, a tool call, a provider
+ * tool result returned inline (Anthropic server tools), or reasoning attached
+ * to the turn. Visible text, media and unrecognized blocks keep the whole turn
+ * in the conversation share. Shape recognition is the taxonomy's, so a call or
+ * result representation this repo's converters accept is accepted here.
+ */
+function scanInvocation(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex
+): InvocationScan {
+  let recognizedCalls = appendProviderMessageToolCalls(message, calls);
+  if (typeof message.content === 'string') {
+    return { recognizedCalls, toolOnly: BLANK_TEXT.test(message.content) };
+  }
+  const parts: ReadonlyArray<string | MessageContentComplex> = message.content;
+  let toolOnly = true;
+  for (const part of parts) {
+    if (typeof part === 'string') {
+      toolOnly &&= BLANK_TEXT.test(part);
+      continue;
+    }
+    const call = getProviderToolCallPartDescriptor(part);
+    if (call != null) {
+      appendProviderToolCallDescriptor(calls, call);
+      recognizedCalls += 1;
+      continue;
+    }
+    if (getProviderToolResultPartDescriptor(part) != null) {
+      continue;
+    }
+    if (isReasoningPart(part)) {
+      continue;
+    }
+    toolOnly &&= isBlankTextPart(part);
+  }
+  return { recognizedCalls, toolOnly };
+}
+
+/** Result attribution: the paired call's name, then the message's own name,
+ *  then the legacy call still pending for a nameless `FunctionMessage`. */
+function getToolMessageResultName(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex,
+  pendingLegacyName: string | undefined
+): string {
+  const descriptor = getProviderToolMessageResultDescriptor(message);
+  const paired =
+    descriptor == null ? undefined : getPairedToolName(descriptor, calls);
+  if (paired != null) {
+    return paired;
+  }
+  if (message.name != null && message.name.length > 0) {
+    return message.name;
+  }
+  return pendingLegacyName ?? UNKNOWN_TOOL;
+}
+
+/**
+ * A user turn made only of `tool_result` parts the converters accept in that
+ * position: the split `AIMessage(tool_call)` + `HumanMessage(tool_result)`
+ * history. The counter measures whole messages, so the turn is attributed to
+ * its one paired tool, or to `unknown_tool` when its parts name several.
+ * Returns undefined for any other user turn.
+ */
+function getUserToolResultName(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex
+): string | undefined {
+  if (typeof message.content === 'string' || message.content.length === 0) {
+    return undefined;
+  }
+  let name: string | undefined;
+  let mixed = false;
+  for (const part of message.content) {
+    const descriptor = getProviderToolResultPartDescriptor(part);
+    if (descriptor?.allowHumanMessagePairing !== true) {
+      return undefined;
+    }
+    const paired = getPairedToolName(descriptor, calls);
+    mixed ||= name != null && paired !== name;
+    name = paired;
+  }
+  return mixed || name == null ? UNKNOWN_TOOL : name;
+}
+
+/** Counts retained tool exchanges without serializing arguments or result content. */
 function computeToolMessageUsage(
   context: readonly BaseMessage[],
   tokenCounter: t.TokenCounter,
@@ -76,108 +189,46 @@ function computeToolMessageUsage(
   t.TokenBudgetBreakdown,
   'toolMessageTokens' | 'toolMessageTokenCounts'
 > {
-  const names = new Map<string, string>();
+  const calls: ProviderToolCallIndex = new Map();
   const counts: Record<string, number> = Object.create(null);
-  let legacyName: string | undefined;
+  let pendingLegacyName: string | undefined;
   let total = 0;
   let resultTotal = 0;
-  const rememberCall = (call: NamedToolCall): void => {
-    const name =
-      call.name != null && call.name.length > 0
-        ? call.name
-        : call.function?.name;
-    if (
-      typeof call.id === 'string' &&
-      typeof name === 'string' &&
-      name.length > 0
-    ) {
-      names.set(call.id, name);
-    }
-  };
-  const rememberInlineCall = (block: InlineToolCallBlock): void => {
-    const nested = block.tool_call;
-    const id = nested?.id ?? block.id;
-    if (typeof id !== 'string' || names.has(id)) {
+  const countResult = (message: BaseMessage, name: string): void => {
+    const tokens = safeCount(tokenCounter(message));
+    total = safeCount(total + tokens);
+    if (tokens === 0) {
       return;
     }
-    rememberCall({ id, name: nested?.name ?? block.name });
+    counts[name] = safeCount((counts[name] ?? 0) + tokens);
+    resultTotal = safeCount(resultTotal + tokens);
   };
 
   for (const message of context) {
-    const type = message.getType();
-    const isResult = type === 'tool' || type === 'function';
-    if (isAssistantMessage(message, type)) {
-      const ai = message as AIMessage;
-      const calls = ai.tool_calls;
-      const rawCalls = ai.additional_kwargs.tool_calls;
-      if (rawCalls != null) {
-        for (const call of rawCalls) {
-          rememberCall(call);
-        }
+    const role = getProviderMessageRole(message);
+    if (role === 'assistant') {
+      const scan = scanInvocation(message, calls);
+      pendingLegacyName = readLegacyFunctionName(message);
+      if (scan.recognizedCalls > 0 && scan.toolOnly) {
+        total = safeCount(total + safeCount(tokenCounter(message)));
       }
-      if (calls != null) {
-        for (const call of calls) {
-          rememberCall(call);
-        }
-      }
-      legacyName = ai.additional_kwargs.function_call?.name;
-      let hasCalls =
-        (calls?.length ?? 0) > 0 ||
-        (rawCalls?.length ?? 0) > 0 ||
-        (legacyName != null && legacyName.length > 0);
-      let toolOnly = true;
-      if (typeof ai.content === 'string') {
-        toolOnly = !/\S/u.test(ai.content);
-      } else {
-        const content: ReadonlyArray<
-          string | Exclude<AIMessage['content'], string>[number]
-        > = ai.content;
-        for (const part of content) {
-          if (typeof part === 'string') {
-            toolOnly &&= !/\S/u.test(part);
-          } else if (part.type === 'tool_use' || part.type === 'tool_call') {
-            hasCalls = true;
-            rememberInlineCall(part as InlineToolCallBlock);
-          } else {
-            toolOnly &&=
-              part.type === 'text' &&
-              typeof part.text === 'string' &&
-              !/\S/u.test(part.text);
-          }
-        }
-      }
-      if (!hasCalls || !toolOnly) {
-        continue;
-      }
-    } else if (!isResult) {
-      legacyName = undefined;
       continue;
     }
-
-    const tokens = safeCount(tokenCounter(message));
-    total = safeCount(total + tokens);
-    if (!isResult) {
+    if (role === 'tool' || role === 'function') {
+      const legacyName = role === 'function' ? pendingLegacyName : undefined;
+      countResult(message, getToolMessageResultName(message, calls, legacyName));
+      if (role === 'function') {
+        pendingLegacyName = undefined;
+      }
       continue;
     }
-    const id =
-      type === 'tool' ? (message as ToolMessage).tool_call_id : undefined;
-    const pendingName =
-      type === 'function' && legacyName != null && legacyName.length > 0
-        ? legacyName
-        : undefined;
-    const name =
-      (id != null ? names.get(id) : undefined) ??
-      (message.name != null && message.name.length > 0
-        ? message.name
-        : pendingName) ??
-      'unknown_tool';
-    if (type === 'function') {
-      legacyName = undefined;
+    const userResultName =
+      role === 'user' ? getUserToolResultName(message, calls) : undefined;
+    if (userResultName != null) {
+      countResult(message, userResultName);
+      continue;
     }
-    if (tokens > 0) {
-      counts[name] = safeCount((counts[name] ?? 0) + tokens);
-      resultTotal = safeCount(resultTotal + tokens);
-    }
+    pendingLegacyName = undefined;
   }
 
   const ratio =

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -16,6 +16,7 @@ import {
   getProviderToolCallPartDescriptor,
   getProviderToolMessageResultDescriptor,
   getProviderToolResultPartDescriptor,
+  isExecutableCodePart,
 } from './toolResultTypes';
 import { getProviderMessageProvenance } from './provenance';
 import { apportionTokenCounts } from '@/utils/tokens';
@@ -118,7 +119,11 @@ function pairResult(
  * destination inheriting tool turns folds each call and its results into one
  * synthetic `HumanMessage`, and compaction of that fold keeps the lineage. The
  * role is user on the wire, the bytes are retained tool output, and the fold
- * is what the provenance stamp records. Per-tool attribution is lost with it.
+ * is what the provenance stamp records. The counter measures whole messages,
+ * so per-tool attribution is lost with the fold, and any visible model text the
+ * fold carried alongside its calls (a "let me search" preamble, the fold's own
+ * scaffolding) is counted with it. That is a bounded over-count on a turn that
+ * exists only because of tool content; the alternative is reporting zero.
  */
 function isFoldedToolHistory(message: BaseMessage): boolean {
   const parts = getProviderMessageProvenance(message)?.parts;
@@ -158,6 +163,11 @@ function scanInvocation(
     const call = getProviderToolCallPartDescriptor(part);
     if (call != null) {
       appendProviderToolCallDescriptor(calls, call);
+      recognizedCalls += 1;
+      previousPart = part;
+      continue;
+    }
+    if (isExecutableCodePart(part)) {
       recognizedCalls += 1;
       previousPart = part;
       continue;

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -17,6 +17,7 @@ import {
   getProviderToolMessageResultDescriptor,
   getProviderToolResultPartDescriptor,
 } from './toolResultTypes';
+import { getProviderMessageProvenance } from './provenance';
 import { apportionTokenCounts } from '@/utils/tokens';
 import { isReasoningContentBlock } from './core';
 import { emitAgentLog } from '@/utils/events';
@@ -112,6 +113,18 @@ function pairResult(
   return paired ? { paired, name } : { paired };
 }
 
+/**
+ * A user turn a provider transform built from tool history: a tool-less
+ * destination inheriting tool turns folds each call and its results into one
+ * synthetic `HumanMessage`, and compaction of that fold keeps the lineage. The
+ * role is user on the wire, the bytes are retained tool output, and the fold
+ * is what the provenance stamp records. Per-tool attribution is lost with it.
+ */
+function isFoldedToolHistory(message: BaseMessage): boolean {
+  const parts = getProviderMessageProvenance(message)?.parts;
+  return parts != null && parts.some((part) => part.attribution === 'tool');
+}
+
 interface InvocationScan {
   readonly recognizedCalls: number;
   readonly toolOnly: boolean;
@@ -135,20 +148,27 @@ function scanInvocation(
   }
   const parts: ReadonlyArray<string | MessageContentComplex> = message.content;
   let toolOnly = true;
+  let previousPart: string | MessageContentComplex | undefined;
   for (const part of parts) {
     if (typeof part === 'string') {
       toolOnly &&= BLANK_TEXT.test(part);
+      previousPart = part;
       continue;
     }
     const call = getProviderToolCallPartDescriptor(part);
     if (call != null) {
       appendProviderToolCallDescriptor(calls, call);
       recognizedCalls += 1;
+      previousPart = part;
       continue;
     }
-    if (getProviderToolResultPartDescriptor(part) != null) {
+    const result = getProviderToolResultPartDescriptor(part);
+    if (result != null) {
+      pairResult(result, calls, previousPart);
+      previousPart = part;
       continue;
     }
+    previousPart = part;
     if (isReasoningPart(part)) {
       continue;
     }
@@ -256,6 +276,10 @@ function computeToolMessageUsage(
       if (role === 'function') {
         pendingLegacyName = undefined;
       }
+      continue;
+    }
+    if (role === 'user' && isFoldedToolHistory(message)) {
+      total = safeCount(total + toCount(tokenCounter(message)));
       continue;
     }
     const userResultName =

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -11,6 +11,7 @@ import type * as t from '@/types';
 import {
   appendProviderMessageToolCalls,
   appendProviderToolCallDescriptor,
+  consumeProviderToolResultPair,
   getProviderMessageRole,
   getProviderToolCallPartDescriptor,
   getProviderToolMessageResultDescriptor,
@@ -24,13 +25,23 @@ import { ContentTypes } from '@/common';
 const UNKNOWN_TOOL = 'unknown_tool';
 const BLANK_TEXT = /^\s*$/u;
 
-/** Rejects counts a subset claim cannot be derived from. Callers must degrade
- *  rather than propagate: this runs on the live pre-invoke path. */
+/** Guards an aggregate: sums of rounded counts must stay safe integers.
+ *  Callers must degrade rather than propagate: this runs on the live pre-invoke path. */
 function safeCount(value: number): number {
   if (!Number.isSafeInteger(value) || value < 0) {
     throw new RangeError('Invalid tool context token count');
   }
   return value;
+}
+
+/** Accepts what the `TokenCounter` contract allows, an approximate `number`
+ *  such as `length / 4`, by rounding it, and rejects only what no subset claim
+ *  can be derived from: NaN, infinities, negatives and values past the safe range. */
+function toCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError('Invalid tool context token count');
+  }
+  return safeCount(Math.round(value));
 }
 
 let warnedUnavailableToolShare = false;
@@ -79,13 +90,26 @@ function readLegacyFunctionName(message: BaseMessage): string | undefined {
   return typeof name === 'string' && name.length > 0 ? name : undefined;
 }
 
-function getPairedToolName(
+interface ResultPairing {
+  readonly paired: boolean;
+  readonly name?: string;
+}
+
+/** Pairs a result with its call the way the wire walkers do: the call is
+ *  validated for kind and name and then consumed, so a provider that reuses a
+ *  call id in a later turn is attributed to the current call rather than
+ *  poisoning the id, and the bounded index never fills with answered calls. */
+function pairResult(
   descriptor: ProviderToolResultPartDescriptor,
-  calls: ProviderToolCallIndex
-): string | undefined {
-  return descriptor.toolCallId == null
-    ? undefined
-    : calls.get(descriptor.toolCallId)?.descriptor.name;
+  calls: ProviderToolCallIndex,
+  previousPart?: unknown
+): ResultPairing {
+  const name =
+    descriptor.toolCallId == null
+      ? undefined
+      : calls.get(descriptor.toolCallId)?.descriptor.name;
+  const paired = consumeProviderToolResultPair(descriptor, calls, previousPart);
+  return paired ? { paired, name } : { paired };
 }
 
 interface InvocationScan {
@@ -141,10 +165,10 @@ function getToolMessageResultName(
   pendingLegacyName: string | undefined
 ): string {
   const descriptor = getProviderToolMessageResultDescriptor(message);
-  const paired =
-    descriptor == null ? undefined : getPairedToolName(descriptor, calls);
-  if (paired != null) {
-    return paired;
+  const pairing =
+    descriptor == null ? undefined : pairResult(descriptor, calls);
+  if (pairing?.name != null) {
+    return pairing.name;
   }
   if (message.name != null && message.name.length > 0) {
     return message.name;
@@ -153,29 +177,41 @@ function getToolMessageResultName(
 }
 
 /**
- * A user turn made only of `tool_result` parts the converters accept in that
- * position: the split `AIMessage(tool_call)` + `HumanMessage(tool_result)`
- * history. The counter measures whole messages, so the turn is attributed to
- * its one paired tool, or to `unknown_tool` when its parts name several.
- * Returns undefined for any other user turn.
+ * A user turn made only of `tool_result` parts that each pair with a pending
+ * call, the split `AIMessage(tool_call)` + `HumanMessage(tool_result)` history
+ * the converters accept. Pairing runs against a candidate copy and commits only
+ * when every part pairs, as the recency walker does; anything else is an
+ * ordinary user turn. The counter measures whole messages, so the turn is
+ * attributed to its one paired tool, or to `unknown_tool` when parts name
+ * several. Returns undefined for any other user turn.
  */
-function getUserToolResultName(
+function takeUserToolResultName(
   message: BaseMessage,
   calls: ProviderToolCallIndex
 ): string | undefined {
   if (typeof message.content === 'string' || message.content.length === 0) {
     return undefined;
   }
+  const candidate: ProviderToolCallIndex = new Map(calls);
   let name: string | undefined;
   let mixed = false;
+  let previousPart: unknown;
   for (const part of message.content) {
     const descriptor = getProviderToolResultPartDescriptor(part);
     if (descriptor?.allowHumanMessagePairing !== true) {
       return undefined;
     }
-    const paired = getPairedToolName(descriptor, calls);
-    mixed ||= name != null && paired !== name;
-    name = paired;
+    const pairing = pairResult(descriptor, candidate, previousPart);
+    if (!pairing.paired) {
+      return undefined;
+    }
+    mixed ||= name != null && pairing.name !== name;
+    name = pairing.name;
+    previousPart = part;
+  }
+  calls.clear();
+  for (const [callId, entry] of candidate) {
+    calls.set(callId, entry);
   }
   return mixed || name == null ? UNKNOWN_TOOL : name;
 }
@@ -195,7 +231,7 @@ function computeToolMessageUsage(
   let total = 0;
   let resultTotal = 0;
   const countResult = (message: BaseMessage, name: string): void => {
-    const tokens = safeCount(tokenCounter(message));
+    const tokens = toCount(tokenCounter(message));
     total = safeCount(total + tokens);
     if (tokens === 0) {
       return;
@@ -210,7 +246,7 @@ function computeToolMessageUsage(
       const scan = scanInvocation(message, calls);
       pendingLegacyName = readLegacyFunctionName(message);
       if (scan.recognizedCalls > 0 && scan.toolOnly) {
-        total = safeCount(total + safeCount(tokenCounter(message)));
+        total = safeCount(total + toCount(tokenCounter(message)));
       }
       continue;
     }
@@ -223,10 +259,13 @@ function computeToolMessageUsage(
       continue;
     }
     const userResultName =
-      role === 'user' ? getUserToolResultName(message, calls) : undefined;
+      role === 'user' ? takeUserToolResultName(message, calls) : undefined;
     if (userResultName != null) {
       countResult(message, userResultName);
       continue;
+    }
+    if (role === 'user') {
+      calls.clear();
     }
     pendingLegacyName = undefined;
   }
@@ -266,12 +305,12 @@ function syncToolMessageShare(
   if (breakdown.toolMessageTokens == null) {
     return;
   }
-  const total = safeCount(breakdown.toolMessageTokens);
-  const clamped = Math.min(total, safeCount(breakdown.messageTokens));
+  const total = toCount(breakdown.toolMessageTokens);
+  const clamped = Math.min(total, toCount(breakdown.messageTokens));
   if (clamped !== total && breakdown.toolMessageTokenCounts != null) {
     let resultTotal = 0;
     for (const count of Object.values(breakdown.toolMessageTokenCounts)) {
-      resultTotal = safeCount(resultTotal + safeCount(count));
+      resultTotal = safeCount(resultTotal + toCount(count));
     }
     const factor = total > 0 ? clamped / total : 0;
     const target = Math.min(clamped, Math.round(resultTotal * factor));

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -1,23 +1,14 @@
-import type {
-  AIMessage,
-  BaseMessage,
-  ToolMessage,
-} from '@langchain/core/messages';
-import type {
-  ProviderToolCallIndex,
-  ProviderToolCallPartDescriptor,
-  ProviderToolResultPartDescriptor,
-} from './toolResultTypes';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ProviderToolCallIndex } from './toolResultTypes';
 import { getProviderSourceMessageIds } from './provenance';
 import {
+  appendProviderMessageToolCalls,
   appendProviderToolCallDescriptor,
   consumeProviderToolResultPair,
   getBoundedProviderPairingArray,
-  getBoundedProviderPairingArrayProperty,
-  getProviderAIMessageToolCallDescriptor,
   getProviderToolCallPartDescriptor,
+  getProviderToolMessageResultDescriptor,
   getProviderToolResultPartDescriptor,
-  PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS,
 } from './toolResultTypes';
 
 export const DEFAULT_RETAIN_RECENT_TURNS = 2;
@@ -102,155 +93,6 @@ export function resolveIntraTurnRetainTokens({
   );
 }
 
-function readOwnString(value: unknown, key: string): string | undefined {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-  try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    return descriptor != null &&
-      'value' in descriptor &&
-      typeof descriptor.value === 'string' &&
-      descriptor.value !== '' &&
-      descriptor.value.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
-      ? descriptor.value
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function readOwnValue(value: unknown, key: string): unknown {
-  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
-    return undefined;
-  }
-  try {
-    const descriptor = Object.getOwnPropertyDescriptor(value, key);
-    return descriptor != null && 'value' in descriptor
-      ? descriptor.value
-      : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-const LEGACY_FUNCTION_CALL_PREFIX = 'legacy_function:';
-
-function getLegacyFunctionCallId(name: string): string | undefined {
-  const callId = `${LEGACY_FUNCTION_CALL_PREFIX}${name}`;
-  return callId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
-    ? callId
-    : undefined;
-}
-
-function getRawToolCallDescriptor(
-  toolCall: unknown
-): ProviderToolCallPartDescriptor | undefined {
-  const callId = readOwnString(toolCall, 'id');
-  if (callId == null) {
-    return undefined;
-  }
-  let name: string | undefined;
-  if (toolCall != null && typeof toolCall === 'object') {
-    try {
-      const property = Object.getOwnPropertyDescriptor(toolCall, 'function');
-      name =
-        property != null && 'value' in property
-          ? readOwnString(property.value, 'name')
-          : undefined;
-    } catch {
-      return undefined;
-    }
-  }
-  return {
-    callId,
-    kind: 'tool',
-    sourceType: 'raw_tool_calls',
-    ...(name == null ? {} : { name }),
-  };
-}
-
-function appendMessageToolCalls(
-  message: BaseMessage,
-  calls: ProviderToolCallIndex
-): void {
-  const messageRole = (message as BaseMessage & { role?: unknown }).role;
-  if (message.getType() !== 'ai' && messageRole !== 'assistant') {
-    return;
-  }
-
-  for (const toolCall of (message as AIMessage).tool_calls ?? []) {
-    const descriptor = getProviderAIMessageToolCallDescriptor(toolCall);
-    if (descriptor != null) {
-      appendProviderToolCallDescriptor(calls, descriptor);
-    }
-  }
-
-  const rawToolCalls = getBoundedProviderPairingArrayProperty(
-    message.additional_kwargs,
-    'tool_calls'
-  );
-  if (rawToolCalls != null) {
-    for (const toolCall of rawToolCalls) {
-      const descriptor = getRawToolCallDescriptor(toolCall);
-      if (descriptor != null) {
-        appendProviderToolCallDescriptor(calls, descriptor);
-      }
-    }
-  }
-
-  const legacyFunctionCall = readOwnValue(
-    message.additional_kwargs,
-    'function_call'
-  );
-  const legacyFunctionName = readOwnString(legacyFunctionCall, 'name');
-  const legacyFunctionCallId =
-    legacyFunctionName == null
-      ? undefined
-      : getLegacyFunctionCallId(legacyFunctionName);
-  if (legacyFunctionCallId != null) {
-    appendProviderToolCallDescriptor(calls, {
-      callId: legacyFunctionCallId,
-      kind: 'tool',
-      name: legacyFunctionName,
-      sourceType: 'legacy_function_call',
-    });
-  }
-}
-
-function getToolMessageResultDescriptor(
-  message: BaseMessage
-): ProviderToolResultPartDescriptor | undefined {
-  if (message.getType() === 'function' && message.name != null) {
-    const toolCallId = getLegacyFunctionCallId(message.name);
-    return toolCallId == null
-      ? undefined
-      : {
-        type: 'function_message',
-        toolCallId,
-        compatibleCallKinds: ['tool'],
-        expectedToolNames: [message.name],
-      };
-  }
-  if (message.getType() !== 'tool') {
-    return undefined;
-  }
-  const toolMessage = message as ToolMessage & { toolCallId?: unknown };
-  const toolCallId =
-    typeof toolMessage.tool_call_id === 'string'
-      ? toolMessage.tool_call_id
-      : toolMessage.toolCallId;
-  return typeof toolCallId === 'string' &&
-    toolCallId !== '' &&
-    toolCallId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
-    ? {
-      type: 'tool_message',
-      toolCallId,
-      compatibleCallKinds: ['tool'],
-    }
-    : undefined;
-}
-
 interface MessagePairingResult {
   completedToolCalls: number;
   trustedHumanToolResult: boolean;
@@ -263,7 +105,7 @@ function inspectMessagePairing(
   const isHuman = message.getType() === 'human';
   const candidateCalls = isHuman ? new Map(calls) : calls;
   if (!isHuman) {
-    appendMessageToolCalls(message, candidateCalls);
+    appendProviderMessageToolCalls(message, candidateCalls);
   }
   const content = getBoundedProviderPairingArray(message.content);
   let completedToolCalls = 0;
@@ -300,7 +142,7 @@ function inspectMessagePairing(
     }
   }
 
-  const toolMessageResult = getToolMessageResultDescriptor(message);
+  const toolMessageResult = getProviderToolMessageResultDescriptor(message);
   if (
     toolMessageResult != null &&
     consumeProviderToolResultPair(toolMessageResult, candidateCalls)

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1121,7 +1121,9 @@ export function appendProviderToolCallDescriptor(
   index.set(descriptor.callId, null);
 }
 
-function isExecutableCodePart(part: unknown): boolean {
+/** Google's built-in code execution emits an `executableCode` part with no call
+ *  id; its `codeExecutionResult` pairs by adjacency instead. */
+export function isExecutableCodePart(part: unknown): boolean {
   const record = getRecord(part);
   if (
     record == null ||

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1,4 +1,10 @@
 import { isProxy } from 'node:util/types';
+import type {
+  AIMessage,
+  BaseMessage,
+  ChatMessage,
+  ToolMessage,
+} from '@langchain/core/messages';
 
 export type ProviderToolCallKind =
   | 'tool'
@@ -1171,4 +1177,214 @@ export function consumeProviderToolResultPair(
   }
   calls.delete(descriptor.toolCallId);
   return true;
+}
+
+function readOwnString(value: unknown, key: string): string | undefined {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor != null &&
+      'value' in descriptor &&
+      typeof descriptor.value === 'string' &&
+      descriptor.value !== '' &&
+      descriptor.value.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readOwnValue(value: unknown, key: string): unknown {
+  if (value == null || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    return descriptor != null && 'value' in descriptor
+      ? descriptor.value
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const LEGACY_FUNCTION_CALL_PREFIX = 'legacy_function:';
+
+export function getLegacyFunctionCallId(name: string): string | undefined {
+  const callId = `${LEGACY_FUNCTION_CALL_PREFIX}${name}`;
+  return callId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+    ? callId
+    : undefined;
+}
+
+export type ProviderMessageRole =
+  | 'assistant'
+  | 'user'
+  | 'system'
+  | 'tool'
+  | 'function';
+
+const GENERIC_MESSAGE_ROLES: Readonly<Record<string, ProviderMessageRole>> = {
+  assistant: 'assistant',
+  user: 'user',
+  system: 'system',
+  developer: 'system',
+  tool: 'tool',
+  function: 'function',
+};
+
+/**
+ * Normalizes a message to the role a provider converter would send it as. A
+ * `ChatMessage` reports its type as `generic` and carries the wire role on
+ * `role`, so every classifier that keys on `getType()` alone silently skips
+ * generic assistant, tool and function messages the converters accept.
+ */
+export function getProviderMessageRole(
+  message: BaseMessage
+): ProviderMessageRole | undefined {
+  const type = message.getType();
+  switch (type) {
+  case 'ai':
+    return 'assistant';
+  case 'human':
+    return 'user';
+  case 'system':
+    return 'system';
+  case 'tool':
+    return 'tool';
+  case 'function':
+    return 'function';
+  case 'generic': {
+    const role = (message as Partial<ChatMessage>).role;
+    return typeof role === 'string' ? GENERIC_MESSAGE_ROLES[role] : undefined;
+  }
+  default:
+    return undefined;
+  }
+}
+
+export function getRawToolCallDescriptor(
+  toolCall: unknown
+): ProviderToolCallPartDescriptor | undefined {
+  const callId = readOwnString(toolCall, 'id');
+  if (callId == null) {
+    return undefined;
+  }
+  let name: string | undefined;
+  if (toolCall != null && typeof toolCall === 'object') {
+    try {
+      const property = Object.getOwnPropertyDescriptor(toolCall, 'function');
+      name =
+        property != null && 'value' in property
+          ? readOwnString(property.value, 'name')
+          : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return {
+    callId,
+    kind: 'tool',
+    sourceType: 'raw_tool_calls',
+    ...(name == null ? {} : { name }),
+  };
+}
+
+/**
+ * Appends every tool call an assistant message carries: parsed
+ * `AIMessage.tool_calls`, raw `additional_kwargs.tool_calls` (where OpenAI
+ * keeps calls when the parsed array is empty) and a legacy
+ * `additional_kwargs.function_call`. Content-block calls are the caller's to
+ * append, since only the caller knows whether the block is being replayed.
+ * Returns how many descriptors were recognized, so a caller can tell an
+ * invocation from a plain assistant turn without re-deriving the shapes.
+ */
+export function appendProviderMessageToolCalls(
+  message: BaseMessage,
+  calls: ProviderToolCallIndex
+): number {
+  if (getProviderMessageRole(message) !== 'assistant') {
+    return 0;
+  }
+  let recognized = 0;
+  for (const toolCall of (message as AIMessage).tool_calls ?? []) {
+    const descriptor = getProviderAIMessageToolCallDescriptor(toolCall);
+    if (descriptor != null) {
+      appendProviderToolCallDescriptor(calls, descriptor);
+      recognized += 1;
+    }
+  }
+
+  const rawToolCalls = getBoundedProviderPairingArrayProperty(
+    message.additional_kwargs,
+    'tool_calls'
+  );
+  if (rawToolCalls != null) {
+    for (const toolCall of rawToolCalls) {
+      const descriptor = getRawToolCallDescriptor(toolCall);
+      if (descriptor != null) {
+        appendProviderToolCallDescriptor(calls, descriptor);
+        recognized += 1;
+      }
+    }
+  }
+
+  const legacyFunctionCall = readOwnValue(
+    message.additional_kwargs,
+    'function_call'
+  );
+  const legacyFunctionName = readOwnString(legacyFunctionCall, 'name');
+  const legacyFunctionCallId =
+    legacyFunctionName == null
+      ? undefined
+      : getLegacyFunctionCallId(legacyFunctionName);
+  if (legacyFunctionCallId != null) {
+    appendProviderToolCallDescriptor(calls, {
+      callId: legacyFunctionCallId,
+      kind: 'tool',
+      name: legacyFunctionName,
+      sourceType: 'legacy_function_call',
+    });
+    recognized += 1;
+  }
+  return recognized;
+}
+
+/** Describes a whole-message tool result: a `ToolMessage`, a `FunctionMessage`,
+ *  or a generic message carrying the equivalent wire role. */
+export function getProviderToolMessageResultDescriptor(
+  message: BaseMessage
+): ProviderToolResultPartDescriptor | undefined {
+  const role = getProviderMessageRole(message);
+  if (role === 'function' && message.name != null) {
+    const toolCallId = getLegacyFunctionCallId(message.name);
+    return toolCallId == null
+      ? undefined
+      : {
+        type: 'function_message',
+        toolCallId,
+        compatibleCallKinds: ['tool'],
+        expectedToolNames: [message.name],
+      };
+  }
+  if (role !== 'tool') {
+    return undefined;
+  }
+  const toolMessage = message as ToolMessage & { toolCallId?: unknown };
+  const toolCallId =
+    typeof toolMessage.tool_call_id === 'string'
+      ? toolMessage.tool_call_id
+      : toolMessage.toolCallId;
+  return typeof toolCallId === 'string' &&
+    toolCallId !== '' &&
+    toolCallId.length <= PROVIDER_TOOL_PAIRING_MAX_IDENTIFIER_CHARS
+    ? {
+      type: 'tool_message',
+      toolCallId,
+      compatibleCallKinds: ['tool'],
+    }
+    : undefined;
 }

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1227,9 +1227,16 @@ export type ProviderMessageRole =
   | 'tool'
   | 'function';
 
+/** The OpenAI converter forwards `assistant` / `user` / `system` / `developer`
+ *  / `tool` / `function`; the Google converter additionally reads `ai`,
+ *  `model` and `supervisor` as the model turn and `human` as the user. */
 const GENERIC_MESSAGE_ROLES: Readonly<Record<string, ProviderMessageRole>> = {
   assistant: 'assistant',
+  ai: 'assistant',
+  model: 'assistant',
+  supervisor: 'assistant',
   user: 'user',
+  human: 'user',
   system: 'system',
   developer: 'system',
   tool: 'tool',

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -475,7 +475,7 @@ export type TokenBudgetBreakdown = {
   toolTokenCounts?: Record<string, number>;
   /** Names of counted tools that are deferred (`defer_loading`) and discovered. */
   deferredToolNames?: string[];
-  /** Calibrated retained tool results plus tool-only assistant messages; subset of messageTokens, not an additional budget category. */
+  /** Calibrated retained tool traffic: tool results plus assistant turns made only of tool calls, inline provider tool results and reasoning. A subset of messageTokens, not an additional budget category. */
   toolMessageTokens?: number;
   /** Per-tool result-message share; excludes assistant invocation overhead. */
   toolMessageTokenCounts?: Record<string, number>;


### PR DESCRIPTION
## Summary

Stacked on #517 and intended to merge after it. Until #517 lands, this diff includes its commits; the change that belongs to this PR is the last commit, `531fa6f`.

`budget.ts` hand-rolled its own answer to "is this message a tool invocation, a tool result, or mixed content" while `src/messages/toolResultTypes.ts` already holds the canonical one, consumed by `format.ts`, `alternation.ts`, `recency.ts` and `handlers.ts`. Six of the eight review findings on #517 were the local classifier lagging a canonical one by one shape. This removes the fifth classifier rather than patching it again.

- Lift the message-level walker `recency.ts` kept private into the taxonomy as exports: `appendProviderMessageToolCalls` (now reporting how many calls it recognized), `getProviderToolMessageResultDescriptor`, and a single `getProviderMessageRole` that normalizes the `ChatMessage` roles the converters accept. `recency.ts` imports them back; its behaviour is unchanged.
- Redefine tool-only on the taxonomy: every part is blank text, a call descriptor, an inline provider tool result, or a reasoning block.
- The lifted helpers stay internal. `toolResultTypes.ts` is not re-exported from the package.

## Behaviour changes to the gauge

All keep `toolMessageTokens` a subset of `messageTokens`.

- Reasoning attached to a tool-only turn now rides with it regardless of where the provider stores it. Previously an Anthropic `thinking` block excluded the turn while OpenAI `reasoning_content` in `additional_kwargs` did not, so the same semantics classified differently by provider.
- `server_tool_use`, `mcp_tool_use` and their inline results are tool content. Retained web-search results are among the largest tool payloads and were reported as zero.
- A user turn made only of paired `tool_result` parts (the split call/result history) is counted and attributed.
- Generic assistant, tool and function roles are classified like their typed counterparts.
- A call id carrying conflicting names is ambiguous and attributed to `unknown_tool`, matching the index's own conflict rule, instead of preferring the structured name.

## Verification

Focused suites were chosen from the code graph's reverse-import closure of the changed files, unioned with the direct consumers of `syncBudgetDerivedFields`: 21 suites, 803 passed, 1 skipped. `tsc --noEmit` and eslint on the changed files with `--max-warnings 0` are clean. The ten new or changed test cases were run against the previous `budget.ts` first and all ten fail there. The full suite is CI's.

Tracked separately: #519 (fold the scan into the pressure meter's pass) and #520 (the default counter's `additional_kwargs.tool_calls` gap, which is wider than this gauge).
