### PR TITLE
🧾 fix: Count Raw OpenAI Tool Call Arguments

### DIFF
--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3563,7 +3563,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         beforeToolInputProjection,
         projectToolMessagesForProvider(
           beforeToolInputProjection,
-          calculateMaxToolCallInputChars(agentContext.maxContextTokens)
+          calculateMaxToolCallInputChars(agentContext.maxContextTokens),
+          agentContext.provider
         )
       );
 

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -210,6 +210,27 @@ describe('createContextPressureMeter', () => {
     expect(tokenCounter).toHaveBeenCalledTimes(2);
   });
 
+  it('does not cache messages carrying mutable raw tool calls', () => {
+    const message = new AIMessage('answer');
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+
+    cache.count(message);
+    message.additional_kwargs.tool_calls = [
+      {
+        id: 'raw-call',
+        type: 'function',
+        function: { name: 'lookup', arguments: '{}' },
+      },
+    ];
+    cache.count(message);
+    message.additional_kwargs.tool_calls[0]!.function.arguments =
+      '{"query":"changed"}';
+    cache.count(message);
+
+    expect(tokenCounter).toHaveBeenCalledTimes(3);
+  });
+
   it('matches forced recounts across append, replace, reorder, and mutation', () => {
     const first = new HumanMessage({ id: 'first', content: 'one' });
     const second = new HumanMessage({ id: 'second', content: 'two' });

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -256,6 +256,22 @@ describe('createContextPressureMeter', () => {
     expect(tokenCounter).toHaveBeenCalledTimes(2);
   });
 
+  it('recounts inherited revoked parsed tool-call proxies safely', () => {
+    const message = new AIMessage('answer');
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+    const { proxy, revoke } = Proxy.revocable([], {});
+    const inherited = Object.create(Object.getPrototypeOf(message));
+    Object.defineProperty(inherited, 'tool_calls', { value: proxy });
+    delete message.tool_calls;
+    Object.setPrototypeOf(message, inherited);
+    revoke();
+
+    expect(() => cache.count(message)).not.toThrow();
+    expect(() => cache.count(message)).not.toThrow();
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
   it('matches forced recounts across append, replace, reorder, and mutation', () => {
     const first = new HumanMessage({ id: 'first', content: 'one' });
     const second = new HumanMessage({ id: 'second', content: 'two' });

--- a/src/llm/contextPressureMeter.test.ts
+++ b/src/llm/contextPressureMeter.test.ts
@@ -231,6 +231,31 @@ describe('createContextPressureMeter', () => {
     expect(tokenCounter).toHaveBeenCalledTimes(3);
   });
 
+  it('does not invoke prototype proxy traps during cache checks', () => {
+    const message = new AIMessage('answer');
+    const tokenCounter = jest.fn(contentLength);
+    const cache = createExactTokenCountCache(tokenCounter);
+    let hasCalls = 0;
+    Object.setPrototypeOf(
+      message.additional_kwargs,
+      new Proxy(
+        {},
+        {
+          has: () => {
+            hasCalls += 1;
+            throw new Error('must not run');
+          },
+        }
+      )
+    );
+
+    cache.count(message);
+    cache.count(message);
+
+    expect(hasCalls).toBe(0);
+    expect(tokenCounter).toHaveBeenCalledTimes(2);
+  });
+
   it('matches forced recounts across append, replace, reorder, and mutation', () => {
     const first = new HumanMessage({ id: 'first', content: 'one' });
     const second = new HumanMessage({ id: 'second', content: 'two' });

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -10,7 +10,7 @@ import {
   isSyntheticProviderContextMessage,
 } from '@/messages';
 import { createToolMessageUsageAccumulator } from '@/messages/budget';
-import { apportionTokenCounts } from '@/utils';
+import { readTokenMetadataProperty, apportionTokenCounts } from '@/utils';
 
 interface ContextPressureUsage {
   contextBudget?: number;
@@ -91,6 +91,21 @@ function readDataProperty(
     : { own: true, safe: false };
 }
 
+function readCacheMetadataProperty(
+  owner: object,
+  property: PropertyKey,
+  path: string
+): { safe: boolean; value?: unknown } {
+  try {
+    return {
+      safe: true,
+      value: readTokenMetadataProperty(owner, property, path),
+    };
+  } catch {
+    return { safe: false };
+  }
+}
+
 function getStableTokenSurface(
   message: BaseMessage
 ): StableTokenSurface | undefined {
@@ -107,10 +122,13 @@ function getStableTokenSurface(
   }
   const messageType = message.getType();
   const roleProperty = readDataProperty(message, 'role');
-  if (!roleProperty.safe || (!roleProperty.own && 'role' in message)) {
+  const resolvedRoleProperty = roleProperty.own
+    ? roleProperty
+    : readCacheMetadataProperty(message, 'role', 'message.role');
+  if (!resolvedRoleProperty.safe) {
     return undefined;
   }
-  const role = roleProperty.value;
+  const role = resolvedRoleProperty.value;
   if (role != null && typeof role !== 'string') {
     return undefined;
   }
@@ -131,11 +149,12 @@ function getStableTokenSurface(
     return undefined;
   }
   const additionalKwargs = rawAdditionalKwargs;
-  try {
-    if ('tool_calls' in additionalKwargs) {
-      return undefined;
-    }
-  } catch {
+  const rawToolCalls = readCacheMetadataProperty(
+    additionalKwargs,
+    'tool_calls',
+    'additional_kwargs.tool_calls'
+  );
+  if (!rawToolCalls.safe || rawToolCalls.value != null) {
     return undefined;
   }
   const typeProperty = readDataProperty(additionalKwargs, 'type');
@@ -147,13 +166,13 @@ function getStableTokenSurface(
       message as AIMessage,
       'tool_calls'
     );
-    if (
-      !toolCallsProperty.safe ||
-      (!toolCallsProperty.own && 'tool_calls' in message)
-    ) {
+    const resolvedToolCallsProperty = toolCallsProperty.own
+      ? toolCallsProperty
+      : readCacheMetadataProperty(message, 'tool_calls', 'message.tool_calls');
+    if (!resolvedToolCallsProperty.safe) {
       return undefined;
     }
-    const toolCalls = toolCallsProperty.value;
+    const toolCalls = resolvedToolCallsProperty.value;
     if (
       toolCalls != null &&
       (!Array.isArray(toolCalls) || isProxy(toolCalls) || toolCalls.length > 0)

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -175,7 +175,7 @@ function getStableTokenSurface(
     const toolCalls = resolvedToolCallsProperty.value;
     if (
       toolCalls != null &&
-      (!Array.isArray(toolCalls) || isProxy(toolCalls) || toolCalls.length > 0)
+      (isProxy(toolCalls) || !Array.isArray(toolCalls) || toolCalls.length > 0)
     ) {
       return undefined;
     }

--- a/src/llm/contextPressureMeter.ts
+++ b/src/llm/contextPressureMeter.ts
@@ -131,6 +131,13 @@ function getStableTokenSurface(
     return undefined;
   }
   const additionalKwargs = rawAdditionalKwargs;
+  try {
+    if ('tool_calls' in additionalKwargs) {
+      return undefined;
+    }
+  } catch {
+    return undefined;
+  }
   const typeProperty = readDataProperty(additionalKwargs, 'type');
   if (!typeProperty.safe) {
     return undefined;

--- a/src/messages/prune.ts
+++ b/src/messages/prune.ts
@@ -2104,7 +2104,8 @@ function projectToolCallInputsInternal(
   messages: BaseMessage[],
   maxInputChars: number,
   dropIncompleteStreamContent: boolean,
-  fromIndex = 0
+  fromIndex = 0,
+  retainRawOpenAIToolCalls = true
 ): BaseMessage[] {
   const normalizedMaxInputChars = normalizeToolInputLimit(maxInputChars);
   let projectedMessages: BaseMessage[] | undefined;
@@ -2191,15 +2192,20 @@ function projectToolCallInputsInternal(
       }
     }
 
-    const additionalKwargsChanges: Record<string, unknown> =
-      rawAdditionalToolCallsProperty.accessor ? { tool_calls: undefined } : {};
-    const rawToolCalls = projectRawOpenAIToolCalls(
-      rawAdditionalToolCalls,
-      normalizedMaxInputChars,
-      canonicalArguments
-    );
-    if (rawToolCalls.changed) {
-      additionalKwargsChanges.tool_calls = rawToolCalls.value;
+    const additionalKwargsChanges: Record<string, unknown> = {};
+    if (!retainRawOpenAIToolCalls && rawAdditionalToolCallsProperty.found) {
+      additionalKwargsChanges.tool_calls = undefined;
+    } else if (rawAdditionalToolCallsProperty.accessor) {
+      additionalKwargsChanges.tool_calls = undefined;
+    } else {
+      const rawToolCalls = projectRawOpenAIToolCalls(
+        rawAdditionalToolCalls,
+        normalizedMaxInputChars,
+        canonicalArguments
+      );
+      if (rawToolCalls.changed) {
+        additionalKwargsChanges.tool_calls = rawToolCalls.value;
+      }
     }
     const legacyFunctionCall = projectLegacyFunctionCall(
       readPropertyWithoutAccessors(
@@ -2292,9 +2298,22 @@ export function projectToolCallInputs(
  */
 export function projectToolMessagesForProvider(
   messages: BaseMessage[],
-  maxInputChars: number
+  maxInputChars: number,
+  provider?: ProviderName
 ): BaseMessage[] {
-  return projectToolCallInputsInternal(messages, maxInputChars, true);
+  const providerFamily =
+    provider == null ? undefined : getProviderFamily(provider);
+  const retainRawOpenAIToolCalls =
+    provider == null ||
+    provider === Providers.OPENAI ||
+    providerFamily === 'openai';
+  return projectToolCallInputsInternal(
+    messages,
+    maxInputChars,
+    true,
+    0,
+    retainRawOpenAIToolCalls
+  );
 }
 
 function applyToolCallInputCaps(params: {

--- a/src/specs/prune.test.ts
+++ b/src/specs/prune.test.ts
@@ -113,7 +113,6 @@ function getMessagesWithinTokenLimit({
 } {
   // Every reply is primed with <|start|>assistant<|message|>, so we
   // start with 3 tokens for the label after all messages have been counted.
-  let summaryIndex = -1;
   let currentTokenCount = 3;
   const instructions =
     _messages[0]?.getType() === 'system' ? _messages[0] : undefined;
@@ -169,7 +168,7 @@ function getMessagesWithinTokenLimit({
   }
 
   const prunedMemory = messages;
-  summaryIndex = prunedMemory.length - 1;
+  const summaryIndex = prunedMemory.length - 1;
   remainingContextTokens -= currentTokenCount;
 
   return {
@@ -1486,6 +1485,35 @@ describe('Prune Messages Tests', () => {
       ];
 
       expect(projectToolMessagesForProvider(messages, 200)).toBe(messages);
+    });
+
+    it('removes raw OpenAI calls from non-OpenAI provider projections', () => {
+      const message = new AIMessage('');
+      message.additional_kwargs.tool_calls = [
+        {
+          id: 'raw-call',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+          },
+        },
+      ];
+
+      const [anthropicMessage] = projectToolMessagesForProvider(
+        [message],
+        200,
+        Providers.ANTHROPIC
+      );
+      const [openAIMessage] = projectToolMessagesForProvider(
+        [message],
+        200,
+        Providers.OPENAI
+      );
+
+      expect(anthropicMessage.additional_kwargs.tool_calls).toBeUndefined();
+      expect(openAIMessage.additional_kwargs.tool_calls).toBeDefined();
+      expect(message.additional_kwargs.tool_calls).toBeDefined();
     });
 
     it('uses the shared 15%-of-context cap with a 200K ceiling', () => {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -252,6 +252,56 @@ describe('getTokenCountForMessage', () => {
     expect(count).toBeGreaterThan(5_000);
   });
 
+  test('counts raw OpenAI tool calls when parsed tool_calls are absent', () => {
+    const message = new AIMessage('');
+    message.additional_kwargs.tool_calls = [
+      {
+        id: 'raw-call',
+        type: 'function',
+        function: {
+          name: 'raw_lookup',
+          arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+        },
+      },
+    ];
+
+    const count = getTokenCountForMessage(message, (text) => text.length);
+
+    expect(message.tool_calls).toHaveLength(0);
+    expect(count).toBeGreaterThan(5_000);
+  });
+
+  test('does not double-count raw OpenAI calls mirrored in parsed tool_calls', () => {
+    const parsed = new AIMessage({
+      content: '',
+      tool_calls: [
+        { id: 'mirrored-call', name: 'lookup', args: { query: 'value' } },
+      ],
+    });
+    const mirrored = new AIMessage({
+      content: '',
+      tool_calls: [
+        { id: 'mirrored-call', name: 'lookup', args: { query: 'value' } },
+      ],
+      additional_kwargs: {
+        tool_calls: [
+          {
+            id: 'mirrored-call',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: '{"query":"value"}',
+            },
+          },
+        ],
+      },
+    });
+
+    expect(getTokenCountForMessage(mirrored, (text) => text.length)).toBe(
+      getTokenCountForMessage(parsed, (text) => text.length)
+    );
+  });
+
   test('keeps nested dense strings on the bounded structured path', () => {
     const callbackLengths: number[] = [];
     const payload = 'x'.repeat(4 * 1024 * 1024);

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -302,6 +302,61 @@ describe('getTokenCountForMessage', () => {
     );
   });
 
+  test('counts inherited raw OpenAI tool calls', () => {
+    const message = new AIMessage('');
+    Object.setPrototypeOf(message.additional_kwargs, {
+      tool_calls: [
+        {
+          id: 'inherited-call',
+          type: 'function',
+          function: {
+            name: 'lookup',
+            arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+          },
+        },
+      ],
+    });
+
+    expect(
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toBeGreaterThan(5_000);
+  });
+
+  test('rejects a revoked raw tool-call proxy with the typed error', () => {
+    const message = new AIMessage('');
+    const { proxy, revoke } = Proxy.revocable([], {});
+    message.additional_kwargs.tool_calls = proxy;
+    revoke();
+
+    expect(() =>
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toThrow(UnsafeTokenMeasurementError);
+  });
+
+  test('rejects raw tool-call array accessors without invoking them', () => {
+    const message = new AIMessage('');
+    const rawCalls: Array<{
+      id: string;
+      type: 'function';
+      function: { name: string; arguments: string };
+    }> = [];
+    let getterCalls = 0;
+    Object.defineProperty(rawCalls, '0', {
+      configurable: true,
+      get: () => {
+        getterCalls += 1;
+        throw new Error('must not run');
+      },
+    });
+    rawCalls.length = 1;
+    message.additional_kwargs.tool_calls = rawCalls;
+
+    expect(() =>
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toThrow(UnsafeTokenMeasurementError);
+    expect(getterCalls).toBe(0);
+  });
+
   test('keeps nested dense strings on the bounded structured path', () => {
     const callbackLengths: number[] = [];
     const payload = 'x'.repeat(4 * 1024 * 1024);

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -302,6 +302,56 @@ describe('getTokenCountForMessage', () => {
     );
   });
 
+  test('ignores stale raw OpenAI calls when parsed calls drive serialization', () => {
+    const parsed = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'parsed-call', name: 'lookup', args: {} }],
+    });
+    const stale = new AIMessage({
+      content: '',
+      tool_calls: [{ id: 'parsed-call', name: 'lookup', args: {} }],
+      additional_kwargs: {
+        tool_calls: [
+          {
+            id: 'stale-call',
+            type: 'function',
+            function: {
+              name: 'lookup',
+              arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(getTokenCountForMessage(stale, (text) => text.length)).toBe(
+      getTokenCountForMessage(parsed, (text) => text.length)
+    );
+  });
+
+  test('counts duplicate ids within the raw OpenAI representation', () => {
+    const single = new AIMessage('');
+    const duplicate = new AIMessage('');
+    const rawCall = {
+      id: 'reused-call',
+      type: 'function' as const,
+      function: {
+        name: 'lookup',
+        arguments: `{"query":"${'x'.repeat(5_000)}"}`,
+      },
+    };
+    single.additional_kwargs.tool_calls = [rawCall];
+    duplicate.additional_kwargs.tool_calls = [rawCall, rawCall];
+
+    const singleCount = getTokenCountForMessage(single, (text) => text.length);
+    const duplicateCount = getTokenCountForMessage(
+      duplicate,
+      (text) => text.length
+    );
+
+    expect(duplicateCount).toBeGreaterThan(singleCount + 5_000);
+  });
+
   test('counts inherited raw OpenAI tool calls', () => {
     const message = new AIMessage('');
     Object.setPrototypeOf(message.additional_kwargs, {
@@ -350,6 +400,28 @@ describe('getTokenCountForMessage', () => {
     });
     rawCalls.length = 1;
     message.additional_kwargs.tool_calls = rawCalls;
+
+    expect(() =>
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toThrow(UnsafeTokenMeasurementError);
+    expect(getterCalls).toBe(0);
+  });
+
+  test('rejects nested raw tool-call accessors without invoking them', () => {
+    const message = new AIMessage('');
+    const rawCall = {
+      id: 'raw-call',
+      type: 'function' as const,
+      function: { name: 'lookup', arguments: '{}' },
+    };
+    let getterCalls = 0;
+    Object.defineProperty(rawCall, 'function', {
+      get: () => {
+        getterCalls += 1;
+        throw new Error('must not run');
+      },
+    });
+    message.additional_kwargs.tool_calls = [rawCall];
 
     expect(() =>
       getTokenCountForMessage(message, (text) => text.length)

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -371,6 +371,33 @@ describe('getTokenCountForMessage', () => {
     ).toBeGreaterThan(5_000);
   });
 
+  test('counts raw OpenAI custom tool inputs', () => {
+    const message = new AIMessage('');
+    Reflect.set(message.additional_kwargs, 'tool_calls', [
+      {
+        id: 'custom-call',
+        type: 'custom',
+        custom: {
+          name: 'shell',
+          input: 'x'.repeat(5_000),
+        },
+      },
+    ]);
+
+    expect(
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toBeGreaterThan(5_000);
+  });
+
+  test('rejects raw tool-call arrays beyond the traversal limit', () => {
+    const message = new AIMessage('');
+    message.additional_kwargs.tool_calls = new Array(10_001);
+
+    expect(() =>
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toThrow(UnsafeTokenMeasurementError);
+  });
+
   test('counts inherited raw OpenAI tool calls', () => {
     const message = new AIMessage('');
     Object.setPrototypeOf(message.additional_kwargs, {

--- a/src/specs/tokens.test.ts
+++ b/src/specs/tokens.test.ts
@@ -352,6 +352,25 @@ describe('getTokenCountForMessage', () => {
     expect(duplicateCount).toBeGreaterThan(singleCount + 5_000);
   });
 
+  test('counts non-enumerable raw OpenAI function arguments', () => {
+    const message = new AIMessage('');
+    const rawFunction = { name: 'lookup', arguments: '' };
+    Object.defineProperty(rawFunction, 'arguments', {
+      value: `{"query":"${'x'.repeat(5_000)}"}`,
+    });
+    message.additional_kwargs.tool_calls = [
+      {
+        id: 'non-enumerable-call',
+        type: 'function',
+        function: rawFunction,
+      },
+    ];
+
+    expect(
+      getTokenCountForMessage(message, (text) => text.length)
+    ).toBeGreaterThan(5_000);
+  });
+
   test('counts inherited raw OpenAI tool calls', () => {
     const message = new AIMessage('');
     Object.setPrototypeOf(message.additional_kwargs, {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1157,6 +1157,7 @@ export function getTokenCountForMessage(
   const messageRole = (message as BaseMessage & { role?: unknown }).role;
   if (messageType === 'ai' || messageRole === 'assistant') {
     const toolCalls = (message as AIMessage).tool_calls ?? [];
+    const parsedToolCallIds = new Set<string>();
     if (isProxy(toolCalls)) {
       throw new UnsafeTokenMeasurementError({
         reason: 'metadata_proxy',
@@ -1176,6 +1177,9 @@ export function getTokenCountForMessage(
       ) {
         continue;
       }
+      if (typeof toolCall.id === 'string' && toolCall.id.length > 0) {
+        parsedToolCallIds.add(toolCall.id);
+      }
       if (typeof toolCall.name === 'string' && toolCall.name.length > 0) {
         numTokens += countText(toolCall.name);
       }
@@ -1185,6 +1189,75 @@ export function getTokenCountForMessage(
           typeof args === 'string'
             ? countText(args)
             : getBoundedStructuredTokenCount(args, countText);
+      }
+    }
+    let rawToolCalls: PropertyDescriptor | undefined;
+    try {
+      rawToolCalls =
+        additionalKwargs != null
+          ? Object.getOwnPropertyDescriptor(additionalKwargs, 'tool_calls')
+          : undefined;
+    } catch {
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_accessor',
+        path: 'additional_kwargs.tool_calls',
+      });
+    }
+    if (rawToolCalls != null) {
+      if (!('value' in rawToolCalls)) {
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_accessor',
+          path: 'additional_kwargs.tool_calls',
+        });
+      }
+      const rawCalls = rawToolCalls.value;
+      if (rawCalls != null) {
+        if (!Array.isArray(rawCalls) || isProxy(rawCalls)) {
+          throw new UnsafeTokenMeasurementError({
+            reason: 'metadata_proxy',
+            path: 'additional_kwargs.tool_calls',
+          });
+        }
+        for (let i = 0; i < rawCalls.length; i++) {
+          const rawCall = rawCalls[i];
+          if (
+            rawCall == null ||
+            typeof rawCall !== 'object' ||
+            isProxy(rawCall)
+          ) {
+            throw new UnsafeTokenMeasurementError({
+              reason: 'metadata_proxy',
+              path: `additional_kwargs.tool_calls[${i}]`,
+            });
+          }
+          let id: PropertyDescriptor | undefined;
+          try {
+            id = Object.getOwnPropertyDescriptor(rawCall, 'id');
+          } catch {
+            throw new UnsafeTokenMeasurementError({
+              reason: 'metadata_accessor',
+              path: `additional_kwargs.tool_calls[${i}].id`,
+            });
+          }
+          if (id != null && !('value' in id)) {
+            throw new UnsafeTokenMeasurementError({
+              reason: 'metadata_accessor',
+              path: `additional_kwargs.tool_calls[${i}].id`,
+            });
+          }
+          const callId = id?.value;
+          if (
+            typeof callId === 'string' &&
+            (representedToolCallIds.has(callId) ||
+              parsedToolCallIds.has(callId))
+          ) {
+            continue;
+          }
+          numTokens += getBoundedStructuredTokenCount(rawCall, countText);
+          if (typeof callId === 'string' && callId.length > 0) {
+            representedToolCallIds.add(callId);
+          }
+        }
       }
     }
     let legacyFunctionCall: PropertyDescriptor | undefined;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -16,6 +16,7 @@ export type UnsafeTokenMeasurementReason =
   | 'content_proxy'
   | 'metadata_proxy'
   | 'metadata_accessor'
+  | 'metadata_limit'
   | 'invalid_count';
 
 export class UnsafeTokenMeasurementError extends Error {
@@ -121,6 +122,7 @@ const MAX_STRUCTURED_TOKENIZATION_CHARS = 200_000;
 /** One UTF-16 character can encode to several tokenizer pieces. */
 const MAX_TOKENS_PER_OMITTED_STRUCTURED_CHAR = 4;
 const MAX_STRUCTURED_SAFETY_INSPECTION_WORK = 10_000;
+const MAX_RAW_TOOL_CALLS = MAX_STRUCTURED_SAFETY_INSPECTION_WORK;
 /** Bounds BPE work per plain-text segment without omitting any text. */
 const MAX_TEXT_TOKENIZATION_CHARS = 8_192;
 /** Covers tokenizer segmentation changes on both sides of a chunk boundary. */
@@ -1265,6 +1267,12 @@ export function getTokenCountForMessage(
           path: 'additional_kwargs.tool_calls',
         });
       }
+      if (rawCalls.length > MAX_RAW_TOOL_CALLS) {
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_limit',
+          path: 'additional_kwargs.tool_calls',
+        });
+      }
       for (let i = 0; i < rawCalls.length; i++) {
         const rawCall = readTokenMetadataProperty(
           rawCalls,
@@ -1303,6 +1311,11 @@ export function getTokenCountForMessage(
           'function',
           `${callPath}.function`
         );
+        const rawCustom = readTokenMetadataProperty(
+          rawCall,
+          'custom',
+          `${callPath}.custom`
+        );
         let projectedFunction = rawFunction;
         if (rawFunction != null && typeof rawFunction === 'object') {
           if (hasUnsafeStructuredSerialization(rawFunction)) {
@@ -1323,11 +1336,36 @@ export function getTokenCountForMessage(
           );
           projectedFunction = { name, arguments: args };
         }
+        let projectedCustom = rawCustom;
+        if (rawCustom != null && typeof rawCustom === 'object') {
+          if (hasUnsafeStructuredSerialization(rawCustom)) {
+            throw new UnsafeTokenMeasurementError({
+              reason: 'metadata_accessor',
+              path: `${callPath}.custom`,
+            });
+          }
+          const name = readTokenMetadataProperty(
+            rawCustom,
+            'name',
+            `${callPath}.custom.name`
+          );
+          const input = readTokenMetadataProperty(
+            rawCustom,
+            'input',
+            `${callPath}.custom.input`
+          );
+          projectedCustom = { name, input };
+        }
         if (typeof callId === 'string' && representedToolCallIds.has(callId)) {
           continue;
         }
         numTokens += getBoundedStructuredTokenCount(
-          { id: callId, type: callType, function: projectedFunction },
+          {
+            id: callId,
+            type: callType,
+            custom: projectedCustom,
+            function: projectedFunction,
+          },
           countText
         );
       }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -1214,7 +1214,6 @@ export function getTokenCountForMessage(
   const messageRole = (message as BaseMessage & { role?: unknown }).role;
   if (messageType === 'ai' || messageRole === 'assistant') {
     const toolCalls = (message as AIMessage).tool_calls ?? [];
-    const parsedToolCallIds = new Set<string>();
     if (isProxy(toolCalls)) {
       throw new UnsafeTokenMeasurementError({
         reason: 'metadata_proxy',
@@ -1234,9 +1233,6 @@ export function getTokenCountForMessage(
       ) {
         continue;
       }
-      if (typeof toolCall.id === 'string' && toolCall.id.length > 0) {
-        parsedToolCallIds.add(toolCall.id);
-      }
       if (typeof toolCall.name === 'string' && toolCall.name.length > 0) {
         numTokens += countText(toolCall.name);
       }
@@ -1249,7 +1245,7 @@ export function getTokenCountForMessage(
       }
     }
     const rawCalls =
-      additionalKwargs == null
+      toolCalls.length > 0 || additionalKwargs == null
         ? undefined
         : readTokenMetadataProperty(
           additionalKwargs,
@@ -1285,32 +1281,39 @@ export function getTokenCountForMessage(
             path: `additional_kwargs.tool_calls[${i}]`,
           });
         }
-        let id: PropertyDescriptor | undefined;
-        try {
-          id = Object.getOwnPropertyDescriptor(rawCall, 'id');
-        } catch {
+        const callPath = `additional_kwargs.tool_calls[${i}]`;
+        if (hasUnsafeStructuredSerialization(rawCall)) {
           throw new UnsafeTokenMeasurementError({
             reason: 'metadata_accessor',
-            path: `additional_kwargs.tool_calls[${i}].id`,
+            path: callPath,
           });
         }
-        if (id != null && !('value' in id)) {
-          throw new UnsafeTokenMeasurementError({
-            reason: 'metadata_accessor',
-            path: `additional_kwargs.tool_calls[${i}].id`,
-          });
+        const callId = readTokenMetadataProperty(
+          rawCall,
+          'id',
+          `${callPath}.id`
+        );
+        const rawFunction = readTokenMetadataProperty(
+          rawCall,
+          'function',
+          `${callPath}.function`
+        );
+        if (rawFunction != null && typeof rawFunction === 'object') {
+          readTokenMetadataProperty(
+            rawFunction,
+            'name',
+            `${callPath}.function.name`
+          );
+          readTokenMetadataProperty(
+            rawFunction,
+            'arguments',
+            `${callPath}.function.arguments`
+          );
         }
-        const callId = id?.value;
-        if (
-          typeof callId === 'string' &&
-          (representedToolCallIds.has(callId) || parsedToolCallIds.has(callId))
-        ) {
+        if (typeof callId === 'string' && representedToolCallIds.has(callId)) {
           continue;
         }
         numTokens += getBoundedStructuredTokenCount(rawCall, countText);
-        if (typeof callId === 'string' && callId.length > 0) {
-          representedToolCallIds.add(callId);
-        }
       }
     }
     let legacyFunctionCall: PropertyDescriptor | undefined;

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -946,6 +946,63 @@ function getBoundedStructuredTokenCount(
   );
 }
 
+function readTokenMetadataProperty(
+  value: object,
+  key: PropertyKey,
+  path: string
+): unknown {
+  const seen = new Set<object>();
+  let current: object | null = value;
+  for (let depth = 0; current != null && depth < 100; depth++) {
+    if (isProxy(current)) {
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_proxy',
+        path,
+      });
+    }
+    if (seen.has(current)) {
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_accessor',
+        path,
+      });
+    }
+    seen.add(current);
+    let descriptor: PropertyDescriptor | undefined;
+    try {
+      descriptor = Object.getOwnPropertyDescriptor(current, key);
+    } catch {
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_accessor',
+        path,
+      });
+    }
+    if (descriptor != null) {
+      if (!('value' in descriptor)) {
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_accessor',
+          path,
+        });
+      }
+      return descriptor.value;
+    }
+    try {
+      current = Object.getPrototypeOf(current) as object | null;
+    } catch {
+      throw new UnsafeTokenMeasurementError({
+        reason: 'metadata_accessor',
+        path,
+      });
+    }
+  }
+  if (current != null) {
+    throw new UnsafeTokenMeasurementError({
+      reason: 'metadata_accessor',
+      path,
+    });
+  }
+  return undefined;
+}
+
 export function getTokenCountForMessage(
   message: BaseMessage,
   getTokenCount: (text: string) => number,
@@ -1191,72 +1248,68 @@ export function getTokenCountForMessage(
             : getBoundedStructuredTokenCount(args, countText);
       }
     }
-    let rawToolCalls: PropertyDescriptor | undefined;
-    try {
-      rawToolCalls =
-        additionalKwargs != null
-          ? Object.getOwnPropertyDescriptor(additionalKwargs, 'tool_calls')
-          : undefined;
-    } catch {
-      throw new UnsafeTokenMeasurementError({
-        reason: 'metadata_accessor',
-        path: 'additional_kwargs.tool_calls',
-      });
-    }
-    if (rawToolCalls != null) {
-      if (!('value' in rawToolCalls)) {
+    const rawCalls =
+      additionalKwargs == null
+        ? undefined
+        : readTokenMetadataProperty(
+          additionalKwargs,
+          'tool_calls',
+          'additional_kwargs.tool_calls'
+        );
+    if (rawCalls != null) {
+      if (isProxy(rawCalls)) {
+        throw new UnsafeTokenMeasurementError({
+          reason: 'metadata_proxy',
+          path: 'additional_kwargs.tool_calls',
+        });
+      }
+      if (!Array.isArray(rawCalls)) {
         throw new UnsafeTokenMeasurementError({
           reason: 'metadata_accessor',
           path: 'additional_kwargs.tool_calls',
         });
       }
-      const rawCalls = rawToolCalls.value;
-      if (rawCalls != null) {
-        if (!Array.isArray(rawCalls) || isProxy(rawCalls)) {
+      for (let i = 0; i < rawCalls.length; i++) {
+        const rawCall = readTokenMetadataProperty(
+          rawCalls,
+          String(i),
+          `additional_kwargs.tool_calls[${i}]`
+        );
+        if (
+          rawCall == null ||
+          typeof rawCall !== 'object' ||
+          isProxy(rawCall)
+        ) {
           throw new UnsafeTokenMeasurementError({
             reason: 'metadata_proxy',
-            path: 'additional_kwargs.tool_calls',
+            path: `additional_kwargs.tool_calls[${i}]`,
           });
         }
-        for (let i = 0; i < rawCalls.length; i++) {
-          const rawCall = rawCalls[i];
-          if (
-            rawCall == null ||
-            typeof rawCall !== 'object' ||
-            isProxy(rawCall)
-          ) {
-            throw new UnsafeTokenMeasurementError({
-              reason: 'metadata_proxy',
-              path: `additional_kwargs.tool_calls[${i}]`,
-            });
-          }
-          let id: PropertyDescriptor | undefined;
-          try {
-            id = Object.getOwnPropertyDescriptor(rawCall, 'id');
-          } catch {
-            throw new UnsafeTokenMeasurementError({
-              reason: 'metadata_accessor',
-              path: `additional_kwargs.tool_calls[${i}].id`,
-            });
-          }
-          if (id != null && !('value' in id)) {
-            throw new UnsafeTokenMeasurementError({
-              reason: 'metadata_accessor',
-              path: `additional_kwargs.tool_calls[${i}].id`,
-            });
-          }
-          const callId = id?.value;
-          if (
-            typeof callId === 'string' &&
-            (representedToolCallIds.has(callId) ||
-              parsedToolCallIds.has(callId))
-          ) {
-            continue;
-          }
-          numTokens += getBoundedStructuredTokenCount(rawCall, countText);
-          if (typeof callId === 'string' && callId.length > 0) {
-            representedToolCallIds.add(callId);
-          }
+        let id: PropertyDescriptor | undefined;
+        try {
+          id = Object.getOwnPropertyDescriptor(rawCall, 'id');
+        } catch {
+          throw new UnsafeTokenMeasurementError({
+            reason: 'metadata_accessor',
+            path: `additional_kwargs.tool_calls[${i}].id`,
+          });
+        }
+        if (id != null && !('value' in id)) {
+          throw new UnsafeTokenMeasurementError({
+            reason: 'metadata_accessor',
+            path: `additional_kwargs.tool_calls[${i}].id`,
+          });
+        }
+        const callId = id?.value;
+        if (
+          typeof callId === 'string' &&
+          (representedToolCallIds.has(callId) || parsedToolCallIds.has(callId))
+        ) {
+          continue;
+        }
+        numTokens += getBoundedStructuredTokenCount(rawCall, countText);
+        if (typeof callId === 'string' && callId.length > 0) {
+          representedToolCallIds.add(callId);
         }
       }
     }

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -946,7 +946,7 @@ function getBoundedStructuredTokenCount(
   );
 }
 
-function readTokenMetadataProperty(
+export function readTokenMetadataProperty(
   value: object,
   key: PropertyKey,
   path: string
@@ -1293,27 +1293,43 @@ export function getTokenCountForMessage(
           'id',
           `${callPath}.id`
         );
+        const callType = readTokenMetadataProperty(
+          rawCall,
+          'type',
+          `${callPath}.type`
+        );
         const rawFunction = readTokenMetadataProperty(
           rawCall,
           'function',
           `${callPath}.function`
         );
+        let projectedFunction = rawFunction;
         if (rawFunction != null && typeof rawFunction === 'object') {
-          readTokenMetadataProperty(
+          if (hasUnsafeStructuredSerialization(rawFunction)) {
+            throw new UnsafeTokenMeasurementError({
+              reason: 'metadata_accessor',
+              path: `${callPath}.function`,
+            });
+          }
+          const name = readTokenMetadataProperty(
             rawFunction,
             'name',
             `${callPath}.function.name`
           );
-          readTokenMetadataProperty(
+          const args = readTokenMetadataProperty(
             rawFunction,
             'arguments',
             `${callPath}.function.arguments`
           );
+          projectedFunction = { name, arguments: args };
         }
         if (typeof callId === 'string' && representedToolCallIds.has(callId)) {
           continue;
         }
-        numTokens += getBoundedStructuredTokenCount(rawCall, countText);
+        numTokens += getBoundedStructuredTokenCount(
+          { id: callId, type: callType, function: projectedFunction },
+          countText
+        );
       }
     }
     let legacyFunctionCall: PropertyDescriptor | undefined;


### PR DESCRIPTION
I fixed the default token counter so raw OpenAI tool calls contribute their serialized inputs to context accounting when LangChain has not populated parsed `tool_calls`.

- Count `additional_kwargs.tool_calls` through a bounded provider-field projection only when that raw representation drives provider serialization.
- Count inherited and non-enumerable function and custom-tool fields through descriptor-safe reads.
- Deduplicate raw calls already represented by content blocks while preserving duplicate IDs within one raw array.
- Reject proxy, inherited-accessor, array-accessor, nested-accessor, and oversized sparse-array metadata without invoking unsafe values or performing unbounded traversal.
- Remove raw OpenAI call metadata from non-OpenAI provider projections while preserving canonical history.
- Reuse bounded descriptor traversal for exact-count cache eligibility and disable caching for messages carrying mutable raw tool calls.
- Add regressions for raw-only calls, parsed-versus-raw precedence, provider switching, inherited metadata, non-enumerable arguments, custom inputs, unsafe accessors and proxies, cache invalidation, sparse arrays, and duplicate raw IDs.

This independently addresses the third remaining case in #520. Merged PR #521 addresses the issue first two retained tool-shape cases.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran 3 affected Jest suites: 180 tests passed.
- Ran `npx tsc --noEmit`.
- Ran ESLint across all changed files with no warnings.
- Ran `npm audit` (0 vulnerabilities).

### **Test Configuration**:

- Base: latest `main` after merged PRs #521 and #523 (`e0334bf4`)
- Package manager: npm 10.5.2

## Checklist

- [x] My code adheres to this project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
