### PR TITLE
🫗 perf: Fold Retained Tool Accounting Into Payload Measurement

### DIFF
--- a/src/agents/AgentContext.ts
+++ b/src/agents/AgentContext.ts
@@ -2140,7 +2140,9 @@ export class AgentContext {
     syncBudgetDerivedFields(
       usage,
       context,
-      this.contextPressureTokenCounts?.count ?? tokenCounter
+      this.contextPressureTokenCounts?.count ?? tokenCounter,
+      undefined,
+      this.provider
     );
     return usage;
   }

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -4159,7 +4159,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           undefined,
           undefined,
           config,
-          agentContext.provider
+          agentContext.provider,
+          finalProjection.toolMessageUsageError
         );
         /** Awaited so async host handlers receive the pre-invoke snapshot
          *  before any model deltas are emitted */

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3535,6 +3535,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
        * the expansion. Exact counts are memoized across repeated projections.
        */
       const contextPressure = createContextPressureMeter({
+        provider: agentContext.provider,
         tokenCounter: agentContext.tokenCounter,
         tokenCountCache: agentContext.contextPressureTokenCounts,
         sourceMessages: messages,
@@ -4149,12 +4150,16 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               finalProjection.projectedMessageTokens
           );
         }
+        contextUsage.breakdown.toolMessageTokens =
+          finalProjection.toolMessageTokens;
+        contextUsage.breakdown.toolMessageTokenCounts =
+          finalProjection.toolMessageTokenCounts;
         syncBudgetDerivedFields(
           contextUsage,
-          finalMessages,
-          agentContext.contextPressureTokenCounts?.count ??
-            agentContext.tokenCounter,
-          config
+          undefined,
+          undefined,
+          config,
+          agentContext.provider
         );
         /** Awaited so async host handlers receive the pre-invoke snapshot
          *  before any model deltas are emitted */
@@ -4337,6 +4342,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         const canSummarizeOverflow =
           agentContext.summarizationEnabled === true &&
           splitAtRecencyBoundary(messages, {
+            provider: agentContext.provider,
             turns:
               agentContext.summarizationConfig?.retainRecent?.turns ??
               DEFAULT_RETAIN_RECENT_TURNS,

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -49,23 +49,43 @@ describe('createContextPressureMeter', () => {
       toolMessageTokenCounts: undefined,
     });
     expect(meter.measure(projected).projectedMessageTokens).toBe(33);
-    /** Tool-share attribution needs raw local counts for every retained
-     *  message; the changed projection also recounts its baseline subtrahend. */
-    expect(tokenCounter).toHaveBeenCalledTimes(3);
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
   });
 
-  it('reuses stable exact counts across request-scoped meters', () => {
+  it('does not recount unchanged rich content for tool attribution', () => {
+    const retained = new HumanMessage({
+      content: [{ type: 'text', text: 'rich retained content' }],
+    });
+    const tokenCounter = jest.fn(contentLength);
+    const meter = createContextPressureMeter({
+      tokenCounter,
+      sourceMessages: [retained],
+      retainedMessages: [retained],
+      indexTokenCountMap: { 0: 20 },
+      contextUsage: {
+        contextBudget: 100,
+        effectiveInstructionTokens: 10,
+        remainingContextTokens: 70,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 10,
+      calibrationRatio: 1,
+    });
+
+    expect(meter.measure([retained]).toolMessageTokens).toBe(0);
+    expect(tokenCounter).not.toHaveBeenCalled();
+  });
+
+  it('avoids recounting provider-grounded messages across meters', () => {
     const retained = Array.from(
       { length: 100 },
       (_, index) =>
         new HumanMessage({ id: `message-${index}`, content: 'retained' })
     );
     const tokenCounter = jest.fn(contentLength);
-    const tokenCountCache = createExactTokenCountCache(tokenCounter);
     const createMeter = (messages: BaseMessage[]) =>
       createContextPressureMeter({
         tokenCounter,
-        tokenCountCache,
         sourceMessages: messages,
         retainedMessages: messages,
         indexTokenCountMap: Object.fromEntries(
@@ -87,7 +107,7 @@ describe('createContextPressureMeter', () => {
     const appended = [...retained, new HumanMessage('new')];
     createMeter(appended).measure(appended);
 
-    expect(tokenCounter).toHaveBeenCalledTimes(101);
+    expect(tokenCounter).not.toHaveBeenCalled();
   });
 
   it('reuses exact counts across request-scoped meters when no stored counts exist', () => {
@@ -286,7 +306,7 @@ describe('createContextPressureMeter', () => {
       ]);
     }
 
-    expect(tokenCounter).toHaveBeenCalledTimes(113);
+    expect(tokenCounter).toHaveBeenCalledTimes(13);
   });
 
   it('uses a conservative ratio for fallback payloads', () => {

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -45,6 +45,8 @@ describe('createContextPressureMeter', () => {
       availableMessageTokens: 90,
       contextBudget: 100,
       effectiveInstructionTokens: 10,
+      toolMessageTokens: 0,
+      toolMessageTokenCounts: undefined,
     });
     expect(meter.measure(projected).projectedMessageTokens).toBe(33);
     /** Stored counts cover the baseline; only the changed projection and its
@@ -309,6 +311,42 @@ describe('createContextPressureMeter', () => {
       availableMessageTokens: 12,
       contextBudget: 17,
       effectiveInstructionTokens: 5,
+      toolMessageTokens: 0,
+      toolMessageTokenCounts: undefined,
     });
+  });
+
+  it('measures tool share during the provider-payload pass', () => {
+    const messages = [
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call-1', name: 'lookup', args: {} }],
+      }),
+      new ToolMessage({
+        content: 'result',
+        tool_call_id: 'call-1',
+      }),
+    ];
+    const tokenCounter = jest.fn(() => 0.5);
+    const meter = createContextPressureMeter({
+      tokenCounter,
+      sourceMessages: messages,
+      retainedMessages: messages,
+      indexTokenCountMap: {},
+      contextUsage: {
+        contextBudget: 100,
+        effectiveInstructionTokens: 10,
+        remainingContextTokens: 90,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 10,
+      calibrationRatio: 1,
+    });
+
+    expect(meter.measure(messages)).toMatchObject({
+      toolMessageTokens: 1,
+      toolMessageTokenCounts: { lookup: 1 },
+    });
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -49,9 +49,9 @@ describe('createContextPressureMeter', () => {
       toolMessageTokenCounts: undefined,
     });
     expect(meter.measure(projected).projectedMessageTokens).toBe(33);
-    /** Stored counts cover the baseline; only the changed projection and its
-     *  baseline subtrahend are tokenized, never the untouched message. */
-    expect(tokenCounter).toHaveBeenCalledTimes(2);
+    /** Tool-share attribution needs raw local counts for every retained
+     *  message; the changed projection also recounts its baseline subtrahend. */
+    expect(tokenCounter).toHaveBeenCalledTimes(3);
   });
 
   it('reuses stable exact counts across request-scoped meters', () => {
@@ -87,7 +87,7 @@ describe('createContextPressureMeter', () => {
     const appended = [...retained, new HumanMessage('new')];
     createMeter(appended).measure(appended);
 
-    expect(tokenCounter).toHaveBeenCalledTimes(0);
+    expect(tokenCounter).toHaveBeenCalledTimes(101);
   });
 
   it('reuses exact counts across request-scoped meters when no stored counts exist', () => {
@@ -286,7 +286,7 @@ describe('createContextPressureMeter', () => {
       ]);
     }
 
-    expect(tokenCounter).toHaveBeenCalledTimes(13);
+    expect(tokenCounter).toHaveBeenCalledTimes(113);
   });
 
   it('uses a conservative ratio for fallback payloads', () => {
@@ -348,5 +348,32 @@ describe('createContextPressureMeter', () => {
       toolMessageTokenCounts: { lookup: 1 },
     });
     expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces invalid tool-share counts without invalidating the projection', () => {
+    const message = new ToolMessage({
+      content: 'result',
+      tool_call_id: 'call-1',
+    });
+    const meter = createContextPressureMeter({
+      tokenCounter: () => Number.NaN,
+      sourceMessages: [message],
+      retainedMessages: [message],
+      indexTokenCountMap: { 0: 10 },
+      contextUsage: {
+        contextBudget: 100,
+        effectiveInstructionTokens: 10,
+        remainingContextTokens: 80,
+        calibrationRatio: 1,
+      },
+      instructionTokens: 10,
+      calibrationRatio: 1,
+    });
+
+    expect(meter.measure([message])).toMatchObject({
+      fits: true,
+      projectedMessageTokens: 10,
+      toolMessageUsageError: expect.any(RangeError),
+    });
   });
 });

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -386,15 +386,16 @@ export function createContextPressureMeter({
           Math.min(availableMessageTokens, Math.max(0, baselineRemaining))
         : undefined;
     const toolUsage = createToolMessageUsageAccumulator(provider);
-    const toolUsageState = { available: true };
+    const toolUsageState: { error?: Error } = {};
     const addToolUsage = (message: BaseMessage, rawTokens: number): void => {
-      if (!toolUsageState.available) {
+      if (toolUsageState.error != null) {
         return;
       }
       try {
         toolUsage.add(message, rawTokens);
-      } catch {
-        toolUsageState.available = false;
+      } catch (error) {
+        toolUsageState.error =
+          error instanceof Error ? error : new Error(String(error));
       }
     };
 
@@ -438,12 +439,7 @@ export function createContextPressureMeter({
       const usedOrigins = new Set<number>();
       for (const message of messages) {
         const origin = origins.get(message);
-        const rawTokens =
-          origin != null &&
-          !usedOrigins.has(origin) &&
-          message === baseline[origin].message
-            ? baseline[origin].accountingWeight
-            : count(message);
+        const rawTokens = count(message);
         addToolUsage(message, rawTokens);
         if (origin == null || usedOrigins.has(origin)) {
           newRawTokens += rawTokens;
@@ -477,10 +473,11 @@ export function createContextPressureMeter({
         >
       | undefined;
     try {
-      measuredToolUsage = toolUsageState.available
-        ? toolUsage.finish(usageRatio)
-        : undefined;
-    } catch {
+      measuredToolUsage =
+        toolUsageState.error == null ? toolUsage.finish(usageRatio) : undefined;
+    } catch (error) {
+      toolUsageState.error =
+        error instanceof Error ? error : new Error(String(error));
       measuredToolUsage = undefined;
     }
     return {
@@ -490,6 +487,9 @@ export function createContextPressureMeter({
       contextBudget,
       effectiveInstructionTokens,
       ...measuredToolUsage,
+      ...(toolUsageState.error == null
+        ? {}
+        : { toolMessageUsageError: toolUsageState.error }),
     };
   };
 

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -9,6 +9,7 @@ import {
   REPLY_PRIMER_TOKENS,
   isSyntheticProviderContextMessage,
 } from '@/messages';
+import { createToolMessageUsageAccumulator } from '@/messages/budget';
 import { apportionTokenCounts } from '@/utils';
 
 interface ContextPressureUsage {
@@ -19,6 +20,7 @@ interface ContextPressureUsage {
 }
 
 interface ContextPressureMeterParams {
+  provider?: t.ProviderName;
   tokenCounter?: t.TokenCounter;
   tokenCountCache?: ExactTokenCountCache;
   sourceMessages: BaseMessage[];
@@ -230,6 +232,7 @@ function getProviderMessageOriginKey(message: BaseMessage): string | undefined {
 
 /** Measures repeated provider projections while tokenizing each message object once. */
 export function createContextPressureMeter({
+  provider,
   tokenCounter,
   tokenCountCache,
   sourceMessages,
@@ -382,6 +385,18 @@ export function createContextPressureMeter({
         ? availableMessageTokens -
           Math.min(availableMessageTokens, Math.max(0, baselineRemaining))
         : undefined;
+    const toolUsage = createToolMessageUsageAccumulator(provider);
+    const toolUsageState = { available: true };
+    const addToolUsage = (message: BaseMessage, rawTokens: number): void => {
+      if (!toolUsageState.available) {
+        return;
+      }
+      try {
+        toolUsage.add(message, rawTokens);
+      } catch {
+        toolUsageState.available = false;
+      }
+    };
 
     let projectedMessageTokens: number;
     if (
@@ -423,15 +438,22 @@ export function createContextPressureMeter({
       const usedOrigins = new Set<number>();
       for (const message of messages) {
         const origin = origins.get(message);
+        const rawTokens =
+          origin != null &&
+          !usedOrigins.has(origin) &&
+          message === baseline[origin].message
+            ? baseline[origin].accountingWeight
+            : count(message);
+        addToolUsage(message, rawTokens);
         if (origin == null || usedOrigins.has(origin)) {
-          newRawTokens += count(message);
+          newRawTokens += rawTokens;
           continue;
         }
         usedOrigins.add(origin);
         const projectionDelta =
           message === baseline[origin].message
             ? 0
-            : count(message) - baseline[origin].rawTokens;
+            : rawTokens - baseline[origin].rawTokens;
         projectedMessageTokens += Math.max(
           0,
           attribution.attributedByOrigin[origin] +
@@ -442,9 +464,24 @@ export function createContextPressureMeter({
     } else {
       let rawTokens = REPLY_PRIMER_TOKENS;
       for (const message of messages) {
-        rawTokens += count(message);
+        const messageTokens = count(message);
+        addToolUsage(message, messageTokens);
+        rawTokens += messageTokens;
       }
       projectedMessageTokens = Math.round(rawTokens * usageRatio);
+    }
+    let measuredToolUsage:
+      | Pick<
+          t.TokenBudgetBreakdown,
+          'toolMessageTokens' | 'toolMessageTokenCounts'
+        >
+      | undefined;
+    try {
+      measuredToolUsage = toolUsageState.available
+        ? toolUsage.finish(usageRatio)
+        : undefined;
+    } catch {
+      measuredToolUsage = undefined;
     }
     return {
       fits: projectedMessageTokens <= availableMessageTokens,
@@ -452,6 +489,7 @@ export function createContextPressureMeter({
       availableMessageTokens,
       contextBudget,
       effectiveInstructionTokens,
+      ...measuredToolUsage,
     };
   };
 

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -387,12 +387,15 @@ export function createContextPressureMeter({
         : undefined;
     const toolUsage = createToolMessageUsageAccumulator(provider);
     const toolUsageState: { error?: Error } = {};
-    const addToolUsage = (message: BaseMessage, rawTokens: number): void => {
+    const addToolUsage = (
+      message: BaseMessage,
+      getRawTokens: () => number
+    ): void => {
       if (toolUsageState.error != null) {
         return;
       }
       try {
-        toolUsage.add(message, rawTokens);
+        toolUsage.add(message, getRawTokens);
       } catch (error) {
         toolUsageState.error =
           error instanceof Error ? error : new Error(String(error));
@@ -439,17 +442,18 @@ export function createContextPressureMeter({
       const usedOrigins = new Set<number>();
       for (const message of messages) {
         const origin = origins.get(message);
-        const rawTokens = count(message);
-        addToolUsage(message, rawTokens);
+        let rawTokens: number | undefined;
+        const getRawTokens = (): number => (rawTokens ??= count(message));
+        addToolUsage(message, getRawTokens);
         if (origin == null || usedOrigins.has(origin)) {
-          newRawTokens += rawTokens;
+          newRawTokens += getRawTokens();
           continue;
         }
         usedOrigins.add(origin);
         const projectionDelta =
           message === baseline[origin].message
             ? 0
-            : rawTokens - baseline[origin].rawTokens;
+            : getRawTokens() - baseline[origin].rawTokens;
         projectedMessageTokens += Math.max(
           0,
           attribution.attributedByOrigin[origin] +
@@ -461,7 +465,7 @@ export function createContextPressureMeter({
       let rawTokens = REPLY_PRIMER_TOKENS;
       for (const message of messages) {
         const messageTokens = count(message);
-        addToolUsage(message, messageTokens);
+        addToolUsage(message, () => messageTokens);
         rawTokens += messageTokens;
       }
       projectedMessageTokens = Math.round(rawTokens * usageRatio);

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -27,11 +27,7 @@ import {
   stripBedrockCacheControl,
   cloneMessage,
 } from '@/messages/cache';
-import {
-  isAnthropicLike,
-  isGoogleLike,
-  isOpenAILike,
-} from '@/utils/llm';
+import { isAnthropicLike, isGoogleLike, isOpenAILike } from '@/utils/llm';
 import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { getProviderFamily } from '@/llm/providerRegistry';
@@ -90,6 +86,8 @@ export interface ProviderPayloadMeasurement {
   readonly availableMessageTokens?: number;
   readonly contextBudget?: number;
   readonly effectiveInstructionTokens?: number;
+  readonly toolMessageTokens?: number;
+  readonly toolMessageTokenCounts?: Record<string, number>;
 }
 
 export interface PreparedProviderRequest {
@@ -380,10 +378,7 @@ function projectAttachmentsForProvider(
       }
       content ??= copyUsableContentPrefix(sourceContent, blockIndex);
       const mimeType = BEDROCK_DOCUMENT_MIME_TYPES[block.document.format];
-      if (
-        mimeType == null ||
-        !canProjectBedrockDocument(provider, mimeType)
-      ) {
+      if (mimeType == null || !canProjectBedrockDocument(provider, mimeType)) {
         continue;
       }
       const standardFile = toStandardFileBlock(block);

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -88,6 +88,7 @@ export interface ProviderPayloadMeasurement {
   readonly effectiveInstructionTokens?: number;
   readonly toolMessageTokens?: number;
   readonly toolMessageTokenCounts?: Record<string, number>;
+  readonly toolMessageUsageError?: Error;
 }
 
 export interface PreparedProviderRequest {

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -209,6 +209,42 @@ describe('splitAtRecencyBoundary', () => {
   });
 
   describe('pairing-balanced intra-turn fallback', () => {
+    it('uses provider roles while finding an intra-turn boundary', () => {
+      const genericAssistant = new ChatMessage({
+        role: 'assistant',
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'generic',
+              type: 'function',
+              function: { name: 'search', arguments: '{}' },
+            },
+          ],
+        },
+      });
+      const messages = [
+        genericAssistant,
+        new ToolMessage({
+          content: 'result',
+          tool_call_id: 'generic',
+          name: 'search',
+        }),
+        new AIMessage('latest state'),
+      ];
+
+      const result = splitAtRecencyBoundary(messages, {
+        provider: 'bedrock',
+        turns: 1,
+        tokenCounter: () => 100,
+        intraTurnTokens: 100,
+      });
+
+      expect(result.head).toEqual([]);
+      expect(result.tail).toEqual(messages);
+      expect(result.usedIntraTurnFallback).toBe(false);
+    });
+
     it('compacts older closed tool units from a single long turn', () => {
       const messages: BaseMessage[] = [new HumanMessage('inspect the repo')];
       for (let index = 0; index < 4; index++) {

--- a/src/messages/__tests__/recency.test.ts
+++ b/src/messages/__tests__/recency.test.ts
@@ -1,5 +1,6 @@
 import {
   AIMessage,
+  ChatMessage,
   FunctionMessage,
   HumanMessage,
   ToolMessage,
@@ -19,9 +20,9 @@ describe('resolveIntraTurnRetainTokens', () => {
         maxContextTokens: 100_000,
       })
     ).toBe(4_096);
-    expect(
-      resolveIntraTurnRetainTokens({ maxContextTokens: 100_000 })
-    ).toBe(16_000);
+    expect(resolveIntraTurnRetainTokens({ maxContextTokens: 100_000 })).toBe(
+      16_000
+    );
   });
 
   it('disables the fallback without a usable context budget', () => {
@@ -116,6 +117,21 @@ describe('splitAtRecencyBoundary', () => {
       expect(result.tail[0]).toBe(messages[4]);
       expect(result.tail).toHaveLength(6);
     });
+  });
+
+  it('uses the serving provider to classify generic turn boundaries', () => {
+    const genericAssistant = new ChatMessage({
+      role: 'assistant',
+      content: 'model turn',
+    });
+    const messages = [new HumanMessage('question'), genericAssistant];
+
+    expect(
+      splitAtRecencyBoundary(messages, { turns: 1, provider: 'openai' }).tail
+    ).toEqual(messages);
+    expect(
+      splitAtRecencyBoundary(messages, { turns: 1, provider: 'bedrock' }).tail
+    ).toEqual([genericAssistant]);
   });
 
   describe('disabled (turns: 0)', () => {

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -16,7 +16,25 @@ import {
 } from './format';
 import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
 import { stampSyntheticProviderMessage } from './provenance';
+import { registerProvider } from '@/llm/providers';
 import { syncBudgetDerivedFields } from './budget';
+import { FakeChatModel } from '@/llm/fake';
+
+declare module '../provider-registration' {
+  interface CustomProviderOptionsMap {
+    'bedrock-family-budget-test': BedrockFamilyBudgetOptions;
+  }
+}
+
+interface BedrockFamilyBudgetOptions {
+  endpoint?: string;
+}
+
+class BedrockFamilyBudgetTestModel extends FakeChatModel {
+  constructor(_config: BedrockFamilyBudgetOptions) {
+    super({ responses: ['ok'] });
+  }
+}
 import { toLangChainContent } from './langchain';
 import { GraphEvents } from '@/common';
 
@@ -663,6 +681,12 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     ];
     const openAIUsage = snapshot();
     const bedrockUsage = snapshot();
+    const customBedrockUsage = snapshot();
+    const dispose = registerProvider({
+      provider: 'bedrock-family-budget-test',
+      model: BedrockFamilyBudgetTestModel,
+      family: 'bedrock',
+    });
 
     syncBudgetDerivedFields(
       openAIUsage,
@@ -678,9 +702,18 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
       undefined,
       'bedrock'
     );
+    syncBudgetDerivedFields(
+      customBedrockUsage,
+      messages,
+      () => 10,
+      undefined,
+      'bedrock-family-budget-test'
+    );
+    dispose();
 
     expect(openAIUsage.breakdown.toolMessageTokens).toBe(10);
     expect(bedrockUsage.breakdown.toolMessageTokens).toBe(0);
+    expect(customBedrockUsage.breakdown.toolMessageTokens).toBe(0);
   });
 
   it('attributes a reused call id to the call it currently answers', () => {
@@ -765,6 +798,20 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
 
     await RunnableLambda.from(
       (_input: unknown, config?: RunnableConfig): void => {
+        const propagated = snapshot();
+        propagated.breakdown.toolMessageTokens = 10;
+        expect(() =>
+          syncBudgetDerivedFields(
+            propagated,
+            undefined,
+            undefined,
+            config,
+            undefined,
+            new RangeError('Invalid tool context token count')
+          )
+        ).not.toThrow();
+        expect(propagated.breakdown.toolMessageTokens).toBeUndefined();
+
         for (const value of [
           Number.NaN,
           Number.POSITIVE_INFINITY,

--- a/src/messages/budget.test.ts
+++ b/src/messages/budget.test.ts
@@ -10,15 +10,15 @@ import {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { AgentLogEvent } from '@/types';
 import type * as t from '@/types';
-import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
-import { stampSyntheticProviderMessage } from './provenance';
-import { GraphEvents } from '@/common';
 import {
   compactSyntheticProviderContextMessage,
   foldToolBlocksForToollessAgent,
 } from './format';
-import { toLangChainContent } from './langchain';
+import { createExactTokenCountCache } from '@/llm/contextPressureMeter';
+import { stampSyntheticProviderMessage } from './provenance';
 import { syncBudgetDerivedFields } from './budget';
+import { toLangChainContent } from './langchain';
+import { GraphEvents } from '@/common';
 
 function snapshot(
   messageTokens = 1_000,
@@ -630,19 +630,57 @@ describe('syncBudgetDerivedFields tool-message accounting', () => {
     expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 13 });
   });
 
-  it('keeps sub-token amounts through aggregation like the pruning path', () => {
+  it('rounds approximate counts after aggregating the retained tool share', () => {
     const usage = snapshot();
     const messages = [
-      toolResult('a', 'lookup'),
-      toolResult('b', 'lookup'),
-      toolResult('c', 'lookup'),
-      toolResult('d', 'lookup'),
+      toolResult('first'),
+      toolResult('second'),
+      toolResult('third'),
+      toolResult('fourth'),
     ];
 
     syncBudgetDerivedFields(usage, messages, () => 0.25);
 
     expect(usage.breakdown.toolMessageTokens).toBe(1);
-    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ lookup: 1 });
+    expect(usage.breakdown.toolMessageTokenCounts).toEqual({ unknown_tool: 1 });
+  });
+
+  it('uses the serving provider to interpret generic message roles', () => {
+    const messages = [
+      new ChatMessage({
+        role: 'assistant',
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'generic',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{}' },
+            },
+          ],
+        },
+      }),
+    ];
+    const openAIUsage = snapshot();
+    const bedrockUsage = snapshot();
+
+    syncBudgetDerivedFields(
+      openAIUsage,
+      messages,
+      () => 10,
+      undefined,
+      'openai'
+    );
+    syncBudgetDerivedFields(
+      bedrockUsage,
+      messages,
+      () => 10,
+      undefined,
+      'bedrock'
+    );
+
+    expect(openAIUsage.breakdown.toolMessageTokens).toBe(10);
+    expect(bedrockUsage.breakdown.toolMessageTokens).toBe(0);
   });
 
   it('attributes a reused call id to the call it currently answers', () => {

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -421,7 +421,8 @@ export function syncBudgetDerivedFields(
   context?: readonly BaseMessage[],
   tokenCounter?: t.TokenCounter,
   config?: RunnableConfig,
-  provider?: t.ProviderName
+  provider?: t.ProviderName,
+  toolMessageUsageError?: Error
 ): void {
   const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
   if (effectiveInstructionTokens != null) {
@@ -442,6 +443,9 @@ export function syncBudgetDerivedFields(
     }
   }
   try {
+    if (toolMessageUsageError != null) {
+      throw toolMessageUsageError;
+    }
     syncToolMessageShare(usage, context, tokenCounter, provider);
   } catch (error) {
     warnUnavailableToolShare(config, error);

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -37,24 +37,20 @@ function safeCount(value: number): number {
 }
 
 /** Accepts what the `TokenCounter` contract allows, an approximate `number`
- *  such as `length / 4`, unrounded, so sub-token amounts survive aggregation the
- *  way they do on the pruning path. Rejects only what no subset claim can be
- *  derived from: NaN, infinities, negatives and values past the safe range. */
-function toRawCount(value: number): number {
-  if (
-    !Number.isFinite(value) ||
-    value < 0 ||
-    value > Number.MAX_SAFE_INTEGER
-  ) {
+ *  such as `length / 4`, by rounding it, and rejects only what no subset claim
+ *  can be derived from: NaN, infinities, negatives and values past the safe range. */
+function toCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new RangeError('Invalid tool context token count');
+  }
+  return safeCount(Math.round(value));
+}
+
+function safeRawCount(value: number): number {
+  if (!Number.isFinite(value) || value < 0 || value > Number.MAX_SAFE_INTEGER) {
     throw new RangeError('Invalid tool context token count');
   }
   return value;
-}
-
-/** A total that arrived already aggregated (the breakdown's own fields) is
- *  rounded once and must then be a safe integer. */
-function toCount(value: number): number {
-  return safeCount(Math.round(toRawCount(value)));
 }
 
 let warnedUnavailableToolShare = false;
@@ -75,7 +71,7 @@ function warnUnavailableToolShare(
     config,
     'warn',
     'budget',
-    'Tool-message context share unavailable: the token counter must return safe, non-negative integers',
+    'Tool-message context share unavailable: the token counter must return finite, non-negative counts within the safe range',
     { error: error instanceof Error ? error.message : String(error) }
   );
 }
@@ -156,9 +152,14 @@ interface InvocationScan {
  */
 function scanInvocation(
   message: BaseMessage,
-  calls: ProviderToolCallIndex
+  calls: ProviderToolCallIndex,
+  provider?: t.ProviderName
 ): InvocationScan {
-  let recognizedCalls = appendProviderMessageToolCalls(message, calls);
+  let recognizedCalls = appendProviderMessageToolCalls(
+    message,
+    calls,
+    provider
+  );
   if (typeof message.content === 'string') {
     return { recognizedCalls, toolOnly: BLANK_TEXT.test(message.content) };
   }
@@ -203,9 +204,10 @@ function scanInvocation(
 function getToolMessageResultName(
   message: BaseMessage,
   calls: ProviderToolCallIndex,
-  pendingLegacyName: string | undefined
+  pendingLegacyName: string | undefined,
+  provider?: t.ProviderName
 ): string {
-  const descriptor = getProviderToolMessageResultDescriptor(message);
+  const descriptor = getProviderToolMessageResultDescriptor(message, provider);
   const pairing =
     descriptor == null ? undefined : pairResult(descriptor, calls);
   if (pairing?.name != null) {
@@ -258,76 +260,115 @@ function takeUserToolResultName(
 }
 
 /** Counts retained tool exchanges without serializing arguments or result content. */
-function computeToolMessageUsage(
-  context: readonly BaseMessage[],
-  tokenCounter: t.TokenCounter,
-  calibrationRatio = 1
-): Pick<
-  t.TokenBudgetBreakdown,
-  'toolMessageTokens' | 'toolMessageTokenCounts'
-> {
+export interface ToolMessageUsageAccumulator {
+  add(message: BaseMessage, rawTokens: number): void;
+  finish(
+    calibrationRatio?: number
+  ): Pick<
+    t.TokenBudgetBreakdown,
+    'toolMessageTokens' | 'toolMessageTokenCounts'
+  >;
+}
+
+/** Accumulates tool-share attribution while its caller walks a provider payload. */
+export function createToolMessageUsageAccumulator(
+  provider?: t.ProviderName
+): ToolMessageUsageAccumulator {
   const calls: ProviderToolCallIndex = new Map();
   const counts: Record<string, number> = Object.create(null);
   let pendingLegacyName: string | undefined;
   let total = 0;
   let resultTotal = 0;
-  const countResult = (message: BaseMessage, name: string): void => {
-    const tokens = toRawCount(tokenCounter(message));
-    total = toRawCount(total + tokens);
+  const addRaw = (current: number, increment: number): number =>
+    safeRawCount(current + safeRawCount(increment));
+  const countResult = (tokens: number, name: string): void => {
+    total = addRaw(total, tokens);
     if (tokens === 0) {
       return;
     }
-    counts[name] = toRawCount((counts[name] ?? 0) + tokens);
-    resultTotal = toRawCount(resultTotal + tokens);
+    counts[name] = addRaw(counts[name] ?? 0, tokens);
+    resultTotal = addRaw(resultTotal, tokens);
   };
 
-  for (const message of context) {
-    const role = getProviderMessageRole(message);
+  const add = (message: BaseMessage, rawTokens: number): void => {
+    const tokens = safeRawCount(rawTokens);
+    const role = getProviderMessageRole(message, provider);
     if (role === 'assistant') {
-      const scan = scanInvocation(message, calls);
+      const scan = scanInvocation(message, calls, provider);
       pendingLegacyName = readLegacyFunctionName(message);
       if (scan.recognizedCalls > 0 && scan.toolOnly) {
-        total = toRawCount(total + toRawCount(tokenCounter(message)));
+        total = addRaw(total, tokens);
       }
-      continue;
+      return;
     }
     if (role === 'tool' || role === 'function') {
       const legacyName = role === 'function' ? pendingLegacyName : undefined;
-      countResult(message, getToolMessageResultName(message, calls, legacyName));
+      countResult(
+        tokens,
+        getToolMessageResultName(message, calls, legacyName, provider)
+      );
       if (role === 'function') {
         pendingLegacyName = undefined;
       }
-      continue;
+      return;
     }
     if (role === 'user' && isFoldedToolHistory(message)) {
-      total = toRawCount(total + toRawCount(tokenCounter(message)));
-      continue;
+      total = addRaw(total, tokens);
+      return;
     }
     const userResultName =
       role === 'user' ? takeUserToolResultName(message, calls) : undefined;
     if (userResultName != null) {
-      countResult(message, userResultName);
-      continue;
+      countResult(tokens, userResultName);
+      return;
     }
     if (role === 'user') {
       calls.clear();
     }
     pendingLegacyName = undefined;
-  }
-
-  const ratio =
-    Number.isFinite(calibrationRatio) && calibrationRatio > 0
-      ? calibrationRatio
-      : 1;
-  const toolMessageTokens = toCount(total * ratio);
-  const resultTokens = Math.min(toolMessageTokens, toCount(resultTotal * ratio));
-  return {
-    toolMessageTokens,
-    toolMessageTokenCounts:
-      resultTotal > 0 && resultTokens > 0
-        ? apportionTokenCounts(counts, ratio, resultTokens)
-        : undefined,
   };
+
+  const finish = (
+    calibrationRatio = 1
+  ): Pick<
+    t.TokenBudgetBreakdown,
+    'toolMessageTokens' | 'toolMessageTokenCounts'
+  > => {
+    const ratio =
+      Number.isFinite(calibrationRatio) && calibrationRatio > 0
+        ? calibrationRatio
+        : 1;
+    const toolMessageTokens = safeCount(Math.round(total * ratio));
+    const resultTokens = Math.min(
+      toolMessageTokens,
+      safeCount(Math.round(resultTotal * ratio))
+    );
+    return {
+      toolMessageTokens,
+      toolMessageTokenCounts:
+        resultTotal > 0 && resultTokens > 0
+          ? apportionTokenCounts(counts, ratio, resultTokens)
+          : undefined,
+    };
+  };
+
+  return { add, finish };
+}
+
+function computeToolMessageUsage(
+  context: readonly BaseMessage[],
+  tokenCounter: t.TokenCounter,
+  calibrationRatio = 1,
+  provider?: t.ProviderName
+): Pick<
+  t.TokenBudgetBreakdown,
+  'toolMessageTokens' | 'toolMessageTokenCounts'
+> {
+  const accumulator = createToolMessageUsageAccumulator(provider);
+  for (const message of context) {
+    accumulator.add(message, tokenCounter(message));
+  }
+  return accumulator.finish(calibrationRatio);
 }
 
 /** Applies the retained tool share and clamps it to the conversation total it
@@ -335,13 +376,19 @@ function computeToolMessageUsage(
 function syncToolMessageShare(
   usage: t.ContextUsageEvent,
   context?: readonly BaseMessage[],
-  tokenCounter?: t.TokenCounter
+  tokenCounter?: t.TokenCounter,
+  provider?: t.ProviderName
 ): void {
   const { breakdown } = usage;
   if (context != null && tokenCounter != null) {
     Object.assign(
       breakdown,
-      computeToolMessageUsage(context, tokenCounter, usage.calibrationRatio)
+      computeToolMessageUsage(
+        context,
+        tokenCounter,
+        usage.calibrationRatio,
+        provider
+      )
     );
   }
   if (breakdown.toolMessageTokens == null) {
@@ -373,7 +420,8 @@ export function syncBudgetDerivedFields(
   usage: t.ContextUsageEvent,
   context?: readonly BaseMessage[],
   tokenCounter?: t.TokenCounter,
-  config?: RunnableConfig
+  config?: RunnableConfig,
+  provider?: t.ProviderName
 ): void {
   const { breakdown, contextBudget, effectiveInstructionTokens } = usage;
   if (effectiveInstructionTokens != null) {
@@ -394,7 +442,7 @@ export function syncBudgetDerivedFields(
     }
   }
   try {
-    syncToolMessageShare(usage, context, tokenCounter);
+    syncToolMessageShare(usage, context, tokenCounter, provider);
   } catch (error) {
     warnUnavailableToolShare(config, error);
     delete breakdown.toolMessageTokens;

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -261,7 +261,7 @@ function takeUserToolResultName(
 
 /** Counts retained tool exchanges without serializing arguments or result content. */
 export interface ToolMessageUsageAccumulator {
-  add(message: BaseMessage, rawTokens: number): void;
+  add(message: BaseMessage, getRawTokens: () => number): void;
   finish(
     calibrationRatio?: number
   ): Pick<
@@ -290,21 +290,21 @@ export function createToolMessageUsageAccumulator(
     resultTotal = addRaw(resultTotal, tokens);
   };
 
-  const add = (message: BaseMessage, rawTokens: number): void => {
-    const tokens = safeRawCount(rawTokens);
+  const add = (message: BaseMessage, getRawTokens: () => number): void => {
+    const readTokens = (): number => safeRawCount(getRawTokens());
     const role = getProviderMessageRole(message, provider);
     if (role === 'assistant') {
       const scan = scanInvocation(message, calls, provider);
       pendingLegacyName = readLegacyFunctionName(message);
       if (scan.recognizedCalls > 0 && scan.toolOnly) {
-        total = addRaw(total, tokens);
+        total = addRaw(total, readTokens());
       }
       return;
     }
     if (role === 'tool' || role === 'function') {
       const legacyName = role === 'function' ? pendingLegacyName : undefined;
       countResult(
-        tokens,
+        readTokens(),
         getToolMessageResultName(message, calls, legacyName, provider)
       );
       if (role === 'function') {
@@ -313,13 +313,13 @@ export function createToolMessageUsageAccumulator(
       return;
     }
     if (role === 'user' && isFoldedToolHistory(message)) {
-      total = addRaw(total, tokens);
+      total = addRaw(total, readTokens());
       return;
     }
     const userResultName =
       role === 'user' ? takeUserToolResultName(message, calls) : undefined;
     if (userResultName != null) {
-      countResult(tokens, userResultName);
+      countResult(readTokens(), userResultName);
       return;
     }
     if (role === 'user') {
@@ -366,7 +366,7 @@ function computeToolMessageUsage(
 > {
   const accumulator = createToolMessageUsageAccumulator(provider);
   for (const message of context) {
-    accumulator.add(message, tokenCounter(message));
+    accumulator.add(message, () => tokenCounter(message));
   }
   return accumulator.finish(calibrationRatio);
 }

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,7 +1,7 @@
 export * from './core';
 export * from './ids';
 export * from './prune';
-export * from './budget';
+export { syncBudgetDerivedFields } from './budget';
 export * from './format';
 export * from './cache';
 export * from './anthropicToolCache';

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -1,15 +1,17 @@
 import type { BaseMessage } from '@langchain/core/messages';
 import type { ProviderToolCallIndex } from './toolResultTypes';
-import { getProviderSourceMessageIds } from './provenance';
+import type { ProviderName } from '@/types/llm';
 import {
   appendProviderMessageToolCalls,
   appendProviderToolCallDescriptor,
   consumeProviderToolResultPair,
   getBoundedProviderPairingArray,
+  getProviderMessageRole,
   getProviderToolCallPartDescriptor,
   getProviderToolMessageResultDescriptor,
   getProviderToolResultPartDescriptor,
 } from './toolResultTypes';
+import { getProviderSourceMessageIds } from './provenance';
 
 export const DEFAULT_RETAIN_RECENT_TURNS = 2;
 export const DEFAULT_INTRA_TURN_RETAIN_RATIO = 0.16;
@@ -19,6 +21,8 @@ export const DEFAULT_INTRA_TURN_RETAIN_RATIO = 0.16;
  * and a tail (to be preserved verbatim).
  */
 export interface RecencyWindowOptions {
+  /** Serving provider used to interpret generic `ChatMessage` roles. */
+  provider?: ProviderName;
   /**
    * Maximum number of recent user-led turns to keep in the tail. A "turn"
    * begins at a user-authored HumanMessage and includes every following
@@ -100,12 +104,13 @@ interface MessagePairingResult {
 
 function inspectMessagePairing(
   message: BaseMessage,
-  calls: ProviderToolCallIndex
+  calls: ProviderToolCallIndex,
+  provider?: ProviderName
 ): MessagePairingResult {
-  const isHuman = message.getType() === 'human';
+  const isHuman = getProviderMessageRole(message, provider) === 'user';
   const candidateCalls = isHuman ? new Map(calls) : calls;
   if (!isHuman) {
-    appendProviderMessageToolCalls(message, candidateCalls);
+    appendProviderMessageToolCalls(message, candidateCalls, provider);
   }
   const content = getBoundedProviderPairingArray(message.content);
   let completedToolCalls = 0;
@@ -142,7 +147,10 @@ function inspectMessagePairing(
     }
   }
 
-  const toolMessageResult = getProviderToolMessageResultDescriptor(message);
+  const toolMessageResult = getProviderToolMessageResultDescriptor(
+    message,
+    provider
+  );
   if (
     toolMessageResult != null &&
     consumeProviderToolResultPair(toolMessageResult, candidateCalls)
@@ -161,20 +169,25 @@ function inspectMessagePairing(
     }
   }
   return {
-    completedToolCalls: isHuman && !trustedHumanToolResult
-      ? 0
-      : completedToolCalls,
+    completedToolCalls:
+      isHuman && !trustedHumanToolResult ? 0 : completedToolCalls,
     trustedHumanToolResult,
   };
 }
 
-function findTurnStarts(messages: BaseMessage[]): number[] {
+function findTurnStarts(
+  messages: BaseMessage[],
+  provider?: ProviderName
+): number[] {
   const turnStarts: number[] = [];
   const calls: ProviderToolCallIndex = new Map();
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i] as BaseMessage;
-    const pairing = inspectMessagePairing(message, calls);
-    if (message.getType() !== 'human' || pairing.trustedHumanToolResult) {
+    const pairing = inspectMessagePairing(message, calls, provider);
+    if (
+      getProviderMessageRole(message, provider) !== 'user' ||
+      pairing.trustedHumanToolResult
+    ) {
       continue;
     }
     turnStarts.push(i);
@@ -292,7 +305,7 @@ export function splitAtRecencyBoundary(
     };
   }
 
-  const turnStarts = findTurnStarts(messages);
+  const turnStarts = findTurnStarts(messages, options.provider);
 
   if (turnStarts.length === 0) {
     return {

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -208,7 +208,8 @@ function findIntraTurnBoundary(
   messages: BaseMessage[],
   countMessageAt: (index: number) => number,
   retainTokens: number,
-  earliestRetainedTurnEndIndex: number
+  earliestRetainedTurnEndIndex: number,
+  provider?: ProviderName
 ): number | undefined {
   let remainingTokens = 0;
   for (let i = 0; i < messages.length; i++) {
@@ -241,9 +242,9 @@ function findIntraTurnBoundary(
     const message = messages[i] as BaseMessage;
     remainingTokens -= countMessageAt(i);
 
-    const pairing = inspectMessagePairing(message, pendingToolCalls);
+    const pairing = inspectMessagePairing(message, pendingToolCalls, provider);
     completedToolCalls += pairing.completedToolCalls;
-    if (message.getType() === 'human' && !pairing.trustedHumanToolResult) {
+    if (pairing.userMessage && !pairing.trustedHumanToolResult) {
       pendingToolCalls.clear();
     }
 
@@ -262,7 +263,7 @@ function findIntraTurnBoundary(
       completedToolCalls > 0 &&
       pendingToolCalls.size === 0 &&
       straddlingSourceIds.size === 0 &&
-      (message.getType() !== 'human' || pairing.trustedHumanToolResult)
+      (!pairing.userMessage || pairing.trustedHumanToolResult)
     ) {
       boundary = i + 1;
     }
@@ -389,7 +390,8 @@ export function splitAtRecencyBoundary(
         messages,
         countMessageAt,
         intraTurnTokens,
-        turnStarts[1] ?? messages.length
+        turnStarts[1] ?? messages.length,
+        options.provider
       );
       if (intraTurnBoundary != null) {
         return {

--- a/src/messages/recency.ts
+++ b/src/messages/recency.ts
@@ -100,6 +100,7 @@ export function resolveIntraTurnRetainTokens({
 interface MessagePairingResult {
   completedToolCalls: number;
   trustedHumanToolResult: boolean;
+  userMessage: boolean;
 }
 
 function inspectMessagePairing(
@@ -172,6 +173,7 @@ function inspectMessagePairing(
     completedToolCalls:
       isHuman && !trustedHumanToolResult ? 0 : completedToolCalls,
     trustedHumanToolResult,
+    userMessage: isHuman,
   };
 }
 
@@ -184,10 +186,7 @@ function findTurnStarts(
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i] as BaseMessage;
     const pairing = inspectMessagePairing(message, calls, provider);
-    if (
-      getProviderMessageRole(message, provider) !== 'user' ||
-      pairing.trustedHumanToolResult
-    ) {
+    if (!pairing.userMessage || pairing.trustedHumanToolResult) {
       continue;
     }
     turnStarts.push(i);

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   ToolMessage,
 } from '@langchain/core/messages';
+import type { ProviderName } from '@/types/llm';
 
 export type ProviderToolCallKind =
   | 'tool'
@@ -329,10 +330,7 @@ function isCacheControl(value: unknown): boolean {
   }
   const ttl = readDataProperty(record, 'ttl');
   return (
-    !ttl.found ||
-    ttl.value === null ||
-    ttl.value === '5m' ||
-    ttl.value === '1h'
+    !ttl.found || ttl.value === null || ttl.value === '5m' || ttl.value === '1h'
   );
 }
 
@@ -365,9 +363,7 @@ function hasValidCallerProperty(record: Record<string, unknown>): boolean {
   return !property.found || isServerToolCaller(property.value);
 }
 
-function hasValidProviderMetadata(
-  record: Record<string, unknown>
-): boolean {
+function hasValidProviderMetadata(record: Record<string, unknown>): boolean {
   const id = readDataProperty(record, 'id');
   if (id.found && !isBoundedProviderPairingString(id.value)) {
     return false;
@@ -399,8 +395,7 @@ function hasValidProviderMetadata(
   }
   const signature = readDataProperty(record, 'thoughtSignature');
   return (
-    !signature.found ||
-    isBoundedProviderPairingString(signature.value, true)
+    !signature.found || isBoundedProviderPairingString(signature.value, true)
   );
 }
 
@@ -492,9 +487,7 @@ export function hasStructurallyValidAnthropicWebSearchResultContent(
   );
 }
 
-function isGoogleCodeExecutionResult(
-  record: Record<string, unknown>
-): boolean {
+function isGoogleCodeExecutionResult(record: Record<string, unknown>): boolean {
   const nested = readDataProperty(record, 'codeExecutionResult');
   const result = nested.found ? getRecord(nested.value) : undefined;
   const outcome = result == null ? undefined : readString(result, 'outcome');
@@ -608,48 +601,42 @@ const LOCAL_RESULT_METADATA_FIELDS = [
   'agentId',
   'groupId',
 ] as const;
-const TOOL_RESULT_ENVELOPE_FIELDS: Readonly<
-  Record<string, readonly string[]>
-> = {
-  advisor_tool_result: ANTHROPIC_RESULT_FIELDS,
-  bash_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
-  code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
-  mcp_tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
-  text_editor_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
-  tool_search_tool_result: ANTHROPIC_RESULT_FIELDS,
-  tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
-  web_fetch_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
-  web_search_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
-  server_tool_call_result: [
-    'type',
-    'toolCallId',
-    'status',
-    'output',
-    ...LOCAL_RESULT_METADATA_FIELDS,
-  ],
-  server_tool_result: [
-    'type',
-    'tool_call_id',
-    'status',
-    'output',
-    ...LOCAL_RESULT_METADATA_FIELDS,
-  ],
-  codeExecutionResult: [
-    'type',
-    'codeExecutionResult',
-    'agentId',
-    'groupId',
-  ],
-  toolResponse: [
-    'type',
-    'toolResponse',
-    'thought',
-    'thoughtSignature',
-    'agentId',
-    'groupId',
-  ],
-  toolResult: ['type', 'toolResult', 'agentId', 'groupId'],
-};
+const TOOL_RESULT_ENVELOPE_FIELDS: Readonly<Record<string, readonly string[]>> =
+  {
+    advisor_tool_result: ANTHROPIC_RESULT_FIELDS,
+    bash_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+    code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+    mcp_tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
+    text_editor_code_execution_tool_result: ANTHROPIC_RESULT_FIELDS,
+    tool_search_tool_result: ANTHROPIC_RESULT_FIELDS,
+    tool_result: ANTHROPIC_GENERIC_RESULT_FIELDS,
+    web_fetch_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
+    web_search_tool_result: ANTHROPIC_SERVER_RESULT_FIELDS,
+    server_tool_call_result: [
+      'type',
+      'toolCallId',
+      'status',
+      'output',
+      ...LOCAL_RESULT_METADATA_FIELDS,
+    ],
+    server_tool_result: [
+      'type',
+      'tool_call_id',
+      'status',
+      'output',
+      ...LOCAL_RESULT_METADATA_FIELDS,
+    ],
+    codeExecutionResult: ['type', 'codeExecutionResult', 'agentId', 'groupId'],
+    toolResponse: [
+      'type',
+      'toolResponse',
+      'thought',
+      'thoughtSignature',
+      'agentId',
+      'groupId',
+    ],
+    toolResult: ['type', 'toolResult', 'agentId', 'groupId'],
+  };
 
 function anthropicDescriptor(
   record: Record<string, unknown>,
@@ -658,9 +645,7 @@ function anthropicDescriptor(
 ): ProviderToolResultPartDescriptor | undefined {
   const toolCallId = readPairingString(record, 'tool_use_id');
   const content = readDataProperty(record, 'content');
-  return toolCallId != null &&
-    content.found &&
-    getRecord(content.value) != null
+  return toolCallId != null && content.found && getRecord(content.value) != null
     ? {
       type,
       toolCallId,
@@ -678,7 +663,8 @@ export function getProviderToolResultPartDescriptor(
     return undefined;
   }
   const type = readString(record, 'type');
-  const allowedFields = type == null ? undefined : TOOL_RESULT_ENVELOPE_FIELDS[type];
+  const allowedFields =
+    type == null ? undefined : TOOL_RESULT_ENVELOPE_FIELDS[type];
   if (
     type == null ||
     allowedFields == null ||
@@ -691,19 +677,14 @@ export function getProviderToolResultPartDescriptor(
   }
   const structuredToolNames = ANTHROPIC_STRUCTURED_RESULT_TOOL_NAMES[type];
   if (structuredToolNames != null) {
-    return anthropicDescriptor(
-      record,
-      type,
-      structuredToolNames
-    );
+    return anthropicDescriptor(record, type, structuredToolNames);
   }
   if (type === 'web_search_tool_result') {
     const toolCallId = readPairingString(record, 'tool_use_id');
     const content = readDataProperty(record, 'content');
     return toolCallId != null &&
       content.found &&
-      (getRecord(content.value) != null ||
-        isOpaqueBoundedArray(content.value))
+      (getRecord(content.value) != null || isOpaqueBoundedArray(content.value))
       ? {
         type,
         toolCallId,
@@ -823,10 +804,7 @@ function getAnthropicCallKind(
   if (type === 'mcp_tool_use') {
     return 'mcp';
   }
-  if (
-    type === 'server_tool_use' ||
-    isAnthropicServerToolCall(callId, name)
-  ) {
+  if (type === 'server_tool_use' || isAnthropicServerToolCall(callId, name)) {
     return 'anthropic-server';
   }
   return 'tool';
@@ -886,11 +864,7 @@ export function getProviderAIMessageToolCallDescriptor(
   const record = getRecord(toolCall);
   if (
     record == null ||
-    !hasExactCallShape(
-      record,
-      AI_TOOL_CALL_FIELDS,
-      ['id', 'name', 'args']
-    ) ||
+    !hasExactCallShape(record, AI_TOOL_CALL_FIELDS, ['id', 'name', 'args']) ||
     !hasOptionalCallType(record, 'tool_call')
   ) {
     return undefined;
@@ -926,18 +900,14 @@ export function getProviderToolCallPartDescriptor(
         ['type', 'tool_call', 'agentId', 'groupId'],
         ['tool_call']
       )
-      : hasExactCallShape(
-        record,
-        STANDARD_CALL_FIELDS,
-        ['id', 'name', 'args']
-      );
+      : hasExactCallShape(record, STANDARD_CALL_FIELDS, ['id', 'name', 'args']);
     const callIsValid = nested.found
       ? call != null &&
-        hasExactCallShape(
-          call,
-          LIBRECHAT_CALL_FIELDS,
-          ['id', 'name', 'args']
-        ) &&
+        hasExactCallShape(call, LIBRECHAT_CALL_FIELDS, [
+          'id',
+          'name',
+          'args',
+        ]) &&
         hasOptionalCallType(call, 'tool_call')
       : call != null;
     if (!outerIsValid || !callIsValid) {
@@ -997,11 +967,7 @@ export function getProviderToolCallPartDescriptor(
   }
   if (type === 'server_tool_call') {
     if (
-      !hasExactCallShape(
-        record,
-        STANDARD_CALL_FIELDS,
-        ['id', 'name', 'args']
-      )
+      !hasExactCallShape(record, STANDARD_CALL_FIELDS, ['id', 'name', 'args'])
     ) {
       return undefined;
     }
@@ -1252,7 +1218,8 @@ const GENERIC_MESSAGE_ROLES: Readonly<Record<string, ProviderMessageRole>> = {
  * generic assistant, tool and function messages the converters accept.
  */
 export function getProviderMessageRole(
-  message: BaseMessage
+  message: BaseMessage,
+  provider?: ProviderName
 ): ProviderMessageRole | undefined {
   const type = message.getType();
   switch (type) {
@@ -1267,6 +1234,9 @@ export function getProviderMessageRole(
   case 'function':
     return 'function';
   case 'generic': {
+    if (provider === 'bedrock') {
+      return 'user';
+    }
     const role = (message as Partial<ChatMessage>).role;
     return typeof role === 'string' ? GENERIC_MESSAGE_ROLES[role] : undefined;
   }
@@ -1313,9 +1283,10 @@ export function getRawToolCallDescriptor(
  */
 export function appendProviderMessageToolCalls(
   message: BaseMessage,
-  calls: ProviderToolCallIndex
+  calls: ProviderToolCallIndex,
+  provider?: ProviderName
 ): number {
-  if (getProviderMessageRole(message) !== 'assistant') {
+  if (getProviderMessageRole(message, provider) !== 'assistant') {
     return 0;
   }
   let recognized = 0;
@@ -1365,9 +1336,10 @@ export function appendProviderMessageToolCalls(
 /** Describes a whole-message tool result: a `ToolMessage`, a `FunctionMessage`,
  *  or a generic message carrying the equivalent wire role. */
 export function getProviderToolMessageResultDescriptor(
-  message: BaseMessage
+  message: BaseMessage,
+  provider?: ProviderName
 ): ProviderToolResultPartDescriptor | undefined {
-  const role = getProviderMessageRole(message);
+  const role = getProviderMessageRole(message, provider);
   if (role === 'function' && message.name != null) {
     const toolCallId = getLegacyFunctionCallId(message.name);
     return toolCallId == null

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -6,6 +6,7 @@ import type {
   ToolMessage,
 } from '@langchain/core/messages';
 import type { ProviderName } from '@/types/llm';
+import { getProviderFamily } from '@/llm/providers';
 
 export type ProviderToolCallKind =
   | 'tool'
@@ -1234,7 +1235,7 @@ export function getProviderMessageRole(
   case 'function':
     return 'function';
   case 'generic': {
-    if (provider === 'bedrock') {
+    if (provider != null && getProviderFamily(provider) === 'bedrock') {
       return 'user';
     }
     const role = (message as Partial<ChatMessage>).role;

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -1210,6 +1210,7 @@ export function createSummarizeNode({
       tailStartIndex,
       usedIntraTurnFallback,
     } = splitAtRecencyBoundary(restoredMessages, {
+      provider: agentContext.provider,
       turns: retainTurns,
       tokens: retainRecent?.tokens,
       tokenCounter: recencyTokenCounter,
@@ -1384,7 +1385,7 @@ export function createSummarizeNode({
           compaction_semantic_index_entries: semanticIndex.entryCount,
           compaction_semantic_index_chars: semanticIndex.charCount,
           compaction_semantic_index_omitted_entries:
-            semanticIndex.omittedEntryCount,
+              semanticIndex.omittedEntryCount,
           /**
              * Per-call model attribution for usage consumers (the subagent
              * usage-capture handler): the summarizer's model can differ from


### PR DESCRIPTION
I consolidated retained tool-message accounting into the provider-payload measurement pass and made generic message roles follow the serving provider.

PR #521 is merged, so this PR is rebased onto and targets `main` as a user-facing-ready follow-up.

- Accumulate retained tool invocation and result usage during the pressure meter existing provider-payload traversal, eliminating the second hot-path walk.
- Preserve the standalone scan for pre-send projections, where no provider measurement exists.
- Aggregate fractional token-counter values before rounding totals and per-tool attribution.
- Interpret generic messages as user turns for Bedrock-family providers while retaining OpenAI and Google role aliases elsewhere.
- Thread provider identity through turn and intra-turn recency splitting so compaction boundaries match the serving converter.
- Propagate accumulator failures into the existing live warning path instead of silently omitting usage fields.
- Add regressions for provider-aware roles, calibration domains, warning propagation, fractional aggregation, and in-pass tool-share measurement.

Closes #519.
Closes #522.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npm audit` (0 vulnerabilities).
- Ran `npx tsc --noEmit`.
- Ran ESLint across all changed files.
- Ran 9 affected Jest suites: 335 tests passed.

### **Test Configuration**:

- Base: `main` after merged PR #521 (`ad61d489`)
- Package manager: npm 10.5.2

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

