### PR TITLE
🧬 refactor: Share Ordered Tool History Projection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -244,6 +244,14 @@ specific replay and wire shaping remain later request projections.
 
 ## Model Context Reconstruction
 
+An **Ordered Tool History Projection** preserves the contributions carried by
+provider history together with their order, actor, item identity, and text or
+media payload. Complete Responses output and partial streaming sidecars have
+different coverage: a sidecar cannot replace ordinary message content or prove
+its position without recorded replay positions. Folding and replay share source
+selection and generated-image interpretation. Native replay policy remains in
+request preparation; the projection never mutates checkpoint messages.
+
 A **Session Log** is the append-only source of persisted conversation events.
 It retains message, summary, and lifecycle history without becoming a second
 mutable message state.

--- a/docs/tool-history-projection.md
+++ b/docs/tool-history-projection.md
@@ -18,6 +18,13 @@ is authoritative, including `false`; a Responses default cannot override an
 explicit Chat selection. Graph regressions exercise both directions and a failed
 intermediate fallback, including source provenance and native media.
 
+Primary and fallback paths reuse the serving-policy, artifact projection, tail
+cache, and synthetic-context compaction helpers. Fallbacks also restore legacy
+formatting and sanitize orphan tool pairs before adding cache markers. Artifact
+expansion is retried without the artifact when necessary; oversized synthetic
+context is compacted against the final, serving-specific measured payload before
+rejecting a fallback. No content is appended after the final budget check.
+
 Regression coverage checks source identity through fallback folding before origin
 tracking, mixed model/tool provenance, completed media, mixed native and parsed
 calls, bounded nested traversal, per-value argument limits, and source immutability.

--- a/docs/tool-history-projection.md
+++ b/docs/tool-history-projection.md
@@ -1,0 +1,36 @@
+# Ordered Tool History Projection
+
+Model Context Reconstruction owns source evidence separately from the serving
+provider's replay policy. A preparation-scoped, copy-on-write cache shares the
+Responses source selection and ordered contributions between tool-less folding
+and sealed-turn replay. Complete output takes precedence over streaming sidecars;
+streaming positions order sidecars when text mapping is unambiguous.
+
+The projection does not select the serving provider or model. Primary and fallback
+preparations each select native replay versus portable folding using the actual
+serving model and invocation options. The cache is not persisted or shared between
+runs. Plain messages without Responses evidence allocate no projection objects.
+
+Regression coverage checks source identity through fallback folding before origin
+tracking, mixed model/tool provenance, completed media, mixed native and parsed
+calls, bounded nested traversal, per-value argument limits, and source immutability.
+This is the first shared consumer slice; compaction and budgeting retain their
+existing interfaces rather than changing checkpoint formats in this PR.
+
+## Benchmark
+
+Run `npx tsx src/scripts/bench-tool-history-projection.ts` from the repository root.
+The benchmark compares a shared preparation with separate preparation caches for
+folding and native replay. Results are medians of five alternating samples, each
+containing 100 preparations. It is a cache comparison, not a baseline-release
+speedup claim or a general allocation profiler.
+
+Local sample (milliseconds per 100 preparations):
+
+| History | Separate caches | Shared cache | Projection objects per preparation |
+| --- | ---: | ---: | ---: |
+| 500 plain-text messages | 2.56 | 2.40 | 0 |
+| 100 tool-heavy Responses messages | 1150.27 | 1105.02 | 100 |
+
+The plain-text fold also asserts input-array identity. Timings are diagnostic,
+not CI thresholds; machine load and runtime warmup affect these small differences.

--- a/docs/tool-history-projection.md
+++ b/docs/tool-history-projection.md
@@ -11,6 +11,13 @@ preparations each select native replay versus portable folding using the actual
 serving model and invocation options. The cache is not persisted or shared between
 runs. Plain messages without Responses evidence allocate no projection objects.
 
+Fallback preparation starts from the pruned history before any primary wire
+shaping. Each fallback applies its own input limits, thinking normalization,
+folding, and measured request projection. A model's call-specific API-mode answer
+is authoritative, including `false`; a Responses default cannot override an
+explicit Chat selection. Graph regressions exercise both directions and a failed
+intermediate fallback, including source provenance and native media.
+
 Regression coverage checks source identity through fallback folding before origin
 tracking, mixed model/tool provenance, completed media, mixed native and parsed
 calls, bounded nested traversal, per-value argument limits, and source immutability.

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3537,6 +3537,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       }
 
       let finalMessages = messagesToUse;
+      /** Primary wire shaping is lossy; each fallback starts from pruned source history. */
+      const fallbackBaseMessages = messagesToUse;
       /**
        * Keep the pruner's provider-grounded aggregate as the authoritative
        * baseline, then attribute it across retained messages. Provider
@@ -4052,8 +4054,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
       }
 
-      const fallbackBaseMessages = finalMessages;
-      const beforeFinalProviderProjection = fallbackBaseMessages;
+      const beforeFinalProviderProjection = finalMessages;
       const preparedRequest = prepareProviderRequest({
         model: (this.overrideModel ?? model) as t.ChatModel,
         messages: beforeFinalProviderProjection,
@@ -4523,14 +4524,36 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   model: fallbackModel,
                   messages: fallbackMessages,
                   provider: fallbackProvider,
+                  clientOptions: fallbackClientOptions,
                   maxContextTokens: fallbackMaxContextTokens,
                   config: fallbackConfig,
                 }) => {
                   const fallbackToolHistory = createToolHistoryPreparation();
+                  let fallbackSourceMessages = trackProviderMessageOrigins(
+                    fallbackMessages,
+                    projectToolMessagesForProvider(
+                      fallbackMessages,
+                      calculateMaxToolCallInputChars(fallbackMaxContextTokens),
+                      fallbackProvider
+                    )
+                  );
+                  if (isThinkingEnabled(fallbackProvider, fallbackClientOptions)) {
+                    const beforeThinking = fallbackSourceMessages;
+                    fallbackSourceMessages = trackProviderMessageOrigins(
+                      beforeThinking,
+                      ensureThinkingBlockInMessages(
+                        beforeThinking,
+                        fallbackProvider,
+                        fallbackConfig,
+                        this.startIndex,
+                        fallbackToolHistory
+                      )
+                    );
+                  }
                   const servingFallbackMessages =
                     toolsForBinding == null || toolsForBinding.length === 0
                       ? foldToolBlocksForToollessAgent(
-                        fallbackMessages,
+                        fallbackSourceMessages,
                         fallbackConfig,
                         usesNativeOpenAIResponses(
                           fallbackModel,
@@ -4539,7 +4562,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                         ),
                         fallbackToolHistory
                       )
-                      : fallbackMessages;
+                      : fallbackSourceMessages;
                   const fallbackToolResultChars =
                     agentContext.maxToolResultChars ??
                     calculateMaxToolResultChars(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -157,6 +157,7 @@ import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
+import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
 import {
   prepareProviderRequest,
@@ -175,7 +176,10 @@ import {
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
-import { createRemoveAllMessage, messagesStateReducer  } from '@/messages/reducer';
+import {
+  createRemoveAllMessage,
+  messagesStateReducer,
+} from '@/messages/reducer';
 import { getTruncationStopReason } from '@/llm/truncation';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
@@ -1619,7 +1623,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     ) {
       return result;
     }
-    return { ...result, messages: [createRemoveAllMessage(), ...result.messages] };
+    return {
+      ...result,
+      messages: [createRemoveAllMessage(), ...result.messages],
+    };
   }
 
   /** Rotates the Langfuse identities that must never cross fresh executions. */
@@ -3549,6 +3556,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         calibrationRatio: agentContext.calibrationRatio,
       });
       const trackProviderMessageOrigins = contextPressure.trackProjection;
+      const toolHistory = createToolHistoryPreparation();
 
       if (agentContext.useLegacyContent) {
         const before = finalMessages;
@@ -3661,7 +3669,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               before,
               agentContext.provider,
               config,
-              this.startIndex
+              this.startIndex,
+              toolHistory
             )
           );
         }
@@ -3681,7 +3690,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                 (this.overrideModel ?? model) as t.ChatModel,
                 agentContext.provider,
                 config
-              )
+              ),
+              toolHistory
             )
           );
           if (agentContext.useLegacyContent) {
@@ -4051,6 +4061,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         context: this,
         config,
         maxToolResultChars: maxProviderToolResultChars,
+        toolHistory,
         measure: (preparedMessages) =>
           measureProviderPayload(
             trackProviderMessageOrigins(
@@ -4515,6 +4526,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   maxContextTokens: fallbackMaxContextTokens,
                   config: fallbackConfig,
                 }) => {
+                  const fallbackToolHistory = createToolHistoryPreparation();
                   const servingFallbackMessages =
                     toolsForBinding == null || toolsForBinding.length === 0
                       ? foldToolBlocksForToollessAgent(
@@ -4524,7 +4536,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                           fallbackModel,
                           fallbackProvider,
                           fallbackConfig
-                        )
+                        ),
+                        fallbackToolHistory
                       )
                       : fallbackMessages;
                   const fallbackToolResultChars =
@@ -4547,6 +4560,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                     context: this,
                     config: fallbackConfig,
                     maxToolResultChars: fallbackToolResultChars,
+                    toolHistory: fallbackToolHistory,
                     measure: (preparedMessages) =>
                       measureProviderPayload(
                         trackProviderMessageOrigins(

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3671,7 +3671,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           const before = transformed;
           transformed = trackProviderMessageOrigins(
             before,
-            foldToolBlocksForToollessAgent(before, config)
+            foldToolBlocksForToollessAgent(
+              before,
+              config,
+              agentContext.provider
+            )
           );
           if (agentContext.useLegacyContent) {
             const beforeLegacyFormat = transformed;

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -3654,12 +3654,24 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       };
 
       const applyProviderMessageTransforms = (
-        candidate: BaseMessage[]
+        candidate: BaseMessage[],
+        serving?: {
+          provider: t.ProviderName;
+          clientOptions?: t.ClientOptions;
+          model: t.ChatModel;
+          config?: RunnableConfig;
+          history: ReturnType<typeof createToolHistoryPreparation>;
+        }
       ): BaseMessage[] => {
+        const provider = serving?.provider ?? agentContext.provider;
+        const clientOptions =
+          serving == null ? agentContext.clientOptions : serving.clientOptions;
+        const callConfig = serving == null ? config : serving.config;
+        const history = serving?.history ?? toolHistory;
+        const servingModel =
+          serving?.model ?? ((this.overrideModel ?? model) as t.ChatModel);
         let transformed = candidate;
-        if (
-          isThinkingEnabled(agentContext.provider, agentContext.clientOptions)
-        ) {
+        if (isThinkingEnabled(provider, clientOptions)) {
           /**
            * Current-run AI messages may validly omit a thinking block. The
            * boundary prevents them from being mistaken for foreign history.
@@ -3669,10 +3681,10 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             before,
             ensureThinkingBlockInMessages(
               before,
-              agentContext.provider,
-              config,
+              provider,
+              callConfig,
               this.startIndex,
-              toolHistory
+              history
             )
           );
         }
@@ -3687,13 +3699,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             before,
             foldToolBlocksForToollessAgent(
               before,
-              config,
-              usesNativeOpenAIResponses(
-                (this.overrideModel ?? model) as t.ChatModel,
-                agentContext.provider,
-                config
-              ),
-              toolHistory
+              callConfig,
+              usesNativeOpenAIResponses(servingModel, provider, callConfig),
+              history
             )
           );
           if (agentContext.useLegacyContent) {
@@ -3713,12 +3721,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
          * tolerant fallback and adds it for a Claude fallback behind a
          * tolerant primary.
          */
-        if (
-          isAnthropicLike(
-            agentContext.provider,
-            agentContext.clientOptions as { model?: string }
-          )
-        ) {
+        if (isAnthropicLike(provider, clientOptions as { model?: string })) {
           const before = transformed;
           transformed = trackProviderMessageOrigins(
             before,
@@ -3741,7 +3744,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         );
 
       const compactSyntheticProviderContext = (
-        candidate: BaseMessage[]
+        candidate: BaseMessage[],
+        measure = measureProviderPayload
       ): BaseMessage[] => {
         const synthetic: Array<{
           index: number;
@@ -3779,7 +3783,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         };
 
         let best = buildCandidate(0);
-        if (!measureProviderPayload(best).fits) {
+        if (!measure(best).fits) {
           return candidate;
         }
         let low = 0;
@@ -3787,7 +3791,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         for (let i = 0; i < 12; i++) {
           const scale = (low + high) / 2;
           const attempt = buildCandidate(scale);
-          if (measureProviderPayload(attempt).fits) {
+          if (measure(attempt).fits) {
             best = attempt;
             low = scale;
           } else {
@@ -3797,27 +3801,83 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         return best;
       };
 
-      let artifactBaseMessages: BaseMessage[] | undefined;
-      if (lastMessageY instanceof ToolMessage) {
-        let artifactCandidate = finalMessages;
-        if (anthropicLike) {
-          artifactCandidate = trackProviderMessageOrigins(
-            finalMessages,
-            projectAnthropicArtifactContent(
-              finalMessages,
-              maxProviderToolResultChars
-            )
-          );
-        } else if (
-          (isOpenAILike(agentContext.provider) &&
-            agentContext.provider !== Providers.DEEPSEEK) ||
-          isGoogleLike(agentContext.provider)
-        ) {
-          artifactCandidate = trackProviderMessageOrigins(
-            finalMessages,
-            projectArtifactPayload(finalMessages, maxProviderToolResultChars)
+      const projectServingArtifacts = (
+        candidate: BaseMessage[],
+        provider: t.ProviderName,
+        clientOptions: t.ClientOptions | undefined,
+        maxChars: number
+      ): BaseMessage[] => {
+        if (!(candidate[candidate.length - 1] instanceof ToolMessage)) {
+          return candidate;
+        }
+        if (isAnthropicLike(provider, clientOptions as { model?: string })) {
+          return trackProviderMessageOrigins(
+            candidate,
+            projectAnthropicArtifactContent(candidate, maxChars)
           );
         }
+        if (
+          (isOpenAILike(provider) && provider !== Providers.DEEPSEEK) ||
+          isGoogleLike(provider)
+        ) {
+          return trackProviderMessageOrigins(
+            candidate,
+            projectArtifactPayload(candidate, maxChars)
+          );
+        }
+        return candidate;
+      };
+
+      const applyServingTailCache = (
+        candidate: BaseMessage[],
+        provider: t.ProviderName,
+        clientOptions: t.ClientOptions | undefined,
+        systemOwnsTail = false
+      ): BaseMessage[] => {
+        if (provider === Providers.BEDROCK) {
+          const options = clientOptions as
+            | t.BedrockAnthropicClientOptions
+            | undefined;
+          return options?.promptCache === true
+            ? trackProviderMessageOrigins(
+              candidate,
+              addBedrockTailCacheControl(
+                candidate,
+                resolveBedrockPromptCacheTtl(
+                  options.promptCacheTtl,
+                  options.model
+                )
+              )
+            )
+            : candidate;
+        }
+        if (
+          systemOwnsTail ||
+          (provider !== Providers.ANTHROPIC &&
+            provider !== Providers.OPENROUTER)
+        ) {
+          return candidate;
+        }
+        const options = clientOptions as t.AnthropicClientOptions | undefined;
+        return options?.promptCache === true
+          ? trackProviderMessageOrigins(
+            candidate,
+            addTailCacheControl(
+              candidate,
+              resolvePromptCacheTtl(options.promptCacheTtl)
+            )
+          )
+          : candidate;
+      };
+
+      let artifactBaseMessages: BaseMessage[] | undefined;
+      if (lastMessageY instanceof ToolMessage) {
+        const artifactCandidate = projectServingArtifacts(
+          finalMessages,
+          agentContext.provider,
+          agentContext.clientOptions,
+          maxProviderToolResultChars
+        );
 
         if (artifactCandidate !== finalMessages) {
           const projection = measureProviderPayload(artifactCandidate);
@@ -4011,48 +4071,12 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // call (zero message caching). Anchoring on the final message list keeps
       // the marker on a block that actually ships. The system-runnable path
       // adds its body marker in AgentContext, so this node skips it there.
-      if (
-        (anthropicPromptCacheEnabled || openRouterPromptCacheEnabled) &&
-        !agentContext.systemRunnable
-      ) {
-        const beforeCacheControl = finalMessages;
-        finalMessages = trackProviderMessageOrigins(
-          beforeCacheControl,
-          addTailCacheControl<BaseMessage>(
-            beforeCacheControl,
-            resolvePromptCacheTtl(
-              anthropicPromptCacheEnabled
-                ? (
-                    agentContext.clientOptions as
-                      | t.AnthropicClientOptions
-                      | undefined
-                )?.promptCacheTtl
-                : (
-                    agentContext.clientOptions as
-                      | t.ProviderOptionsMap[Providers.OPENROUTER]
-                      | undefined
-                )?.promptCacheTtl
-            )
-          )
-        );
-      } else if (bedrockPromptCacheEnabled) {
-        const bedrockOptions = agentContext.clientOptions as
-          | t.BedrockAnthropicClientOptions
-          | undefined;
-        // Non-Claude models (Nova) reject the extended 1h TTL, so resolve it
-        // against the model — message/system caching stays on, clamped to 5m.
-        const beforeCacheControl = finalMessages;
-        finalMessages = trackProviderMessageOrigins(
-          beforeCacheControl,
-          addBedrockTailCacheControl<BaseMessage>(
-            beforeCacheControl,
-            resolveBedrockPromptCacheTtl(
-              bedrockOptions?.promptCacheTtl,
-              (bedrockOptions as { model?: string } | undefined)?.model
-            )
-          )
-        );
-      }
+      finalMessages = applyServingTailCache(
+        finalMessages,
+        agentContext.provider,
+        agentContext.clientOptions,
+        agentContext.systemRunnable != null
+      );
 
       const beforeFinalProviderProjection = finalMessages;
       const preparedRequest = prepareProviderRequest({
@@ -4529,40 +4553,6 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   config: fallbackConfig,
                 }) => {
                   const fallbackToolHistory = createToolHistoryPreparation();
-                  let fallbackSourceMessages = trackProviderMessageOrigins(
-                    fallbackMessages,
-                    projectToolMessagesForProvider(
-                      fallbackMessages,
-                      calculateMaxToolCallInputChars(fallbackMaxContextTokens),
-                      fallbackProvider
-                    )
-                  );
-                  if (isThinkingEnabled(fallbackProvider, fallbackClientOptions)) {
-                    const beforeThinking = fallbackSourceMessages;
-                    fallbackSourceMessages = trackProviderMessageOrigins(
-                      beforeThinking,
-                      ensureThinkingBlockInMessages(
-                        beforeThinking,
-                        fallbackProvider,
-                        fallbackConfig,
-                        this.startIndex,
-                        fallbackToolHistory
-                      )
-                    );
-                  }
-                  const servingFallbackMessages =
-                    toolsForBinding == null || toolsForBinding.length === 0
-                      ? foldToolBlocksForToollessAgent(
-                        fallbackSourceMessages,
-                        fallbackConfig,
-                        usesNativeOpenAIResponses(
-                          fallbackModel,
-                          fallbackProvider,
-                          fallbackConfig
-                        ),
-                        fallbackToolHistory
-                      )
-                      : fallbackSourceMessages;
                   const fallbackToolResultChars =
                     agentContext.maxToolResultChars ??
                     calculateMaxToolResultChars(
@@ -4576,32 +4566,112 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                         primaryContextBudget ?? fallbackMaxContextTokens,
                         fallbackMaxContextTokens
                       );
-                  const preparedFallbackRequest = prepareProviderRequest({
-                    model: fallbackModel,
-                    messages: servingFallbackMessages,
-                    provider: fallbackProvider,
-                    context: this,
-                    config: fallbackConfig,
-                    maxToolResultChars: fallbackToolResultChars,
-                    toolHistory: fallbackToolHistory,
-                    measure: (preparedMessages) =>
-                      measureProviderPayload(
-                        trackProviderMessageOrigins(
-                          servingFallbackMessages,
-                          preparedMessages
-                        ),
-                        {
-                          contextBudget: fallbackContextBudget,
-                          forceRawRecount: true,
-                        }
-                      ),
-                  });
-                  const projection =
-                    preparedFallbackRequest.measurement ??
-                    measureProviderPayload(preparedFallbackRequest.messages, {
+                  const measureFallback = (
+                    candidate: BaseMessage[]
+                  ): ReturnType<typeof measureProviderPayload> =>
+                    measureProviderPayload(candidate, {
                       contextBudget: fallbackContextBudget,
                       forceRawRecount: true,
                     });
+                  const source = agentContext.useLegacyContent
+                    ? trackProviderMessageOrigins(
+                      fallbackMessages,
+                      formatContentStrings(fallbackMessages)
+                    )
+                    : fallbackMessages;
+                  const boundedSource = trackProviderMessageOrigins(
+                    source,
+                    projectToolMessagesForProvider(
+                      source,
+                      calculateMaxToolCallInputChars(fallbackMaxContextTokens),
+                      fallbackProvider
+                    )
+                  );
+                  const artifactSource = projectServingArtifacts(
+                    boundedSource,
+                    fallbackProvider,
+                    fallbackClientOptions,
+                    fallbackToolResultChars
+                  );
+                  const transformFallback = (
+                    candidate: BaseMessage[]
+                  ): BaseMessage[] =>
+                    applyProviderMessageTransforms(candidate, {
+                      provider: fallbackProvider,
+                      clientOptions: fallbackClientOptions,
+                      model: fallbackModel,
+                      config: fallbackConfig,
+                      history: fallbackToolHistory,
+                    });
+                  const prepareFallback = (
+                    candidate: BaseMessage[]
+                  ): {
+                    request: ReturnType<typeof prepareProviderRequest>;
+                    projection: ReturnType<typeof measureProviderPayload>;
+                  } => {
+                    const sanitized = isAnthropicLike(
+                      fallbackProvider,
+                      fallbackClientOptions as { model?: string }
+                    )
+                      ? trackProviderMessageOrigins(
+                        candidate,
+                        sanitizeOrphanToolBlocks(
+                          candidate,
+                          (original, clone) =>
+                            contextPressure.trackClone(original, clone)
+                        )
+                      )
+                      : candidate;
+                    const cached = applyServingTailCache(
+                      sanitized,
+                      fallbackProvider,
+                      fallbackClientOptions
+                    );
+                    let projection: ReturnType<typeof measureProviderPayload> | undefined;
+                    const request = prepareProviderRequest({
+                      model: fallbackModel,
+                      messages: cached,
+                      provider: fallbackProvider,
+                      context: this,
+                      config: fallbackConfig,
+                      maxToolResultChars: fallbackToolResultChars,
+                      toolHistory: fallbackToolHistory,
+                      measure: (prepared) => {
+                        projection = measureFallback(
+                          trackProviderMessageOrigins(cached, prepared)
+                        );
+                        return projection;
+                      },
+                    });
+                    if (projection == null) {
+                      throw new Error('Fallback preparation did not measure its payload');
+                    }
+                    return { request, projection };
+                  };
+                  let servingFallbackMessages =
+                    transformFallback(artifactSource);
+                  let preparedFallbackRequest = prepareFallback(
+                    servingFallbackMessages
+                  );
+                  let projection = preparedFallbackRequest.projection;
+                  if (!projection.fits && artifactSource !== boundedSource) {
+                    servingFallbackMessages = transformFallback(boundedSource);
+                    preparedFallbackRequest = prepareFallback(
+                      servingFallbackMessages
+                    );
+                    projection = preparedFallbackRequest.projection;
+                  }
+                  if (!projection.fits) {
+                    const compacted = compactSyntheticProviderContext(
+                      servingFallbackMessages,
+                      (candidate) =>
+                        prepareFallback(candidate).projection
+                    );
+                    if (compacted !== servingFallbackMessages) {
+                      preparedFallbackRequest = prepareFallback(compacted);
+                      projection = preparedFallbackRequest.projection;
+                    }
+                  }
                   if (!projection.fits) {
                     throw createProviderPayloadOverflowError({
                       projection,
@@ -4609,7 +4679,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       info: 'Fallback provider message formatting exceeded the context budget before invocation.',
                     });
                   }
-                  return preparedFallbackRequest;
+                  return preparedFallbackRequest.request;
                 },
               })
           );

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -158,7 +158,10 @@ import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import { prepareProviderRequest } from '@/llm/prepareProviderRequest';
+import {
+  prepareProviderRequest,
+  usesNativeOpenAIResponses,
+} from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { calculateMaxToolCallInputChars } from '@/utils/truncation';
 import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
@@ -3674,7 +3677,11 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             foldToolBlocksForToollessAgent(
               before,
               config,
-              agentContext.provider
+              usesNativeOpenAIResponses(
+                (this.overrideModel ?? model) as t.ChatModel,
+                agentContext.provider,
+                config
+              )
             )
           );
           if (agentContext.useLegacyContent) {
@@ -4508,6 +4515,18 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   maxContextTokens: fallbackMaxContextTokens,
                   config: fallbackConfig,
                 }) => {
+                  const servingFallbackMessages =
+                    toolsForBinding == null || toolsForBinding.length === 0
+                      ? foldToolBlocksForToollessAgent(
+                        fallbackMessages,
+                        fallbackConfig,
+                        usesNativeOpenAIResponses(
+                          fallbackModel,
+                          fallbackProvider,
+                          fallbackConfig
+                        )
+                      )
+                      : fallbackMessages;
                   const fallbackToolResultChars =
                     agentContext.maxToolResultChars ??
                     calculateMaxToolResultChars(
@@ -4523,7 +4542,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       );
                   const preparedFallbackRequest = prepareProviderRequest({
                     model: fallbackModel,
-                    messages: fallbackMessages,
+                    messages: servingFallbackMessages,
                     provider: fallbackProvider,
                     context: this,
                     config: fallbackConfig,
@@ -4531,7 +4550,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                     measure: (preparedMessages) =>
                       measureProviderPayload(
                         trackProviderMessageOrigins(
-                          fallbackMessages,
+                          servingFallbackMessages,
                           preparedMessages
                         ),
                         {

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -13,6 +13,7 @@ import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import { OVERFLOW_SIGNATURES } from '@/utils/__tests__/fixtures/contextOverflowSignatures';
 import { ContentTypes, GraphEvents, Providers } from '@/common';
+import { getProviderSourceMessageIds } from '@/messages/provenance';
 import * as init from '@/llm/init';
 import { Run } from '@/run';
 
@@ -157,6 +158,112 @@ const streamConfig = {
 };
 
 describe('context overflow recovery', () => {
+  it.each([
+    { primaryNative: false, intermediate: false },
+    { primaryNative: true, intermediate: false },
+    { primaryNative: false, intermediate: true },
+  ])(
+    'preserves source history across serving policy changes: %j',
+    async ({ primaryNative, intermediate }) => {
+      const source = new AIMessage({
+        content: 'A drawing.',
+        additional_kwargs: { sourceMessageId: 'original-drawing' },
+        response_metadata: {
+          model_provider: 'openai',
+          preempted: true,
+          output: [
+            {
+              type: 'image_generation_call',
+              id: 'image-1',
+              status: 'completed',
+              result: '/9j/AA==',
+            },
+            {
+              type: 'message',
+              id: 'msg-1',
+              content: [{ type: 'output_text', text: 'A drawing.' }],
+            },
+          ],
+        },
+      });
+      const run = await createRun({
+        runId: 'native-fallback-source-history',
+        maxContextTokens: 1_000_000,
+        provider: primaryNative ? Providers.OPENAI : Providers.ANTHROPIC,
+        tokenCounter: () => 10,
+        fallbacks: [
+          ...(intermediate
+            ? [{ provider: Providers.GOOGLE, maxContextTokens: 1_000_000 }]
+            : []),
+          {
+            provider: primaryNative ? Providers.ANTHROPIC : Providers.OPENAI,
+            maxContextTokens: 1_000_000,
+          },
+        ],
+      });
+      if (!run.Graph) {
+        throw new Error('Expected graph');
+      }
+      const primary = new OverflowThenSucceedModel({
+        message: '503 unavailable',
+      });
+      const fallback = new OverflowThenSucceedModel({}, 0);
+      Object.assign(primary, {
+        _useResponsesApi: (): boolean => primaryNative,
+      });
+      Object.assign(fallback, { _useResponsesApi: (): boolean => true });
+      const initializeSpy = jest.spyOn(init, 'initializeModel');
+      if (intermediate) {
+        initializeSpy.mockReturnValueOnce(
+          new OverflowThenSucceedModel({
+            message: '503 intermediate unavailable',
+          }) as ReturnType<typeof init.initializeModel>
+        );
+      }
+      initializeSpy.mockReturnValue(
+        fallback as ReturnType<typeof init.initializeModel>
+      );
+      run.Graph.overrideModel = primary;
+      try {
+        await run.processStream(
+          {
+            messages: [
+              new HumanMessage('Draw'),
+              source,
+              new HumanMessage('Continue'),
+            ],
+          },
+          streamConfig
+        );
+        expect(
+          JSON.stringify(primary.calls[0]).includes(
+            '[Previous tool interaction]'
+          )
+        ).toBe(!primaryNative);
+        expect(fallback.calls).toHaveLength(1);
+        const retained = fallback.calls[0].find((message) =>
+          getProviderSourceMessageIds(message).includes('original-drawing')
+        );
+        expect(retained?.content).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'image',
+              mimeType: 'image/jpeg',
+              data: '/9j/AA==',
+            }),
+          ])
+        );
+        expect(
+          JSON.stringify(fallback.calls[0]).includes(
+            '[Previous tool interaction]'
+          )
+        ).toBe(primaryNative);
+        expect(source.response_metadata.output).toBeDefined();
+      } finally {
+        initializeSpy.mockRestore();
+      }
+    }
+  );
   it('projects structured OpenAI tool content before the final payload check', async () => {
     const toolCallId = 'tc-openai-structured';
     const toolMessage = new ToolMessage({

--- a/src/graphs/__tests__/Graph.contextOverflow.test.ts
+++ b/src/graphs/__tests__/Graph.contextOverflow.test.ts
@@ -157,7 +157,196 @@ const streamConfig = {
   version: 'v2' as const,
 };
 
+async function captureFallback(
+  messages: BaseMessage[],
+  fallbackConfig: t.FallbackConfig,
+  options: Partial<Parameters<typeof createRun>[0]> & { legacy?: boolean } = {}
+): Promise<BaseMessage[]> {
+  const run = await createRun({
+    runId: 'fallback-serving-pipeline',
+    maxContextTokens: 1_000_000,
+    provider: Providers.ANTHROPIC,
+    tokenCounter: () => 10,
+    ...options,
+    fallbacks: [fallbackConfig],
+  });
+  if (!run.Graph) {
+    throw new Error('Expected graph');
+  }
+  const context = run.Graph.agentContexts.get('default');
+  if (context != null && options.legacy === true) {
+    context.useLegacyContent = true;
+  }
+  const primary = new OverflowThenSucceedModel({ message: '503 unavailable' });
+  const fallback = new OverflowThenSucceedModel({}, 0);
+  const spy = jest
+    .spyOn(init, 'initializeModel')
+    .mockReturnValue(fallback as ReturnType<typeof init.initializeModel>);
+  run.Graph.overrideModel = primary;
+  try {
+    await run.processStream({ messages }, streamConfig);
+    expect(primary.calls).toHaveLength(1);
+    expect(fallback.calls).toHaveLength(1);
+    return fallback.calls[0];
+  } finally {
+    spy.mockRestore();
+  }
+}
+
 describe('context overflow recovery', () => {
+  it.each([Providers.ANTHROPIC, Providers.OPENAI, Providers.GOOGLE])(
+    'preserves fallback artifacts for %s',
+    async (provider) => {
+      const source = new ToolMessage({
+        content: 'rendered',
+        name: 'render',
+        tool_call_id: 'render-1',
+        artifact: {
+          content: [
+            { type: 'text', text: 'fallback-artifact-evidence' },
+            {
+              type: 'image_url',
+              image_url: { url: 'data:image/png;base64,aW1hZ2U=' },
+            },
+          ],
+        },
+      });
+      const result = await captureFallback(
+        [
+          new HumanMessage('Render'),
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'render-1', name: 'render', args: {} }],
+          }),
+          source,
+        ],
+        { provider, maxContextTokens: 1_000_000 }
+      );
+      const wire = JSON.stringify(result.map((message) => message.content));
+      expect(wire).toContain('fallback-artifact-evidence');
+      expect(wire).toContain('aW1hZ2U=');
+      expect(source.content).toBe('rendered');
+    }
+  );
+
+  it('restores legacy string content for fallback endpoints', async () => {
+    const result = await captureFallback(
+      [
+        new HumanMessage({
+          content: [{ type: 'text', text: 'legacy question' }],
+        }),
+      ],
+      { provider: Providers.OPENAI, maxContextTokens: 1_000_000 },
+      { legacy: true }
+    );
+    expect(result.every((message) => typeof message.content === 'string')).toBe(
+      true
+    );
+    expect(result[0].content).toContain('legacy question');
+  });
+
+  it('omits optional artifact expansion when the fallback budget cannot fit it', async () => {
+    const result = await captureFallback(
+      [
+        new HumanMessage('Keep this question'),
+        new AIMessage({
+          content: '',
+          tool_calls: [{ id: 'call', name: 'render', args: {} }],
+        }),
+        new ToolMessage({
+          content: 'rendered',
+          tool_call_id: 'call',
+          artifact: { content: [{ type: 'text', text: 'oversized-artifact' }] },
+        }),
+      ],
+      { provider: Providers.ANTHROPIC, maxContextTokens: 1_000 },
+      {
+        tokenCounter: (message) =>
+          JSON.stringify(message.content).includes('oversized-artifact')
+            ? 100_000
+            : 10,
+      }
+    );
+    const wire = JSON.stringify(result.map((message) => message.content));
+    expect(wire).not.toContain('oversized-artifact');
+    expect(wire).toContain('rendered');
+    expect(wire).toContain('Keep this question');
+  });
+
+  it.each([Providers.ANTHROPIC, Providers.OPENROUTER, Providers.BEDROCK])(
+    'adds serving fallback cache markers for %s',
+    async (provider) => {
+      const result = await captureFallback(
+        [new HumanMessage('cache this history')],
+        {
+          provider,
+          clientOptions: {
+            promptCache: true,
+            model: 'anthropic.claude-sonnet-4-5',
+          },
+          maxContextTokens: 1_000_000,
+        }
+      );
+      expect(
+        JSON.stringify(result.map((message) => message.content))
+      ).toContain(
+        provider === Providers.BEDROCK ? 'cachePoint' : 'cache_control'
+      );
+    }
+  );
+
+  it('sanitizes orphan tool results before a tool-enabled fallback', async () => {
+    const result = await captureFallback(
+      [
+        new HumanMessage('Continue'),
+        new ToolMessage({
+          content: 'orphan evidence',
+          tool_call_id: 'missing',
+          name: 'lookup',
+        }),
+        new HumanMessage('Latest'),
+      ],
+      { provider: Providers.ANTHROPIC, maxContextTokens: 1_000_000 },
+      {
+        tools: [
+          tool(async () => 'unused', {
+            name: 'lookup',
+            description: 'Lookup',
+            schema: z.object({}),
+          }),
+        ],
+      }
+    );
+    expect(result.some((message) => message.getType() === 'tool')).toBe(false);
+  });
+
+  it('compacts only synthetic fallback context to fit a smaller window', async () => {
+    const result = await captureFallback(
+      [
+        new HumanMessage('Keep this question'),
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'call', name: 'lookup', args: { query: 'x'.repeat(5_000) } },
+          ],
+        }),
+        new ToolMessage({ content: 'result', tool_call_id: 'call' }),
+      ],
+      { provider: Providers.ANTHROPIC, maxContextTokens: 1_000 },
+      {
+        tokenCounter: (message) => JSON.stringify(message.content).length,
+      }
+    );
+    expect(JSON.stringify(result.map((message) => message.content))).toContain(
+      'Keep this question'
+    );
+    expect(
+      result.reduce(
+        (sum, message) => sum + JSON.stringify(message.content).length,
+        0
+      )
+    ).toBeLessThanOrEqual(1_000);
+  });
   it.each([
     { primaryNative: false, intermediate: false },
     { primaryNative: true, intermediate: false },

--- a/src/llm/prepareProviderRequest.test.ts
+++ b/src/llm/prepareProviderRequest.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import {
-  AIMessage,
-  HumanMessage,
-  ToolMessage,
-} from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type * as t from '@/types';
 import {
@@ -14,6 +10,13 @@ import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { _convertMessagesToOpenAIParams } from '@/llm/openai/utils';
 import { attemptInvoke } from '@/llm/invoke';
 import { Providers } from '@/common';
+import { foldToolBlocksForToollessAgent } from '@/messages/format';
+import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
+import { createContextPressureMeter } from './contextPressureMeter';
+import {
+  getProviderMessageProvenance,
+  getProviderSourceMessageIds,
+} from '@/messages/provenance';
 
 type StubModel = {
   model?: string;
@@ -41,6 +44,120 @@ function createCapturingModel(): CapturingModel {
 }
 
 describe('prepareProviderRequest', () => {
+  it('shares source facts without caching the destination serving policy', () => {
+    const { model } = createCapturingModel();
+    model._useResponsesApi = (): boolean => true;
+    const message = new AIMessage({
+      content: 'approval needed',
+      additional_kwargs: {
+        tool_outputs: [
+          {
+            type: 'mcp_approval_request',
+            id: 'approval',
+            name: 'lookup',
+            arguments: '{}',
+          },
+        ],
+      },
+    });
+    const messages = [message];
+    const history = createToolHistoryPreparation();
+    const facts = history.get(message);
+    const native = foldToolBlocksForToollessAgent(
+      messages,
+      undefined,
+      true,
+      history
+    );
+    const fallback = foldToolBlocksForToollessAgent(
+      messages,
+      undefined,
+      false,
+      history
+    );
+    expect(native).toBe(messages);
+    expect(fallback).not.toBe(messages);
+    expect(JSON.stringify(fallback[0].content)).toContain(
+      'mcp_approval_request'
+    );
+    expect(history.get(message)).toBe(facts);
+    expect(
+      prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: native,
+        provider: Providers.OPENAI,
+        toolHistory: history,
+      }).projectionMode
+    ).toBe('openai-responses');
+    expect(
+      prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: fallback,
+        provider: Providers.ANTHROPIC,
+        toolHistory: history,
+      }).projectionMode
+    ).not.toBe('openai-responses');
+  });
+  it('preserves original provenance when fallback folds before origin tracking', () => {
+    const { model } = createCapturingModel();
+    const message = new AIMessage({
+      content: 'The answer is 4.',
+      additional_kwargs: { sourceMessageId: 'original-assistant-row' },
+      response_metadata: {
+        output: [
+          {
+            type: 'code_interpreter_call',
+            status: 'completed',
+            outputs: [{ type: 'logs', logs: '4' }],
+          },
+          {
+            type: 'message',
+            content: [{ type: 'output_text', text: 'The answer is 4.' }],
+          },
+        ],
+      },
+    });
+    const messages = [message];
+    const meter = createContextPressureMeter({
+      indexTokenCountMap: {},
+      sourceMessages: messages,
+      retainedMessages: messages,
+      provider: Providers.OPENAI,
+      tokenCounter: (entry) => JSON.stringify(entry.content).length,
+      instructionTokens: 0,
+      calibrationRatio: 1,
+      contextUsage: { contextBudget: 10_000, effectiveInstructionTokens: 0 },
+    });
+    const toolHistory = createToolHistoryPreparation();
+    const folded = foldToolBlocksForToollessAgent(
+      messages,
+      undefined,
+      false,
+      toolHistory
+    );
+    const request = prepareProviderRequest({
+      model: model as t.ChatModel,
+      provider: Providers.ANTHROPIC,
+      messages: folded,
+      toolHistory,
+      measure: (prepared) =>
+        meter.measure(meter.trackProjection(folded, prepared), {
+          contextBudget: 10_000,
+          forceRawRecount: true,
+        }),
+    });
+    expect(getProviderSourceMessageIds(request.messages[0])).toEqual([
+      'original-assistant-row',
+    ]);
+    expect(getProviderMessageProvenance(request.messages[0])?.parts).toEqual(
+      expect.arrayContaining([
+        { attribution: 'model', sourceMessageId: 'original-assistant-row' },
+        { attribution: 'tool', sourceMessageId: 'original-assistant-row' },
+      ])
+    );
+    expect(request.measurement?.toolMessageTokens).toBeGreaterThan(0);
+    expect(message.content).toBe('The answer is 4.');
+  });
   it.each([
     ['CSV', 'csv'],
     ['XLSX', 'xlsx'],
@@ -267,10 +384,7 @@ describe('prepareProviderRequest', () => {
 
   it('measures and sends the exact prepared message array without re-projection', async () => {
     const { model, invocations } = createCapturingModel();
-    const source = [
-      new HumanMessage('first'),
-      new HumanMessage('second'),
-    ];
+    const source = [new HumanMessage('first'), new HumanMessage('second')];
     const measure = jest.fn((messages: BaseMessage[]) => ({
       fits: true,
       projectedMessageTokens: messages.length * 10,
@@ -331,9 +445,7 @@ describe('prepareProviderRequest', () => {
       measure,
     });
 
-    expect(request.messages[0].content).toBe(
-      '[ref: tool0turn0]\ntool output'
-    );
+    expect(request.messages[0].content).toBe('[ref: tool0turn0]\ntool output');
     expect(measure).toHaveBeenCalledWith(request.messages);
     expect(toolMessage.content).toBe('tool output');
     expect(toolMessage.additional_kwargs._refKey).toBe('tool0turn0');
@@ -341,7 +453,10 @@ describe('prepareProviderRequest', () => {
 
   it('includes serving-provider handoff shaping before measurement', () => {
     const { model } = createCapturingModel();
-    const predecessor = new AIMessage({ id: 'previous-agent', content: 'done' });
+    const predecessor = new AIMessage({
+      id: 'previous-agent',
+      content: 'done',
+    });
     const measure = jest.fn((messages: BaseMessage[]) => ({
       fits: messages.length > 0,
     }));

--- a/src/llm/prepareProviderRequest.test.ts
+++ b/src/llm/prepareProviderRequest.test.ts
@@ -44,6 +44,27 @@ function createCapturingModel(): CapturingModel {
 }
 
 describe('prepareProviderRequest', () => {
+  it('honors an explicit Chat override over Responses model defaults', () => {
+    const { model } = createCapturingModel();
+    model._useResponsesApi = (options?: unknown): boolean =>
+      (options as { configurable?: { apiMode?: string } } | undefined)
+        ?.configurable?.apiMode !== 'chat';
+    expect(
+      prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: [new HumanMessage('hello')],
+        provider: Providers.OPENAI,
+        config: { configurable: { apiMode: 'chat' } },
+      }).projectionMode
+    ).toBe('chat-messages');
+    expect(
+      prepareProviderRequest({
+        model: model as t.ChatModel,
+        messages: [new HumanMessage('hello')],
+        provider: Providers.OPENAI,
+      }).projectionMode
+    ).toBe('openai-responses');
+  });
   it('shares source facts without caching the destination serving policy', () => {
     const { model } = createCapturingModel();
     model._useResponsesApi = (): boolean => true;

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -7,6 +7,7 @@ import type {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import type * as t from '@/types';
+import type { ToolHistoryPreparation } from '@/messages/toolHistoryProjection';
 import {
   projectCacheControlledToolOutputsToText,
   projectComputerCallOutputsToText,
@@ -32,6 +33,7 @@ import { annotateMessagesForLLM } from '@/tools/toolOutputReferences';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { getProviderFamily } from '@/llm/providerRegistry';
 import { Providers } from '@/common';
+import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
 
 const preparedProviderRequestBrand = Symbol('PreparedProviderRequest');
 const OMITTED_ATTACHMENT_TEXT =
@@ -119,6 +121,7 @@ export interface PrepareProviderRequestParams {
   config?: RunnableConfig;
   maxToolResultChars?: number;
   measure?: (messages: BaseMessage[]) => ProviderPayloadMeasurement;
+  toolHistory?: ToolHistoryPreparation;
 }
 
 export function usesNativeOpenAIResponses(
@@ -207,6 +210,7 @@ interface ProjectMessagesForProviderParams {
   provider: t.ProviderName;
   maxToolResultChars?: number;
   callOptions?: unknown;
+  toolHistory?: ToolHistoryPreparation;
 }
 
 function isSerializedBuffer(value: object): value is SerializedBuffer {
@@ -404,7 +408,12 @@ function projectAttachmentsForProvider(
 }
 
 function projectMessagesForProviderMode(
-  { messages, provider, maxToolResultChars }: ProjectMessagesForProviderParams,
+  {
+    messages,
+    provider,
+    maxToolResultChars,
+    toolHistory,
+  }: ProjectMessagesForProviderParams,
   projectionMode: ProviderMessageProjectionMode
 ): BaseMessage[] {
   const providerFamily = getProviderFamily(provider);
@@ -413,7 +422,8 @@ function projectMessagesForProviderMode(
     projectToolStreamContentForProvider(
       messages,
       nativeOpenAIResponses ? 'native' : 'fallback',
-      maxToolResultChars
+      maxToolResultChars,
+      toolHistory
     ),
     provider
   );
@@ -525,6 +535,7 @@ export function prepareProviderRequest({
   config,
   maxToolResultChars,
   measure,
+  toolHistory = createToolHistoryPreparation(),
 }: PrepareProviderRequestParams): PreparedProviderRequest {
   const projectionMode = resolveProviderMessageProjectionMode(
     model,
@@ -538,6 +549,7 @@ export function prepareProviderRequest({
       provider,
       maxToolResultChars,
       callOptions: config,
+      toolHistory,
     },
     projectionMode
   );

--- a/src/llm/prepareProviderRequest.ts
+++ b/src/llm/prepareProviderRequest.ts
@@ -166,11 +166,8 @@ export function usesNativeOpenAIResponses(
       } else if (effectiveCallOptions == null) {
         effectiveCallOptions = runnable.defaultOptions;
       }
-      if (
-        runnable._useResponsesApi?.(effectiveCallOptions) === true ||
-        runnable._useResponsesApi?.(undefined) === true
-      ) {
-        return true;
+      if (typeof runnable._useResponsesApi === 'function') {
+        return runnable._useResponsesApi(effectiveCallOptions) === true;
       }
     } catch {
       // Continue through RunnableSequence/RunnableBinding wrappers.

--- a/src/messages/alternation.test.ts
+++ b/src/messages/alternation.test.ts
@@ -9,6 +9,7 @@ import {
   coalesceAdjacentUserTurns,
   strictAlternationProviders,
 } from './alternation';
+import { getLegacyFunctionCallId } from './toolResultTypes';
 import { Providers } from '@/common';
 
 describe('strictAlternationProviders', () => {
@@ -165,6 +166,62 @@ describe('coalesceAdjacentUserTurns', () => {
       }),
       new HumanMessage({ content: 'steer' }),
     ]);
+    expect(result).toHaveLength(3);
+  });
+
+  it('pairs human tool results with raw OpenAI calls', () => {
+    const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          tool_calls: [
+            {
+              id: 'raw-call',
+              type: 'function',
+              function: { name: 'lookup', arguments: '{}' },
+            },
+          ],
+        },
+      }),
+      new HumanMessage({
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'raw-call',
+            content: 'ok',
+          },
+        ],
+      }),
+      new HumanMessage('steer'),
+    ]);
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('pairs human tool results with legacy function calls', () => {
+    const legacyCallId = getLegacyFunctionCallId('lookup');
+    if (legacyCallId == null) {
+      throw new Error('Expected a bounded legacy call id');
+    }
+    const result = coalesceAdjacentUserTurns([
+      new AIMessage({
+        content: '',
+        additional_kwargs: {
+          function_call: { name: 'lookup', arguments: '{}' },
+        },
+      }),
+      new HumanMessage({
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: legacyCallId,
+            content: 'ok',
+          },
+        ],
+      }),
+      new HumanMessage('steer'),
+    ]);
+
     expect(result).toHaveLength(3);
   });
 

--- a/src/messages/alternation.ts
+++ b/src/messages/alternation.ts
@@ -4,10 +4,10 @@ import type { BaseMessage, MessageContent } from '@langchain/core/messages';
 import type { ProviderMessageProvenancePart } from './provenance';
 import type { ProviderToolCallIndex } from './toolResultTypes';
 import {
+  appendProviderMessageToolCalls,
   appendProviderToolCallDescriptor,
   consumeProviderToolResultPair,
   getBoundedProviderPairingArrayProperty,
-  getProviderAIMessageToolCallDescriptor,
   getProviderToolCallPartDescriptor,
   getProviderToolResultPartDescriptor,
 } from './toolResultTypes';
@@ -42,24 +42,11 @@ export const strictAlternationProviders: ReadonlySet<Providers> = new Set([
  */
 function collectProviderToolCalls(message: BaseMessage): ProviderToolCallIndex {
   const calls: ProviderToolCallIndex = new Map();
+  appendProviderMessageToolCalls(message, calls);
   const content = getBoundedProviderPairingArrayProperty(message, 'content');
   if (content != null) {
     for (let index = 0; index < content.length; index++) {
       const descriptor = getProviderToolCallPartDescriptor(content[index]);
-      if (descriptor != null) {
-        appendProviderToolCallDescriptor(calls, descriptor);
-      }
-    }
-  }
-  const toolCalls = getBoundedProviderPairingArrayProperty(
-    message,
-    'tool_calls'
-  );
-  if (toolCalls != null) {
-    for (let index = 0; index < toolCalls.length; index++) {
-      const descriptor = getProviderAIMessageToolCallDescriptor(
-        toolCalls[index]
-      );
       if (descriptor != null) {
         appendProviderToolCallDescriptor(calls, descriptor);
       }

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -11,6 +11,11 @@ import type { ContentBlock as LangChainContentBlock } from '@langchain/core/mess
 import type { ToolCall, ToolCallChunk } from '@langchain/core/messages/tool';
 import type { ProviderMessageProvenancePart } from './provenance';
 import type * as t from '@/types';
+import type {
+  ResponsesReplayPosition,
+  ToolHistoryPreparation,
+  OrderedToolHistoryProjection,
+} from './toolHistoryProjection';
 import {
   cloneToolMessageWithContent,
   compactToolContent,
@@ -34,6 +39,13 @@ import { stripAnthropicCacheControl } from './cache';
 import { isReasoningContentBlock } from './reasoningTypes';
 import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
+import {
+  OPENAI_RESPONSES_REPLAY_POSITIONS_KEY,
+  createToolHistoryPreparation,
+  getGeneratedImageMimeType,
+  getResponsesHistorySource,
+  isResponsesReplayPosition,
+} from './toolHistoryProjection';
 
 type ReasoningSummary = { summary?: Array<{ text?: string }> };
 type ReasoningDetail = { type?: string; text?: string };
@@ -836,19 +848,13 @@ function hasReplayableEncryptedReasoning(reasoning: unknown): boolean {
 
 type ResponsesReplayProjection = 'fallback' | 'native';
 
-export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
-  '__openai_responses_replay_positions__';
+export { OPENAI_RESPONSES_REPLAY_POSITIONS_KEY } from './toolHistoryProjection';
 
 /** Reasoning item currently streaming, so a terminal ciphertext seals against its own id. */
 export const OPENAI_RESPONSES_ACTIVE_REASONING_ID_KEY =
   '__openai_responses_active_reasoning_id__';
 
-export type ResponsesReplayPosition = {
-  contentIndex?: number;
-  itemId: string;
-  kind: 'message' | 'output' | 'reasoning' | 'text';
-  outputIndex: number;
-};
+export type { ResponsesReplayPosition } from './toolHistoryProjection';
 
 type CompletedGeneratedImages = {
   blocks: PositionedResponsesReplayBlock[];
@@ -1277,56 +1283,7 @@ function projectPreemptedResponsesV1Content(
 }
 
 function getAuthoritativeResponsesOutput(message: AIMessage): unknown[] {
-  const responseOutput = message.response_metadata.output;
-  const toolOutputs = message.additional_kwargs.tool_outputs;
-  if (Array.isArray(responseOutput) && responseOutput.length > 0) {
-    return responseOutput;
-  }
-  return Array.isArray(toolOutputs) ? toolOutputs : [];
-}
-
-function isResponsesReplayPosition(
-  value: unknown
-): value is ResponsesReplayPosition {
-  if (value == null || typeof value !== 'object') {
-    return false;
-  }
-  const position = value as Partial<ResponsesReplayPosition>;
-  return (
-    (position.kind === 'message' ||
-      position.kind === 'output' ||
-      position.kind === 'reasoning' ||
-      position.kind === 'text') &&
-    typeof position.itemId === 'string' &&
-    position.itemId.length > 0 &&
-    typeof position.outputIndex === 'number' &&
-    Number.isSafeInteger(position.outputIndex) &&
-    position.outputIndex >= 0 &&
-    (position.contentIndex == null ||
-      (typeof position.contentIndex === 'number' &&
-        Number.isSafeInteger(position.contentIndex) &&
-        position.contentIndex >= 0))
-  );
-}
-
-function getGeneratedImageMimeType(data: string): string {
-  const bytes = Buffer.from(data.slice(0, 16), 'base64');
-  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
-    return 'image/jpeg';
-  }
-  if (
-    bytes[0] === 0x52 &&
-    bytes[1] === 0x49 &&
-    bytes[2] === 0x46 &&
-    bytes[3] === 0x46 &&
-    bytes[8] === 0x57 &&
-    bytes[9] === 0x45 &&
-    bytes[10] === 0x42 &&
-    bytes[11] === 0x50
-  ) {
-    return 'image/webp';
-  }
-  return 'image/png';
+  return getResponsesHistorySource(message)?.items ?? [];
 }
 
 function getResponsesReplayItemKey(
@@ -1362,7 +1319,8 @@ function getResponsesReplayArtifacts(
   output: readonly unknown[],
   maxChars: number,
   replayProjection: ResponsesReplayProjection,
-  replayPositionValue?: unknown
+  replayPositionValue?: unknown,
+  history?: OrderedToolHistoryProjection
 ): ResponsesReplayArtifacts {
   const blocks: PositionedResponsesReplayBlock[] = [];
   const data = new Set<string>();
@@ -1421,7 +1379,11 @@ function getResponsesReplayArtifacts(
       kind: 'message',
       outputIndex,
     });
-    if (!('content' in item) || !Array.isArray(item.content)) {
+    if (
+      history != null ||
+      !('content' in item) ||
+      !Array.isArray(item.content)
+    ) {
       continue;
     }
     for (
@@ -1451,6 +1413,24 @@ function getResponsesReplayArtifacts(
         kind: 'text',
         outputIndex,
       });
+    }
+  }
+  if (history?.source.coverage === 'complete-output') {
+    for (const contribution of history.contributions) {
+      if (contribution.kind !== 'text') {
+        continue;
+      }
+      const itemId =
+        contribution.itemId ?? `message-${contribution.outputIndex}`;
+      textPositionsByKey.set(
+        `${itemId}:${contribution.outputIndex}:${contribution.contentIndex ?? 0}`,
+        {
+          itemId,
+          kind: 'text',
+          outputIndex: contribution.outputIndex,
+          contentIndex: contribution.contentIndex,
+        }
+      );
     }
   }
   if (hasAuthoritativeMessage) {
@@ -1898,7 +1878,8 @@ function isPreemptedOpenAIResponsesMessage(message: AIMessage): boolean {
 function projectPreemptedOpenAIResponsesMessage(
   message: AIMessage,
   maxChars: number,
-  replayProjection: ResponsesReplayProjection
+  replayProjection: ResponsesReplayProjection,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): AIMessage {
   if (!isPreemptedOpenAIResponsesMessage(message)) {
     return message;
@@ -1909,7 +1890,9 @@ function projectPreemptedOpenAIResponsesMessage(
   const retainsEncryptedReasoning =
     replayProjection === 'native' &&
     hasReplayableEncryptedReasoning(additionalKwargs.reasoning);
-  const authoritativeOutput = getAuthoritativeResponsesOutput(message);
+  const history = preparation.get(message);
+  const authoritativeOutput =
+    history?.source.items ?? getAuthoritativeResponsesOutput(message);
   const {
     generatedImages,
     messagePositions,
@@ -1921,7 +1904,8 @@ function projectPreemptedOpenAIResponsesMessage(
     authoritativeOutput,
     maxChars,
     replayProjection,
-    additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY]
+    additionalKwargs[OPENAI_RESPONSES_REPLAY_POSITIONS_KEY],
+    history
   );
   const reasoningItemId =
     retainsEncryptedReasoning &&
@@ -2023,7 +2007,8 @@ function projectPreemptedOpenAIResponsesMessage(
 export function projectToolStreamContentForProvider(
   messages: BaseMessage[],
   responsesReplayProjection?: ResponsesReplayProjection,
-  maxChars = HARD_MAX_TOOL_RESULT_CHARS
+  maxChars = HARD_MAX_TOOL_RESULT_CHARS,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): BaseMessage[] {
   let projected: BaseMessage[] | undefined;
   for (let i = 0; i < messages.length; i++) {
@@ -2039,7 +2024,8 @@ export function projectToolStreamContentForProvider(
       const replaySafeMessage = projectPreemptedOpenAIResponsesMessage(
         assistantMessage,
         maxChars,
-        responsesReplayProjection
+        responsesReplayProjection,
+        preparation
       );
       if (replaySafeMessage !== assistantMessage) {
         projected ??= [...messages];
@@ -2778,14 +2764,18 @@ export function findLastIndex<T>(
 function readOwnDataProperty(target: object, key: PropertyKey): unknown {
   try {
     const descriptor = Object.getOwnPropertyDescriptor(target, key);
-    return descriptor != null && 'value' in descriptor ? descriptor.value : undefined;
+    return descriptor != null && 'value' in descriptor
+      ? descriptor.value
+      : undefined;
   } catch {
     return undefined;
   }
 }
 
 /** Whether message content carries non-whitespace text in any text block. */
-export function hasNonEmptyTextContent(content: BaseMessage['content']): boolean {
+export function hasNonEmptyTextContent(
+  content: BaseMessage['content']
+): boolean {
   if (typeof content === 'string') {
     return content.trim() !== '';
   }

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -14,6 +14,32 @@ import {
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from './langchain';
 
+test('folds computer actions as model calls rather than tool results', () => {
+  const [folded] = foldToolBlocksForToollessAgent([
+    new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          {
+            type: 'computer_call',
+            id: 'item',
+            call_id: 'call',
+            action: { type: 'click', x: 10, y: 20 },
+          },
+        ],
+      },
+    }),
+  ]);
+  expect(getTextContent(folded)).toContain(
+    '[tool_call] computer({"type":"click","x":10,"y":20})'
+  );
+  expect(getTextContent(folded)).not.toContain('server_tool_output');
+  expect(folded.additional_kwargs.provenance).toEqual({
+    version: 1,
+    parts: [{ attribution: 'synthetic' }, { attribution: 'model' }],
+  });
+});
+
 test('retains a generated-image sidecar alongside a distinct native tool call', () => {
   const message = new AIMessage({
     content: [

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -432,6 +432,46 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(getTextContent(result[0])).toContain('web_search_tool_result');
   });
 
+  test('preserves authorship in mixed server-tool assistant turns', () => {
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          { type: 'text', text: 'I found the answer.' },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: [],
+          },
+        ]),
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('AI: I found the answer.');
+    expect(text).toContain('Tool: [web_search_tool_result]');
+    expect(text).not.toContain('Tool: I found the answer.');
+  });
+
+  test('folds standalone Google executable-code blocks', () => {
+    const messages = [
+      new AIMessage({
+        content: [
+          {
+            type: 'executableCode',
+            executableCode: { language: 'PYTHON', code: 'print(2 + 2)' },
+          },
+        ],
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).not.toBe(messages);
+    expect(getTextContent(result[0])).toContain('AI: [executableCode]');
+  });
+
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {
     const messages = [
       new HumanMessage('Search'),

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -13,6 +13,7 @@ import {
 } from './format';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from './langchain';
+import { Providers } from '@/common';
 
 /** Concatenated text across a message's content (string or structured array). */
 function getTextContent(msg: {
@@ -419,6 +420,14 @@ describe('foldToolBlocksForToollessAgent', () => {
             },
           },
         ]),
+        tool_calls: [
+          {
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            args: { query: 'retained' },
+            type: 'tool_call',
+          },
+        ],
       }),
     ];
 
@@ -430,6 +439,7 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(isSyntheticProviderContextMessage(result[0])).toBe(true);
     expect(getTextContent(result[0])).toContain('server_tool_use');
     expect(getTextContent(result[0])).toContain('web_search_tool_result');
+    expect(getTextContent(result[0])).not.toContain('[tool_call]');
   });
 
   test('preserves authorship in mixed server-tool assistant turns', () => {
@@ -470,6 +480,54 @@ describe('foldToolBlocksForToollessAgent', () => {
 
     expect(result).not.toBe(messages);
     expect(getTextContent(result[0])).toContain('AI: [executableCode]');
+  });
+
+  test('folds oversized standard tool-result arrays', () => {
+    const content = Array.from({ length: 257 }, (_, index) => ({
+      type: 'text',
+      text: `result-${index}`,
+    }));
+    const messages = [
+      new HumanMessage({
+        content: [{ type: 'tool_result', tool_use_id: 'call-1', content }],
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).not.toBe(messages);
+    expect(result[0]).toBeInstanceOf(HumanMessage);
+    expect(isSyntheticProviderContextMessage(result[0])).toBe(true);
+  });
+
+  test('preserves native OpenAI server-tool turns without bound client tools', () => {
+    const messages = [
+      new AIMessage({
+        content: [
+          {
+            type: 'server_tool_call',
+            id: 'server-1',
+            name: 'code_interpreter',
+            args: { code: 'print(2 + 2)' },
+          },
+          {
+            type: 'server_tool_call_result',
+            toolCallId: 'server-1',
+            status: 'success',
+            output: { stdout: '4' },
+          },
+          { type: 'text', text: 'The result is 4.' },
+        ],
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(
+      messages,
+      undefined,
+      Providers.OPENAI
+    );
+
+    expect(result).toBe(messages);
   });
 
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -543,6 +543,18 @@ describe('foldToolBlocksForToollessAgent', () => {
               code: 'print(2 + 2)',
               outputs: [{ type: 'logs', logs: '4' }],
             },
+            {
+              id: 'message-1',
+              type: 'message',
+              role: 'assistant',
+              content: [{ type: 'output_text', text: 'duplicate text' }],
+            },
+            {
+              id: 'function-1',
+              type: 'function_call',
+              name: 'lookup',
+              arguments: '{}',
+            },
           ],
         },
       }),
@@ -554,6 +566,26 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(getTextContent(result[0])).toContain('server_tool_output');
     expect(getTextContent(result[0])).toContain('code_interpreter_call');
     expect(getTextContent(result[0])).toContain('The calculation completed.');
+    expect(getTextContent(result[0])).not.toContain('duplicate text');
+    expect(getTextContent(result[0])).not.toContain('function_call');
+  });
+
+  test('preserves user authorship in mixed tool-result turns', () => {
+    const messages = [
+      new HumanMessage({
+        content: [
+          { type: 'tool_result', tool_use_id: 'call-1', content: 'result' },
+          { type: 'text', text: 'Please continue carefully.' },
+        ],
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('Tool: [tool_result] result');
+    expect(text).toContain('User: Please continue carefully.');
+    expect(text).not.toContain('Tool: Please continue carefully.');
   });
 
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -14,6 +14,37 @@ import {
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from './langchain';
 
+test('retains a generated-image sidecar alongside a distinct native tool call', () => {
+  const message = new AIMessage({
+    content: [
+      { type: 'text', text: 'drawing' },
+      { type: 'tool_use', id: 'lookup', name: 'lookup', input: {} },
+    ],
+    additional_kwargs: {
+      tool_outputs: [
+        {
+          type: 'image_generation_call',
+          id: 'image-1',
+          status: 'completed',
+          result: '/9j/AA==',
+        },
+      ],
+    },
+  });
+  const [folded] = foldToolBlocksForToollessAgent([message]);
+  expect(folded.content).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: 'image',
+        mimeType: 'image/jpeg',
+        data: '/9j/AA==',
+      }),
+    ])
+  );
+  expect(getTextContent(folded)).toContain('lookup');
+  expect(getTextContent(folded)).not.toContain('/9j/AA==');
+});
+
 /** Concatenated text across a message's content (string or structured array). */
 function getTextContent(msg: {
   content: string | ExtendedMessageContent[];
@@ -211,34 +242,35 @@ describe('foldToolBlocksForToollessAgent', () => {
       'malformed legacy lineage',
       { sourceMessageIds: { 0: 'forged', length: 1 } },
     ],
-  ])('preserves %s invalidity when folding retained bytes', (_, additional_kwargs) => {
-    const sourceProvenance = (additional_kwargs as { provenance?: unknown })
-      .provenance;
-    const result = foldToolBlocksForToollessAgent([
-      new AIMessage({
-        content: '',
-        tool_calls: [
-          { id: 'call', name: 'lookup', args: {}, type: 'tool_call' },
-        ],
-      }),
-      new ToolMessage({
-        content: 'untrusted tool bytes',
-        tool_call_id: 'call',
-        additional_kwargs,
-      }),
-    ]);
+  ])(
+    'preserves %s invalidity when folding retained bytes',
+    (_, additional_kwargs) => {
+      const sourceProvenance = (additional_kwargs as { provenance?: unknown })
+        .provenance;
+      const result = foldToolBlocksForToollessAgent([
+        new AIMessage({
+          content: '',
+          tool_calls: [
+            { id: 'call', name: 'lookup', args: {}, type: 'tool_call' },
+          ],
+        }),
+        new ToolMessage({
+          content: 'untrusted tool bytes',
+          tool_call_id: 'call',
+          additional_kwargs,
+        }),
+      ]);
 
-    expect(result[0].additional_kwargs.provenance).toEqual({
-      version: 1,
-      parts: null,
-    });
-    expect(result[0].additional_kwargs.provenance).not.toBe(
-      sourceProvenance
-    );
-    expect(result[0].lc_kwargs.additional_kwargs).toBe(
-      result[0].additional_kwargs
-    );
-  });
+      expect(result[0].additional_kwargs.provenance).toEqual({
+        version: 1,
+        parts: null,
+      });
+      expect(result[0].additional_kwargs.provenance).not.toBe(sourceProvenance);
+      expect(result[0].lc_kwargs.additional_kwargs).toBe(
+        result[0].additional_kwargs
+      );
+    }
+  );
 
   test('folds historical tool content that precedes the last human turn (the reported bug)', () => {
     const messages = [
@@ -520,11 +552,7 @@ describe('foldToolBlocksForToollessAgent', () => {
       }),
     ];
 
-    const result = foldToolBlocksForToollessAgent(
-      messages,
-      undefined,
-      true
-    );
+    const result = foldToolBlocksForToollessAgent(messages, undefined, true);
 
     expect(result).toBe(messages);
   });
@@ -619,10 +647,145 @@ describe('foldToolBlocksForToollessAgent', () => {
     const [folded] = foldToolBlocksForToollessAgent(messages);
     const text = getTextContent(folded);
 
-    expect(text).toContain('server_tool_output');
-    expect(text).toContain('custom_tool_call');
+    expect(text).toContain('[tool_call] execute(');
     expect(text).toContain('execute');
     expect(text).toContain('print(2 + 2)');
+  });
+
+  test('folds streamed Responses MCP approval requests', () => {
+    const messages = [
+      new AIMessage({
+        content: [],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: 'approval-1',
+              type: 'mcp_approval_request',
+              name: 'delete_file',
+              arguments: '{"path":"draft.txt"}',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+
+    expect(getTextContent(folded)).toContain('mcp_approval_request');
+    expect(getTextContent(folded)).toContain('delete_file');
+  });
+
+  test('preserves generated images from ordered Responses output', () => {
+    const messages = [
+      new AIMessage({
+        content: [],
+        response_metadata: {
+          output: [
+            {
+              id: 'image-1',
+              type: 'image_generation_call',
+              status: 'completed',
+              result: 'base64ImageData',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+
+    expect(folded.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'image',
+          mimeType: 'image/png',
+          data: 'base64ImageData',
+          id: 'image-1',
+        }),
+      ])
+    );
+  });
+
+  test('caps ordered Responses function-call arguments per block', () => {
+    const messages = [
+      new AIMessage({
+        content: 'Done.',
+        response_metadata: {
+          output: [
+            { type: 'web_search_call', status: 'completed' },
+            {
+              type: 'function_call',
+              name: 'lookup',
+              arguments: 'x'.repeat(20_000),
+            },
+            {
+              type: 'message',
+              content: [{ type: 'output_text', text: 'Done.' }],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('[tool_call] lookup(');
+    expect(text).toContain('Done.');
+    expect(text.length).toBeLessThan(10_000);
+  });
+
+  test('bounds nested ordered Responses message content', () => {
+    const messages = [
+      new AIMessage({
+        content: [],
+        response_metadata: {
+          output: [
+            {
+              type: 'message',
+              content: Array.from({ length: 100_005 }, () => ({
+                type: 'output_text',
+                text: '',
+              })),
+            },
+            { type: 'web_search_call', status: 'completed' },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+
+    expect(getTextContent(folded)).toContain(
+      'additional folded context omitted'
+    );
+  });
+
+  test('preserves parsed calls alongside Gemini executable code', () => {
+    const messages = [
+      new AIMessage({
+        content: [
+          {
+            type: 'executableCode',
+            executableCode: { language: 'PYTHON', code: 'print(2 + 2)' },
+          },
+        ],
+        tool_calls: [
+          {
+            id: 'function-1',
+            name: 'lookup',
+            args: { query: 'roadmap' },
+            type: 'tool_call',
+          },
+        ],
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('[executableCode]');
+    expect(text).toContain('[tool_call] lookup({"query":"roadmap"})');
   });
 
   test.each([
@@ -962,44 +1125,40 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(foldedText).toContain('additional folded context omitted');
   });
 
-  test(
-    'folds a 150k-block tool result without call-argument spreading',
-    () => {
-      const blockCount = 150_000;
-      const repeatedBlock = { type: 'text', text: 'x' } as const;
-      const largeContent = new Array(blockCount).fill(repeatedBlock);
-      const toolMessage = new ToolMessage({
-        content: largeContent,
-        tool_call_id: 'large-result',
-        additional_kwargs: { sourceMessageId: 'large-tool-row' },
-      });
-      const messages = [
-        new HumanMessage('Run'),
-        new AIMessage({
-          content: '',
-          tool_calls: [
-            {
-              id: 'large-result',
-              name: 'query',
-              args: {},
-              type: 'tool_call',
-            },
-          ],
-        }),
-        toolMessage,
-      ];
+  test('folds a 150k-block tool result without call-argument spreading', () => {
+    const blockCount = 150_000;
+    const repeatedBlock = { type: 'text', text: 'x' } as const;
+    const largeContent = new Array(blockCount).fill(repeatedBlock);
+    const toolMessage = new ToolMessage({
+      content: largeContent,
+      tool_call_id: 'large-result',
+      additional_kwargs: { sourceMessageId: 'large-tool-row' },
+    });
+    const messages = [
+      new HumanMessage('Run'),
+      new AIMessage({
+        content: '',
+        tool_calls: [
+          {
+            id: 'large-result',
+            name: 'query',
+            args: {},
+            type: 'tool_call',
+          },
+        ],
+      }),
+      toolMessage,
+    ];
 
-      const result = foldToolBlocksForToollessAgent(messages);
-      const folded = result.find(isSyntheticProviderContextMessage)!;
+    const result = foldToolBlocksForToollessAgent(messages);
+    const folded = result.find(isSyntheticProviderContextMessage)!;
 
-      expect(folded).toBeInstanceOf(HumanMessage);
-      expect(getTextContent(folded).length).toBeLessThanOrEqual(
-        HARD_MAX_TOOL_RESULT_CHARS
-      );
-      expect(toolMessage.content).toBe(largeContent);
-    },
-    30_000
-  );
+    expect(folded).toBeInstanceOf(HumanMessage);
+    expect(getTextContent(folded).length).toBeLessThanOrEqual(
+      HARD_MAX_TOOL_RESULT_CHARS
+    );
+    expect(toolMessage.content).toBe(largeContent);
+  }, 30_000);
 
   test('omits source rows whose bytes do not survive the shared fold cap', () => {
     const messages = [
@@ -1266,10 +1425,7 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(folded.additional_kwargs.sourceMessageIds).toBeUndefined();
     expect(folded.additional_kwargs.provenance).toEqual({
       version: 1,
-      parts: [
-        { attribution: 'synthetic' },
-        { attribution: 'model' },
-      ],
+      parts: [{ attribution: 'synthetic' }, { attribution: 'model' }],
     });
   });
 

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -12,6 +12,7 @@ import {
   isSyntheticProviderContextMessage,
 } from './format';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import { toLangChainContent } from './langchain';
 
 /** Concatenated text across a message's content (string or structured array). */
 function getTextContent(msg: {
@@ -397,6 +398,38 @@ describe('foldToolBlocksForToollessAgent', () => {
 
     expect(hasResidualToolContent(result)).toBe(false);
     expect(result.map(getTextContent).join('\n')).toContain('Found roadmap.md');
+  });
+
+  test('folds Anthropic server-search blocks for a tool-less destination', () => {
+    const messages = [
+      new AIMessage({
+        content: toLangChainContent([
+          {
+            type: 'server_tool_use',
+            id: 'srvtoolu_1',
+            name: 'web_search',
+            input: { query: 'retained' },
+          },
+          {
+            type: 'web_search_tool_result',
+            tool_use_id: 'srvtoolu_1',
+            content: {
+              type: 'web_search_tool_result_error',
+              error_code: 'max_uses_exceeded',
+            },
+          },
+        ]),
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).not.toBe(messages);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(HumanMessage);
+    expect(isSyntheticProviderContextMessage(result[0])).toBe(true);
+    expect(getTextContent(result[0])).toContain('server_tool_use');
+    expect(getTextContent(result[0])).toContain('web_search_tool_result');
   });
 
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -529,7 +529,7 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(result).toBe(messages);
   });
 
-  test('folds authoritative Responses v0 server output for another provider', () => {
+  test('folds authoritative Responses v0 output in source order', () => {
     const messages = [
       new AIMessage({
         content: 'The calculation completed.',
@@ -547,7 +547,12 @@ describe('foldToolBlocksForToollessAgent', () => {
               id: 'message-1',
               type: 'message',
               role: 'assistant',
-              content: [{ type: 'output_text', text: 'duplicate text' }],
+              content: [
+                {
+                  type: 'output_text',
+                  text: 'The calculation completed.',
+                },
+              ],
             },
             {
               id: 'function-1',
@@ -566,8 +571,58 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(getTextContent(result[0])).toContain('server_tool_output');
     expect(getTextContent(result[0])).toContain('code_interpreter_call');
     expect(getTextContent(result[0])).toContain('The calculation completed.');
-    expect(getTextContent(result[0])).not.toContain('duplicate text');
-    expect(getTextContent(result[0])).not.toContain('function_call');
+    const text = getTextContent(result[0]);
+    expect(text).toContain('The calculation completed.');
+    expect(text).toContain('[tool_call] lookup({})');
+    expect(text.indexOf('code_interpreter_call')).toBeLessThan(
+      text.indexOf('The calculation completed.')
+    );
+    expect(text.indexOf('The calculation completed.')).toBeLessThan(
+      text.indexOf('[tool_call] lookup')
+    );
+    expect(result[0].additional_kwargs.provenance).toEqual({
+      version: 1,
+      parts: [
+        { attribution: 'synthetic' },
+        { attribution: 'model' },
+        { attribution: 'tool' },
+      ],
+    });
+  });
+
+  test('folds Responses custom tool calls from authoritative output', () => {
+    const messages = [
+      new AIMessage({
+        content: 'Running the custom tool.',
+        response_metadata: {
+          output: [
+            {
+              id: 'message-1',
+              type: 'message',
+              role: 'assistant',
+              content: [
+                { type: 'output_text', text: 'Running the custom tool.' },
+              ],
+            },
+            {
+              id: 'custom-1',
+              call_id: 'call-1',
+              type: 'custom_tool_call',
+              name: 'execute',
+              input: 'print(2 + 2)',
+            },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('server_tool_output');
+    expect(text).toContain('custom_tool_call');
+    expect(text).toContain('execute');
+    expect(text).toContain('print(2 + 2)');
   });
 
   test.each([

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -570,6 +570,62 @@ describe('foldToolBlocksForToollessAgent', () => {
     expect(getTextContent(result[0])).not.toContain('function_call');
   });
 
+  test.each([
+    'apply_patch_call_output',
+    'local_shell_call_output',
+    'mcp_list_tools',
+    'program_output',
+    'shell_call_output',
+    'tool_search_output',
+  ])('folds replayable Responses output type %s', (type) => {
+    const messages = [
+      new AIMessage({
+        content: [],
+        additional_kwargs: {
+          tool_outputs: [{ type, output: 'result', result: 'result' }],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+
+    expect(getTextContent(folded)).toContain('server_tool_output');
+    expect(getTextContent(folded)).toContain(type);
+  });
+
+  test('preserves parsed calls alongside authoritative Responses output', () => {
+    const messages = [
+      new AIMessage({
+        content: [{ type: 'text', text: 'I will use both tools.' }],
+        tool_calls: [
+          {
+            id: 'function-1',
+            name: 'lookup',
+            args: { query: 'roadmap' },
+            type: 'tool_call',
+          },
+        ],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              id: 'server-1',
+              type: 'code_interpreter_call',
+              status: 'completed',
+              outputs: [{ type: 'logs', logs: '4' }],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const [folded] = foldToolBlocksForToollessAgent(messages);
+    const text = getTextContent(folded);
+
+    expect(text).toContain('server_tool_output');
+    expect(text).toContain('code_interpreter_call');
+    expect(text).toContain('[tool_call] lookup({"query":"roadmap"})');
+  });
+
   test('preserves user authorship in mixed tool-result turns', () => {
     const messages = [
       new HumanMessage({

--- a/src/messages/foldToollessToolBlocks.test.ts
+++ b/src/messages/foldToollessToolBlocks.test.ts
@@ -13,7 +13,6 @@ import {
 } from './format';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { toLangChainContent } from './langchain';
-import { Providers } from '@/common';
 
 /** Concatenated text across a message's content (string or structured array). */
 function getTextContent(msg: {
@@ -524,10 +523,37 @@ describe('foldToolBlocksForToollessAgent', () => {
     const result = foldToolBlocksForToollessAgent(
       messages,
       undefined,
-      Providers.OPENAI
+      true
     );
 
     expect(result).toBe(messages);
+  });
+
+  test('folds authoritative Responses v0 server output for another provider', () => {
+    const messages = [
+      new AIMessage({
+        content: 'The calculation completed.',
+        response_metadata: {
+          model_provider: 'openai',
+          output: [
+            {
+              id: 'server-1',
+              type: 'code_interpreter_call',
+              status: 'completed',
+              code: 'print(2 + 2)',
+              outputs: [{ type: 'logs', logs: '4' }],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const result = foldToolBlocksForToollessAgent(messages);
+
+    expect(result).not.toBe(messages);
+    expect(getTextContent(result[0])).toContain('server_tool_output');
+    expect(getTextContent(result[0])).toContain('code_interpreter_call');
+    expect(getTextContent(result[0])).toContain('The calculation completed.');
   });
 
   test('detects v1 standard-content tool_call blocks (no AIMessage.tool_calls)', () => {

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -3789,16 +3789,17 @@ function getAuthoritativeResponsesToolOutput(
   if (output == null || output.length === 0) {
     return undefined;
   }
+  const serverToolOutput: unknown[] = [];
   for (let index = 0; index < output.length; index++) {
     const type = readFoldedDataProperty(output[index], 'type');
     if (
       typeof type === 'string' &&
       OPENAI_RESPONSES_SERVER_TOOL_TYPES.has(type)
     ) {
-      return output;
+      serverToolOutput.push(output[index]);
     }
   }
-  return undefined;
+  return serverToolOutput.length > 0 ? serverToolOutput : undefined;
 }
 
 /**
@@ -4427,7 +4428,7 @@ function isToolResultMessage(msg: BaseMessage): boolean {
   return false;
 }
 
-function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' {
+function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' | 'User' {
   if (isToolMessage(msg)) {
     return 'Tool';
   }
@@ -4437,6 +4438,9 @@ function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' {
     ('role' in msg && msg.role === 'assistant')
   ) {
     return 'AI';
+  }
+  if (msg instanceof HumanMessage || ('role' in msg && msg.role === 'user')) {
+    return 'User';
   }
   return isToolResultMessage(msg) ? 'Tool' : 'AI';
 }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -3546,6 +3546,7 @@ interface FoldedSourceMessage {
    * string content or tool-call metadata contributed as a whole. */
   readonly retainedContentPartIndices?: ReadonlySet<number>;
   readonly mappingAmbiguous?: boolean;
+  readonly additionalAttributions?: readonly ProviderMessageAttribution[];
 }
 
 function getFoldedSourceAttribution(
@@ -3667,6 +3668,9 @@ function getSyntheticProviderContextProvenanceParts(
     if (parts.length === sourcePartStart) {
       parts.push({ attribution: fallbackAttribution });
     }
+    for (const attribution of source.additionalAttributions ?? []) {
+      parts.push({ attribution });
+    }
   }
   return mergeAdjacentProviderProvenanceParts(parts);
 }
@@ -3766,6 +3770,7 @@ const OPENAI_RESPONSES_SERVER_TOOL_TYPES: ReadonlySet<string> = new Set([
   'apply_patch_call_output',
   'code_interpreter_call',
   'computer_call',
+  'custom_tool_call',
   'file_search_call',
   'image_generation_call',
   'local_shell_call_output',
@@ -3777,9 +3782,14 @@ const OPENAI_RESPONSES_SERVER_TOOL_TYPES: ReadonlySet<string> = new Set([
   'web_search_call',
 ]);
 
+interface AuthoritativeResponsesToolOutput {
+  readonly output: readonly unknown[];
+  readonly preservesOrder: boolean;
+}
+
 function getAuthoritativeResponsesToolOutput(
   message: BaseMessage
-): readonly unknown[] | undefined {
+): AuthoritativeResponsesToolOutput | undefined {
   const responseOutput = getBoundedProviderPairingArrayProperty(
     message.response_metadata,
     'output'
@@ -3788,10 +3798,8 @@ function getAuthoritativeResponsesToolOutput(
     message.additional_kwargs,
     'tool_outputs'
   );
-  const output =
-    responseOutput != null && responseOutput.length > 0
-      ? responseOutput
-      : toolOutputs;
+  const preservesOrder = responseOutput != null && responseOutput.length > 0;
+  const output = preservesOrder ? responseOutput : toolOutputs;
   if (output == null || output.length === 0) {
     return undefined;
   }
@@ -3805,7 +3813,69 @@ function getAuthoritativeResponsesToolOutput(
       serverToolOutput.push(output[index]);
     }
   }
-  return serverToolOutput.length > 0 ? serverToolOutput : undefined;
+  if (serverToolOutput.length === 0) {
+    return undefined;
+  }
+  return {
+    output: preservesOrder ? output : serverToolOutput,
+    preservesOrder,
+  };
+}
+
+function appendOrderedResponsesOutput(
+  output: readonly unknown[],
+  textChunks: string[],
+  budget: FoldContextBudget
+): { contributed: boolean; complete: boolean } {
+  const remainingCharsBefore = budget.remainingChars;
+  let complete = true;
+  for (const item of output) {
+    if (!consumeFoldedWork(textChunks, budget)) {
+      complete = false;
+      break;
+    }
+    const type = readFoldedDataProperty(item, 'type');
+    if (type === 'message') {
+      const content = readFoldedDataProperty(item, 'content');
+      if (!Array.isArray(content)) {
+        continue;
+      }
+      for (const part of content) {
+        const partType = readFoldedDataProperty(part, 'type');
+        const value =
+          partType === 'refusal'
+            ? readFoldedDataProperty(part, 'refusal')
+            : readFoldedDataProperty(part, 'text');
+        if (typeof value === 'string' && value) {
+          appendFoldedLine(textChunks, budget, ['AI: ', value]);
+        }
+      }
+      continue;
+    }
+    if (type === 'function_call') {
+      const name = readFoldedDataProperty(item, 'name');
+      const args = readFoldedDataProperty(item, 'arguments');
+      appendFoldedLine(textChunks, budget, [
+        `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
+        typeof args === 'string' ? args : serializeFoldedValue(args ?? {}),
+        ')',
+      ]);
+      continue;
+    }
+    if (
+      typeof type === 'string' &&
+      OPENAI_RESPONSES_SERVER_TOOL_TYPES.has(type)
+    ) {
+      appendFoldedLine(textChunks, budget, [
+        'AI: [server_tool_output] ',
+        serializeFoldedValue(item),
+      ]);
+    }
+  }
+  return {
+    contributed: budget.remainingChars < remainingCharsBefore,
+    complete,
+  };
 }
 
 /**
@@ -3827,6 +3897,21 @@ function appendMessageContent(
   budget: FoldContextBudget
 ): FoldedSourceMessage | undefined {
   const { content } = msg;
+  const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
+  if (responsesOutput?.preservesOrder === true) {
+    const orderedOutput = appendOrderedResponsesOutput(
+      responsesOutput.output,
+      textChunks,
+      budget
+    );
+    return orderedOutput.contributed
+      ? {
+        message: msg,
+        mappingAmbiguous: true,
+        additionalAttributions: ['tool'],
+      }
+      : undefined;
+  }
 
   if (typeof content === 'string') {
     const remainingCharsBefore = budget.remainingChars;
@@ -3836,11 +3921,10 @@ function appendMessageContent(
         consumeFoldedWork(textChunks, budget) &&
         appendFoldedLine(textChunks, budget, [`${role}: `, content]);
     }
-    const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
     if (responsesOutput != null) {
       appendFoldedLine(textChunks, budget, [
         'AI: [server_tool_output] ',
-        serializeFoldedValue(responsesOutput),
+        serializeFoldedValue(responsesOutput.output),
       ]);
     }
     const toolCalls = appendToolCalls(msg, role, textChunks, budget);
@@ -3849,6 +3933,9 @@ function appendMessageContent(
         message: msg,
         ...((!contentComplete || !toolCalls.complete) && {
           mappingAmbiguous: true,
+        }),
+        ...(responsesOutput != null && {
+          additionalAttributions: ['tool'] as const,
         }),
       }
       : undefined;
@@ -4053,12 +4140,11 @@ function appendMessageContent(
 
   let responsesOutputContributed = false;
   if (!hasToolUseBlock) {
-    const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
     if (responsesOutput != null) {
       const remainingCharsBefore = budget.remainingChars;
       appendFoldedLine(textChunks, budget, [
         'AI: [server_tool_output] ',
-        serializeFoldedValue(responsesOutput),
+        serializeFoldedValue(responsesOutput.output),
       ]);
       responsesOutputContributed =
         budget.remainingChars < remainingCharsBefore;
@@ -4075,6 +4161,9 @@ function appendMessageContent(
       message: msg,
       ...((responsesOutputContributed || !toolCalls.complete) && {
         mappingAmbiguous: true,
+      }),
+      ...(responsesOutputContributed && {
+        additionalAttributions: ['tool'] as const,
       }),
     };
   }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -3762,6 +3762,45 @@ function flushTextChunks(
   textChunks.length = 0;
 }
 
+const OPENAI_RESPONSES_SERVER_TOOL_TYPES: ReadonlySet<string> = new Set([
+  'code_interpreter_call',
+  'computer_call',
+  'file_search_call',
+  'image_generation_call',
+  'mcp_call',
+  'web_search_call',
+]);
+
+function getAuthoritativeResponsesToolOutput(
+  message: BaseMessage
+): readonly unknown[] | undefined {
+  const responseOutput = getBoundedProviderPairingArrayProperty(
+    message.response_metadata,
+    'output'
+  );
+  const toolOutputs = getBoundedProviderPairingArrayProperty(
+    message.additional_kwargs,
+    'tool_outputs'
+  );
+  const output =
+    responseOutput != null && responseOutput.length > 0
+      ? responseOutput
+      : toolOutputs;
+  if (output == null || output.length === 0) {
+    return undefined;
+  }
+  for (let index = 0; index < output.length; index++) {
+    const type = readFoldedDataProperty(output[index], 'type');
+    if (
+      typeof type === 'string' &&
+      OPENAI_RESPONSES_SERVER_TOOL_TYPES.has(type)
+    ) {
+      return output;
+    }
+  }
+  return undefined;
+}
+
 /**
  * Appends a single message's content to the running `textChunks` / `parts`
  * accumulators. Portable image blocks are shallow-copied into `parts` so
@@ -3789,6 +3828,13 @@ function appendMessageContent(
       contentComplete =
         consumeFoldedWork(textChunks, budget) &&
         appendFoldedLine(textChunks, budget, [`${role}: `, content]);
+    }
+    const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
+    if (responsesOutput != null) {
+      appendFoldedLine(textChunks, budget, [
+        'AI: [server_tool_output] ',
+        serializeFoldedValue(responsesOutput),
+      ]);
     }
     const toolCalls = appendToolCalls(msg, role, textChunks, budget);
     return budget.remainingChars < remainingCharsBefore || toolCalls.contributed
@@ -3996,6 +4042,17 @@ function appendMessageContent(
       ]);
     }
     markBlockRetained();
+  }
+
+  if (!hasToolUseBlock) {
+    const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
+    if (responsesOutput != null) {
+      appendFoldedLine(textChunks, budget, [
+        'AI: [server_tool_output] ',
+        serializeFoldedValue(responsesOutput),
+      ]);
+      hasToolUseBlock = true;
+    }
   }
 
   // If content array had no tool_use blocks, fall back to tool_calls metadata
@@ -4306,7 +4363,7 @@ export function ensureThinkingBlockInMessages(
  *  `assistant(tool_calls) -> user(...)` sequence. */
 function messageHasToolContent(
   msg: BaseMessage,
-  provider?: ProviderName
+  preserveNativeOpenAIResponses = false
 ): boolean {
   if (isToolMessage(msg)) {
     return true;
@@ -4324,7 +4381,7 @@ function messageHasToolContent(
     for (const block of msg.content as ExtendedMessageContent[]) {
       const type = readFoldedDataProperty(block, 'type');
       const isNativeOpenAIServerContent =
-        provider === Providers.OPENAI &&
+        preserveNativeOpenAIResponses &&
         (type === 'server_tool_call' ||
           type === 'server_tool_call_result' ||
           type === 'server_tool_result');
@@ -4341,6 +4398,12 @@ function messageHasToolContent(
     if (hasOpenAINativeServerContent) {
       return false;
     }
+  }
+  if (
+    !preserveNativeOpenAIResponses &&
+    getAuthoritativeResponsesToolOutput(msg) != null
+  ) {
+    return true;
   }
   return false;
 }
@@ -4402,7 +4465,7 @@ function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' {
 export function foldToolBlocksForToollessAgent(
   messages: BaseMessage[],
   config?: RunnableConfig,
-  provider?: ProviderName
+  preserveNativeOpenAIResponses = false
 ): BaseMessage[] {
   let result: BaseMessage[] | null = null;
   let foldedCount = 0;
@@ -4410,7 +4473,7 @@ export function foldToolBlocksForToollessAgent(
   let i = 0;
   while (i < messages.length) {
     const msg = messages[i];
-    if (!messageHasToolContent(msg, provider)) {
+    if (!messageHasToolContent(msg, preserveNativeOpenAIResponses)) {
       result?.push(msg);
       i++;
       continue;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -14,6 +14,11 @@ import type {
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type {
+  OrderedToolHistoryProjection,
+  ToolHistoryPreparation,
+  ToolHistoryCallMirrors,
+} from './toolHistoryProjection';
+import type {
   BedrockReasoningContentText,
   ExtendedMessageContent,
   GoogleReasoningContentText,
@@ -44,7 +49,6 @@ import {
   getProviderToolCallPartDescriptor,
   getProviderToolResultPartDescriptor,
   hasStructurallyValidAnthropicWebSearchResultContent,
-  isProviderToolCallContentPart,
   isProviderToolContentPart,
 } from './toolResultTypes';
 import {
@@ -78,6 +82,11 @@ import { isReasoningContentBlock } from './reasoningTypes';
 import { flattenLegacyContent, isLegacyConvertible } from './content';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { emitAgentLog } from '@/utils/events';
+import {
+  createToolHistoryPreparation,
+  isToolHistoryCallMirror,
+  recordToolHistoryCallMirror,
+} from './toolHistoryProjection';
 
 interface MediaMessageParams {
   message: {
@@ -604,8 +613,7 @@ function createDerivedCompactionSemanticIndexCollector(
     Number.isSafeInteger(serializedProvidedEntryCount) &&
     serializedProvidedEntryCount >= snapshotProvidedEntryCount;
   const providedEntryCount =
-    validSerializedProvidedEntryCount &&
-    serializedProvidedEntryCount != null
+    validSerializedProvidedEntryCount && serializedProvidedEntryCount != null
       ? serializedProvidedEntryCount
       : snapshotProvidedEntryCount;
   collector.omittedBaseEntryCount = Math.max(
@@ -3036,10 +3044,7 @@ export const formatAgentMessages = (
             }
           }
 
-          if (
-            discoveredTools.has(toolName) ||
-            isSdkManagedToolName(toolName)
-          ) {
+          if (discoveredTools.has(toolName) || isSdkManagedToolName(toolName)) {
             filteredContent.push(part);
             filteredSourceContentPartIndices.push(partSourceContentIndices);
             if (
@@ -3669,7 +3674,20 @@ function getSyntheticProviderContextProvenanceParts(
       parts.push({ attribution: fallbackAttribution });
     }
     for (const attribution of source.additionalAttributions ?? []) {
-      parts.push({ attribution });
+      const sourceMessageId =
+        sourceMessageIds.length === 1
+          ? sourceMessageIds[0]
+          : undefined;
+      const retainedSourceId =
+        retainedSourceIds.size === 1
+          ? retainedSourceIds.values().next().value
+          : undefined;
+      parts.push({
+        attribution,
+        ...((sourceMessageId ?? retainedSourceId) != null && {
+          sourceMessageId: sourceMessageId ?? retainedSourceId,
+        }),
+      });
     }
   }
   return mergeAdjacentProviderProvenanceParts(parts);
@@ -3766,115 +3784,75 @@ function flushTextChunks(
   textChunks.length = 0;
 }
 
-const OPENAI_RESPONSES_SERVER_TOOL_TYPES: ReadonlySet<string> = new Set([
-  'apply_patch_call_output',
-  'code_interpreter_call',
-  'computer_call',
-  'custom_tool_call',
-  'file_search_call',
-  'image_generation_call',
-  'local_shell_call_output',
-  'mcp_call',
-  'mcp_list_tools',
-  'program_output',
-  'shell_call_output',
-  'tool_search_output',
-  'web_search_call',
-]);
-
-interface AuthoritativeResponsesToolOutput {
-  readonly output: readonly unknown[];
-  readonly preservesOrder: boolean;
-}
-
 function getAuthoritativeResponsesToolOutput(
-  message: BaseMessage
-): AuthoritativeResponsesToolOutput | undefined {
-  const responseOutput = getBoundedProviderPairingArrayProperty(
-    message.response_metadata,
-    'output'
-  );
-  const toolOutputs = getBoundedProviderPairingArrayProperty(
-    message.additional_kwargs,
-    'tool_outputs'
-  );
-  const preservesOrder = responseOutput != null && responseOutput.length > 0;
-  const output = preservesOrder ? responseOutput : toolOutputs;
-  if (output == null || output.length === 0) {
-    return undefined;
-  }
-  const serverToolOutput: unknown[] = [];
-  for (let index = 0; index < output.length; index++) {
-    const type = readFoldedDataProperty(output[index], 'type');
-    if (
-      typeof type === 'string' &&
-      OPENAI_RESPONSES_SERVER_TOOL_TYPES.has(type)
-    ) {
-      serverToolOutput.push(output[index]);
-    }
-  }
-  if (serverToolOutput.length === 0) {
-    return undefined;
-  }
-  return {
-    output: preservesOrder ? output : serverToolOutput,
-    preservesOrder,
-  };
+  message: BaseMessage,
+  preparation: ToolHistoryPreparation
+): OrderedToolHistoryProjection | undefined {
+  const projection = preparation.get(message);
+  return projection?.hasToolContent === true ? projection : undefined;
 }
 
 function appendOrderedResponsesOutput(
-  output: readonly unknown[],
+  projection: OrderedToolHistoryProjection,
   textChunks: string[],
-  budget: FoldContextBudget
-): { contributed: boolean; complete: boolean } {
-  const remainingCharsBefore = budget.remainingChars;
-  let complete = true;
-  for (const item of output) {
+  parts: MessageContentComplex[],
+  budget: FoldContextBudget,
+  omitText = false
+): { contributed: boolean; complete: boolean; hasTool: boolean } {
+  let contributed = false;
+  let hasTool = false;
+  for (const contribution of projection.contributions) {
     if (!consumeFoldedWork(textChunks, budget)) {
-      complete = false;
       break;
     }
-    const type = readFoldedDataProperty(item, 'type');
-    if (type === 'message') {
-      const content = readFoldedDataProperty(item, 'content');
-      if (!Array.isArray(content)) {
+    const remainingCharsBefore = budget.remainingChars;
+    if (contribution.kind === 'image') {
+      const chars = getToolContentCharLength([contribution.image]);
+      if (chars > budget.remainingChars) {
+        appendFoldedLine(textChunks, budget, [
+          'Tool: [image omitted: folded context limit]',
+        ]);
+        contributed = true;
+        hasTool = true;
         continue;
       }
-      for (const part of content) {
-        const partType = readFoldedDataProperty(part, 'type');
-        const value =
-          partType === 'refusal'
-            ? readFoldedDataProperty(part, 'refusal')
-            : readFoldedDataProperty(part, 'text');
-        if (typeof value === 'string' && value) {
-          appendFoldedLine(textChunks, budget, ['AI: ', value]);
-        }
-      }
+      flushTextChunks(textChunks, parts);
+      parts.push(contribution.image as MessageContentComplex);
+      budget.remainingChars -= chars;
+      contributed = true;
+      hasTool = true;
       continue;
     }
-    if (type === 'function_call') {
-      const name = readFoldedDataProperty(item, 'name');
-      const args = readFoldedDataProperty(item, 'arguments');
+    if (contribution.kind === 'text') {
+      if (omitText) {
+        continue;
+      }
+      appendFoldedLine(textChunks, budget, ['AI: ', contribution.text]);
+    } else if (contribution.kind === 'call') {
       appendFoldedLine(textChunks, budget, [
-        `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
-        typeof args === 'string' ? args : serializeFoldedValue(args ?? {}),
+        `AI: [tool_call] ${contribution.name}(`,
+        serializeFoldedValue(contribution.arguments),
         ')',
       ]);
-      continue;
-    }
-    if (
-      typeof type === 'string' &&
-      OPENAI_RESPONSES_SERVER_TOOL_TYPES.has(type)
-    ) {
+    } else if (contribution.providerType !== 'reasoning') {
       appendFoldedLine(textChunks, budget, [
         'AI: [server_tool_output] ',
-        serializeFoldedValue(item),
+        serializeFoldedValue(contribution.value),
       ]);
     }
+    const retained = budget.remainingChars < remainingCharsBefore;
+    contributed ||= retained;
+    hasTool ||= retained && contribution.actor === 'tool';
+  }
+  if (projection.truncated) {
+    const before = budget.remainingChars;
+    appendFoldedLine(textChunks, budget, [FOLDED_CONTEXT_TRUNCATION_NOTICE]);
+    contributed ||= budget.remainingChars < before;
   }
   return {
-    contributed: budget.remainingChars < remainingCharsBefore,
-    complete,
+    contributed,
+    complete: !budget.truncated && !projection.truncated,
+    hasTool,
   };
 }
 
@@ -3885,30 +3863,46 @@ function appendOrderedResponsesOutput(
  * blocks are retained as bounded text so a folded cross-provider history
  * cannot contain an unsupported native block or JSON-expand without limit.
  *
- * When `content` is an array containing tool_use blocks, `tool_calls` is NOT
- * additionally serialized (avoiding double output).  `tool_calls` is used as
- * a fallback when `content` is a plain string or an array with no tool_use.
+ * Parsed calls are omitted only when identity, name, and complete arguments
+ * establish an equivalent content representation.
  */
 function appendMessageContent(
   msg: BaseMessage,
   role: string,
   textChunks: string[],
   parts: MessageContentComplex[],
-  budget: FoldContextBudget
+  budget: FoldContextBudget,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): FoldedSourceMessage | undefined {
   const { content } = msg;
-  const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
-  if (responsesOutput?.preservesOrder === true) {
+  const responsesOutput = getAuthoritativeResponsesToolOutput(msg, preparation);
+  if (
+    responsesOutput != null &&
+    (responsesOutput.source.coverage === 'complete-output' ||
+      typeof content === 'string' ||
+      (Array.isArray(content) &&
+        content.length <= MAX_FOLDED_CONTEXT_WORK &&
+        content.every(
+          (block) => readFoldedDataProperty(block, 'type') === 'text'
+        )))
+  ) {
     const orderedOutput = appendOrderedResponsesOutput(
-      responsesOutput.output,
+      responsesOutput,
       textChunks,
+      parts,
       budget
     );
-    return orderedOutput.contributed
+    const toolCalls =
+      responsesOutput.source.coverage === 'tool-sidecar'
+        ? appendToolCalls(msg, role, textChunks, budget)
+        : { contributed: false, complete: true };
+    return orderedOutput.contributed || toolCalls.contributed
       ? {
         message: msg,
         mappingAmbiguous: true,
-        additionalAttributions: ['tool'],
+        ...(orderedOutput.hasTool && {
+          additionalAttributions: ['tool'] as const,
+        }),
       }
       : undefined;
   }
@@ -3921,21 +3915,12 @@ function appendMessageContent(
         consumeFoldedWork(textChunks, budget) &&
         appendFoldedLine(textChunks, budget, [`${role}: `, content]);
     }
-    if (responsesOutput != null) {
-      appendFoldedLine(textChunks, budget, [
-        'AI: [server_tool_output] ',
-        serializeFoldedValue(responsesOutput.output),
-      ]);
-    }
     const toolCalls = appendToolCalls(msg, role, textChunks, budget);
     return budget.remainingChars < remainingCharsBefore || toolCalls.contributed
       ? {
         message: msg,
         ...((!contentComplete || !toolCalls.complete) && {
           mappingAmbiguous: true,
-        }),
-        ...(responsesOutput != null && {
-          additionalAttributions: ['tool'] as const,
         }),
       }
       : undefined;
@@ -3951,13 +3936,12 @@ function appendMessageContent(
       : undefined;
   }
 
-  let hasToolUseBlock = false;
+  const representedToolCalls: ToolHistoryCallMirrors = new Map();
   const retainedContentPartIndices = new Set<number>();
 
   for (let blockIndex = 0; blockIndex < content.length; blockIndex++) {
     const block = content[blockIndex] as ExtendedMessageContent;
     if (!consumeFoldedWork(textChunks, budget)) {
-      hasToolUseBlock = true;
       break;
     }
     const remainingCharsBefore = budget.remainingChars;
@@ -3971,8 +3955,10 @@ function appendMessageContent(
       typeof blockTypeValue === 'string' ? blockTypeValue : undefined;
     const blockRole =
       getProviderToolResultPartDescriptor(block) != null ? 'Tool' : role;
-    hasToolUseBlock ||= isProviderToolCallContentPart(block);
-
+    const callDescriptor = getProviderToolCallPartDescriptor(block);
+    if (callDescriptor != null) {
+      recordToolHistoryCallMirror(representedToolCalls, block);
+    }
     if (
       blockType !== 'tool_use' &&
       blockType !== 'tool_call' &&
@@ -4002,7 +3988,6 @@ function appendMessageContent(
     }
 
     if (blockType === 'tool_use') {
-      hasToolUseBlock = true;
       const name = readFoldedDataProperty(block, 'name');
       const input = readFoldedDataProperty(block, 'input');
       appendFoldedLine(textChunks, budget, [
@@ -4019,7 +4004,6 @@ function appendMessageContent(
     // output } }`, from `convertMessagesToContent` / persisted history). Handle
     // both, and emit any embedded output, so the name/args/result survive.
     if (blockType === 'tool_call') {
-      hasToolUseBlock = true;
       const nested = readFoldedDataProperty(block, 'tool_call');
       const nestedName = readFoldedDataProperty(nested, 'name');
       const topLevelName = readFoldedDataProperty(block, 'name');
@@ -4053,16 +4037,12 @@ function appendMessageContent(
     // user message carrying the result). Preserve nested image blocks as-is
     // instead of JSON-stringifying them through the generic fallback.
     if (blockType === 'tool_result') {
-      hasToolUseBlock = true;
       const inner = readFoldedDataProperty(block, 'content') as
         | ToolResultContent['content']
         | undefined;
       if (typeof inner === 'string') {
         if (inner) {
-          appendFoldedLine(textChunks, budget, [
-            'Tool: [tool_result] ',
-            inner,
-          ]);
+          appendFoldedLine(textChunks, budget, ['Tool: [tool_result] ', inner]);
         }
       } else if (Array.isArray(inner)) {
         for (const innerBlock of inner as Array<
@@ -4138,24 +4118,23 @@ function appendMessageContent(
     markBlockRetained();
   }
 
-  let responsesOutputContributed = false;
-  if (!hasToolUseBlock) {
-    if (responsesOutput != null) {
-      const remainingCharsBefore = budget.remainingChars;
-      appendFoldedLine(textChunks, budget, [
-        'AI: [server_tool_output] ',
-        serializeFoldedValue(responsesOutput.output),
-      ]);
-      responsesOutputContributed =
-        budget.remainingChars < remainingCharsBefore;
-    }
-  }
+  const responsesOutputContributed =
+    responsesOutput != null &&
+    appendOrderedResponsesOutput(
+      responsesOutput,
+      textChunks,
+      parts,
+      budget,
+      true
+    ).contributed;
 
-  // If content array had no tool_use blocks, fall back to tool_calls metadata
-  // (handles edge case: empty content array with tool_calls populated)
-  const toolCalls = !hasToolUseBlock
-    ? appendToolCalls(msg, role, textChunks, budget)
-    : { contributed: false, complete: true };
+  const toolCalls = appendToolCalls(
+    msg,
+    role,
+    textChunks,
+    budget,
+    representedToolCalls
+  );
   if (toolCalls.contributed || responsesOutputContributed) {
     return {
       message: msg,
@@ -4176,7 +4155,8 @@ function appendToolCalls(
   msg: BaseMessage,
   role: string,
   textChunks: string[],
-  budget: FoldContextBudget
+  budget: FoldContextBudget,
+  representedToolCalls?: ToolHistoryCallMirrors
 ): { contributed: boolean; complete: boolean } {
   if (role !== 'AI') {
     return { contributed: false, complete: true };
@@ -4212,6 +4192,16 @@ function appendToolCalls(
       }
       const name = readFoldedDataProperty(tc, 'name');
       const args = readFoldedDataProperty(tc, 'args');
+      if (
+        isToolHistoryCallMirror(
+          representedToolCalls,
+          readFoldedDataProperty(tc, 'id'),
+          name,
+          args
+        )
+      ) {
+        continue;
+      }
       appendFoldedLine(textChunks, budget, [
         `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
         serializeFoldedValue(args),
@@ -4242,7 +4232,7 @@ function appendToolCalls(
     const args = readFoldedDataProperty(fn, 'arguments');
     appendFoldedLine(textChunks, budget, [
       `AI: [tool_call] ${typeof name === 'string' ? name : ''}(`,
-      typeof args === 'string' ? args : '',
+      serializeFoldedValue(typeof args === 'string' ? args : ''),
       ')',
     ]);
   }
@@ -4282,7 +4272,8 @@ export function ensureThinkingBlockInMessages(
   messages: BaseMessage[],
   _provider: ProviderName,
   config?: RunnableConfig,
-  runStartIndex?: number
+  runStartIndex?: number,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): BaseMessage[] {
   if (messages.length === 0) {
     return messages;
@@ -4405,7 +4396,8 @@ export function ensureThinkingBlockInMessages(
         'AI',
         textChunks,
         parts,
-        foldBudget
+        foldBudget,
+        preparation
       );
       if (aiSource != null) {
         foldedSourceMessages.push(aiSource);
@@ -4418,7 +4410,8 @@ export function ensureThinkingBlockInMessages(
           'Tool',
           textChunks,
           parts,
-          foldBudget
+          foldBudget,
+          preparation
         );
         if (toolSource != null) {
           foldedSourceMessages.push(toolSource);
@@ -4464,7 +4457,8 @@ export function ensureThinkingBlockInMessages(
  *  `assistant(tool_calls) -> user(...)` sequence. */
 function messageHasToolContent(
   msg: BaseMessage,
-  preserveNativeOpenAIResponses = false
+  preserveNativeOpenAIResponses = false,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): boolean {
   if (isToolMessage(msg)) {
     return true;
@@ -4502,7 +4496,7 @@ function messageHasToolContent(
   }
   if (
     !preserveNativeOpenAIResponses &&
-    getAuthoritativeResponsesToolOutput(msg) != null
+    getAuthoritativeResponsesToolOutput(msg, preparation) != null
   ) {
     return true;
   }
@@ -4569,7 +4563,8 @@ function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' | 'User' {
 export function foldToolBlocksForToollessAgent(
   messages: BaseMessage[],
   config?: RunnableConfig,
-  preserveNativeOpenAIResponses = false
+  preserveNativeOpenAIResponses = false,
+  preparation: ToolHistoryPreparation = createToolHistoryPreparation()
 ): BaseMessage[] {
   let result: BaseMessage[] | null = null;
   let foldedCount = 0;
@@ -4577,7 +4572,9 @@ export function foldToolBlocksForToollessAgent(
   let i = 0;
   while (i < messages.length) {
     const msg = messages[i];
-    if (!messageHasToolContent(msg, preserveNativeOpenAIResponses)) {
+    if (
+      !messageHasToolContent(msg, preserveNativeOpenAIResponses, preparation)
+    ) {
       result?.push(msg);
       i++;
       continue;
@@ -4597,7 +4594,8 @@ export function foldToolBlocksForToollessAgent(
       getFoldedMessageRole(msg),
       textChunks,
       parts,
-      foldBudget
+      foldBudget,
+      preparation
     );
     if (initialSource != null) {
       foldedSourceMessages.push(initialSource);
@@ -4611,7 +4609,8 @@ export function foldToolBlocksForToollessAgent(
         getFoldedMessageRole(messages[j]),
         textChunks,
         parts,
-        foldBudget
+        foldBudget,
+        preparation
       );
       if (toolSource != null) {
         foldedSourceMessages.push(toolSource);

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -44,6 +44,7 @@ import {
   getProviderToolCallPartDescriptor,
   getProviderToolResultPartDescriptor,
   hasStructurallyValidAnthropicWebSearchResultContent,
+  isExecutableCodePart,
 } from './toolResultTypes';
 import {
   hasBijectiveProviderContentPartMapping,
@@ -3827,6 +3828,8 @@ function appendMessageContent(
     const blockTypeValue = readFoldedDataProperty(block, 'type');
     const blockType =
       typeof blockTypeValue === 'string' ? blockTypeValue : undefined;
+    const blockRole =
+      getProviderToolResultPartDescriptor(block) != null ? 'Tool' : role;
 
     if (
       blockType !== 'tool_use' &&
@@ -3838,7 +3841,7 @@ function appendMessageContent(
         const blockChars = getToolContentCharLength([block]);
         if (blockChars > budget.remainingChars) {
           appendFoldedLine(textChunks, budget, [
-            `${role}: [${blockType ?? 'media'} omitted: folded context limit]`,
+            `${blockRole}: [${blockType ?? 'media'} omitted: folded context limit]`,
           ]);
           markBlockRetained();
           continue;
@@ -3848,7 +3851,7 @@ function appendMessageContent(
         budget.remainingChars -= blockChars;
       } else {
         appendFoldedLine(textChunks, budget, [
-          `${role}: [${blockType ?? 'media'}] `,
+          `${blockRole}: [${blockType ?? 'media'}] `,
           serializeFoldedValue(block),
         ]);
       }
@@ -3915,7 +3918,7 @@ function appendMessageContent(
       if (typeof inner === 'string') {
         if (inner) {
           appendFoldedLine(textChunks, budget, [
-            `${role}: [tool_result] `,
+            'Tool: [tool_result] ',
             inner,
           ]);
         }
@@ -3929,7 +3932,7 @@ function appendMessageContent(
           if (typeof innerBlock === 'string') {
             if (innerBlock) {
               appendFoldedLine(textChunks, budget, [
-                `${role}: [tool_result] `,
+                'Tool: [tool_result] ',
                 innerBlock,
               ]);
             }
@@ -3948,7 +3951,7 @@ function appendMessageContent(
                 budget.remainingChars -= blockChars;
               } else {
                 appendFoldedLine(textChunks, budget, [
-                  `${role}: [${innerType ?? 'media'} omitted: folded context limit]`,
+                  `Tool: [${innerType ?? 'media'} omitted: folded context limit]`,
                 ]);
               }
             } else {
@@ -3956,7 +3959,7 @@ function appendMessageContent(
               const inputValue = readFoldedDataProperty(innerBlock, 'input');
               const innerText = textValue ?? inputValue;
               appendFoldedLine(textChunks, budget, [
-                `${role}: [tool_result] `,
+                'Tool: [tool_result] ',
                 typeof innerText === 'string' && innerText
                   ? innerText
                   : serializeFoldedValue(innerBlock),
@@ -3966,7 +3969,7 @@ function appendMessageContent(
         }
       } else if (inner != null) {
         appendFoldedLine(textChunks, budget, [
-          `${role}: [tool_result] `,
+          'Tool: [tool_result] ',
           serializeFoldedValue(inner),
         ]);
       }
@@ -3986,7 +3989,7 @@ function appendMessageContent(
     // Fallback: serialize unrecognized block types to preserve context
     if (blockType != null && blockType !== '') {
       appendFoldedLine(textChunks, budget, [
-        `${role}: [${blockType}] `,
+        `${blockRole}: [${blockType}] `,
         serializeFoldedValue(block),
       ]);
     }
@@ -4317,6 +4320,7 @@ function messageHasToolContent(msg: BaseMessage): boolean {
         typeof block === 'object' &&
         (getProviderToolCallPartDescriptor(block) != null ||
           getProviderToolResultPartDescriptor(block) != null ||
+          isExecutableCodePart(block) ||
           readFoldedDataProperty(block, 'tool_call') != null)
       ) {
         return true;
@@ -4343,6 +4347,20 @@ function isToolResultMessage(msg: BaseMessage): boolean {
     );
   }
   return false;
+}
+
+function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' {
+  if (isToolMessage(msg)) {
+    return 'Tool';
+  }
+  if (
+    msg instanceof AIMessage ||
+    msg instanceof AIMessageChunk ||
+    ('role' in msg && msg.role === 'assistant')
+  ) {
+    return 'AI';
+  }
+  return isToolResultMessage(msg) ? 'Tool' : 'AI';
 }
 
 /**
@@ -4393,7 +4411,7 @@ export function foldToolBlocksForToollessAgent(
     appendFoldedLine(textChunks, foldBudget, ['[Previous tool interaction]']);
     const initialSource = appendMessageContent(
       msg,
-      isToolResultMessage(msg) ? 'Tool' : 'AI',
+      getFoldedMessageRole(msg),
       textChunks,
       parts,
       foldBudget
@@ -4407,7 +4425,7 @@ export function foldToolBlocksForToollessAgent(
     while (j < messages.length && isToolResultMessage(messages[j])) {
       const toolSource = appendMessageContent(
         messages[j],
-        'Tool',
+        getFoldedMessageRole(messages[j]),
         textChunks,
         parts,
         foldBudget

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -44,7 +44,8 @@ import {
   getProviderToolCallPartDescriptor,
   getProviderToolResultPartDescriptor,
   hasStructurallyValidAnthropicWebSearchResultContent,
-  isExecutableCodePart,
+  isProviderToolCallContentPart,
+  isProviderToolContentPart,
 } from './toolResultTypes';
 import {
   hasBijectiveProviderContentPartMapping,
@@ -3830,6 +3831,7 @@ function appendMessageContent(
       typeof blockTypeValue === 'string' ? blockTypeValue : undefined;
     const blockRole =
       getProviderToolResultPartDescriptor(block) != null ? 'Tool' : role;
+    hasToolUseBlock ||= isProviderToolCallContentPart(block);
 
     if (
       blockType !== 'tool_use' &&
@@ -4302,7 +4304,10 @@ export function ensureThinkingBlockInMessages(
  *  `toolUse` / `toolResult`). Missing the parent AI message is not just a
  *  passthrough: folding its ToolMessage alone would leave an orphan
  *  `assistant(tool_calls) -> user(...)` sequence. */
-function messageHasToolContent(msg: BaseMessage): boolean {
+function messageHasToolContent(
+  msg: BaseMessage,
+  provider?: ProviderName
+): boolean {
   if (isToolMessage(msg)) {
     return true;
   }
@@ -4315,16 +4320,26 @@ function messageHasToolContent(msg: BaseMessage): boolean {
     return true;
   }
   if (Array.isArray(msg.content)) {
+    let hasOpenAINativeServerContent = false;
     for (const block of msg.content as ExtendedMessageContent[]) {
+      const type = readFoldedDataProperty(block, 'type');
+      const isNativeOpenAIServerContent =
+        provider === Providers.OPENAI &&
+        (type === 'server_tool_call' ||
+          type === 'server_tool_call_result' ||
+          type === 'server_tool_result');
+      hasOpenAINativeServerContent ||= isNativeOpenAIServerContent;
       if (
         typeof block === 'object' &&
-        (getProviderToolCallPartDescriptor(block) != null ||
-          getProviderToolResultPartDescriptor(block) != null ||
-          isExecutableCodePart(block) ||
+        !isNativeOpenAIServerContent &&
+        (isProviderToolContentPart(block) ||
           readFoldedDataProperty(block, 'tool_call') != null)
       ) {
         return true;
       }
+    }
+    if (hasOpenAINativeServerContent) {
+      return false;
     }
   }
   return false;
@@ -4386,7 +4401,8 @@ function getFoldedMessageRole(msg: BaseMessage): 'AI' | 'Tool' {
  */
 export function foldToolBlocksForToollessAgent(
   messages: BaseMessage[],
-  config?: RunnableConfig
+  config?: RunnableConfig,
+  provider?: ProviderName
 ): BaseMessage[] {
   let result: BaseMessage[] | null = null;
   let foldedCount = 0;
@@ -4394,7 +4410,7 @@ export function foldToolBlocksForToollessAgent(
   let i = 0;
   while (i < messages.length) {
     const msg = messages[i];
-    if (!messageHasToolContent(msg)) {
+    if (!messageHasToolContent(msg, provider)) {
       result?.push(msg);
       i++;
       continue;

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -3763,11 +3763,17 @@ function flushTextChunks(
 }
 
 const OPENAI_RESPONSES_SERVER_TOOL_TYPES: ReadonlySet<string> = new Set([
+  'apply_patch_call_output',
   'code_interpreter_call',
   'computer_call',
   'file_search_call',
   'image_generation_call',
+  'local_shell_call_output',
   'mcp_call',
+  'mcp_list_tools',
+  'program_output',
+  'shell_call_output',
+  'tool_search_output',
   'web_search_call',
 ]);
 
@@ -4045,14 +4051,17 @@ function appendMessageContent(
     markBlockRetained();
   }
 
+  let responsesOutputContributed = false;
   if (!hasToolUseBlock) {
     const responsesOutput = getAuthoritativeResponsesToolOutput(msg);
     if (responsesOutput != null) {
+      const remainingCharsBefore = budget.remainingChars;
       appendFoldedLine(textChunks, budget, [
         'AI: [server_tool_output] ',
         serializeFoldedValue(responsesOutput),
       ]);
-      hasToolUseBlock = true;
+      responsesOutputContributed =
+        budget.remainingChars < remainingCharsBefore;
     }
   }
 
@@ -4061,10 +4070,12 @@ function appendMessageContent(
   const toolCalls = !hasToolUseBlock
     ? appendToolCalls(msg, role, textChunks, budget)
     : { contributed: false, complete: true };
-  if (toolCalls.contributed) {
+  if (toolCalls.contributed || responsesOutputContributed) {
     return {
       message: msg,
-      ...(!toolCalls.complete && { mappingAmbiguous: true }),
+      ...((responsesOutputContributed || !toolCalls.complete) && {
+        mappingAmbiguous: true,
+      }),
     };
   }
   return retainedContentPartIndices.size > 0

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -4313,10 +4313,11 @@ function messageHasToolContent(msg: BaseMessage): boolean {
   }
   if (Array.isArray(msg.content)) {
     for (const block of msg.content as ExtendedMessageContent[]) {
-      const type = readFoldedDataProperty(block, 'type');
       if (
         typeof block === 'object' &&
-        (type === 'tool_use' || type === 'tool_call' || type === 'tool_result')
+        (getProviderToolCallPartDescriptor(block) != null ||
+          getProviderToolResultPartDescriptor(block) != null ||
+          readFoldedDataProperty(block, 'tool_call') != null)
       ) {
         return true;
       }
@@ -4338,7 +4339,7 @@ function isToolResultMessage(msg: BaseMessage): boolean {
     return (msg.content as ExtendedMessageContent[]).some(
       (block) =>
         typeof block === 'object' &&
-        readFoldedDataProperty(block, 'type') === 'tool_result'
+        getProviderToolResultPartDescriptor(block) != null
     );
   }
   return false;

--- a/src/messages/toolHistoryProjection.test.ts
+++ b/src/messages/toolHistoryProjection.test.ts
@@ -1,0 +1,209 @@
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { ToolHistoryCallMirrors } from './toolHistoryProjection';
+import {
+  getResponsesHistorySource,
+  projectResponsesHistory,
+  createToolHistoryPreparation,
+  recordToolHistoryCallMirror,
+  isToolHistoryCallMirror,
+} from './toolHistoryProjection';
+
+describe('Ordered Tool History Projection', () => {
+  test('keeps source precedence and does not mutate provider evidence', () => {
+    const output = [
+      { type: 'message', content: [{ type: 'output_text', text: 'answer' }] },
+    ];
+    const message = new AIMessage({
+      content: 'answer',
+      response_metadata: { output },
+      additional_kwargs: {
+        tool_outputs: [{ type: 'mcp_call', output: 'stale' }],
+      },
+    });
+    const source = getResponsesHistorySource(message)!;
+    expect(source.coverage).toBe('complete-output');
+    expect(source.items).toBe(output);
+    expect([...projectResponsesHistory(source, () => true)]).toEqual([
+      {
+        outputIndex: 0,
+        contentIndex: 0,
+        kind: 'text',
+        actor: 'model',
+        text: 'answer',
+      },
+    ]);
+    expect(message.content).toBe('answer');
+  });
+
+  test('retains actor, call identity, and event order', () => {
+    const source = getResponsesHistorySource(
+      new AIMessage({
+        content: 'beforeafter',
+        response_metadata: {
+          output: [
+            {
+              type: 'message',
+              content: [{ type: 'output_text', text: 'before' }],
+            },
+            {
+              type: 'custom_tool_call',
+              id: 'item',
+              call_id: 'call',
+              name: 'execute',
+              input: 'code',
+            },
+            { type: 'mcp_call', output: 'result' },
+            {
+              type: 'message',
+              content: [{ type: 'refusal', refusal: 'after' }],
+            },
+          ],
+        },
+      })
+    )!;
+    const contributions = [...projectResponsesHistory(source, () => true)];
+    expect(
+      contributions.map((entry) => [entry.kind, entry.actor, entry.outputIndex])
+    ).toEqual([
+      ['text', 'model', 0],
+      ['call', 'model', 1],
+      ['provider-item', 'tool', 2],
+      ['text', 'model', 3],
+    ]);
+    expect(contributions[1]).toMatchObject({
+      itemId: 'item',
+      callId: 'call',
+      name: 'execute',
+      arguments: 'code',
+    });
+  });
+
+  test('preserves completed JPEG media and excludes incomplete image fragments', () => {
+    const source = getResponsesHistorySource(
+      new AIMessage({
+        content: [],
+        additional_kwargs: {
+          tool_outputs: [
+            {
+              type: 'image_generation_call',
+              status: 'in_progress',
+              result: 'partial',
+            },
+            {
+              type: 'image_generation_call',
+              status: 'completed',
+              result: '/9j/AA==',
+            },
+          ],
+        },
+      })
+    )!;
+    expect(source.coverage).toBe('tool-sidecar');
+    const contributions = [...projectResponsesHistory(source, () => true)];
+    expect(
+      contributions.filter((entry) => entry.kind === 'image')
+    ).toHaveLength(1);
+    expect(contributions[1]).toMatchObject({
+      kind: 'image',
+      actor: 'tool',
+      image: { mimeType: 'image/jpeg', data: '/9j/AA==' },
+    });
+    expect(JSON.stringify(contributions)).not.toContain('partial');
+  });
+
+  test('stops nested traversal at the shared work limit', () => {
+    const source = getResponsesHistorySource(
+      new AIMessage({
+        content: [],
+        response_metadata: {
+          output: [
+            {
+              type: 'message',
+              content: [
+                { type: 'output_text', text: 'first' },
+                { type: 'output_text', text: 'second' },
+              ],
+            },
+          ],
+        },
+      })
+    )!;
+    let remaining = 2;
+    expect([...projectResponsesHistory(source, () => remaining-- > 0)]).toEqual(
+      [
+        {
+          outputIndex: 0,
+          contentIndex: 0,
+          kind: 'text',
+          actor: 'model',
+          text: 'first',
+        },
+      ]
+    );
+  });
+
+  test('reuses one projection per preparation while plain text has no projection', () => {
+    const preparation = createToolHistoryPreparation();
+    expect(preparation.get(new HumanMessage('plain text'))).toBeUndefined();
+    const message = new AIMessage({
+      content: [],
+      response_metadata: {
+        output: [{ type: 'mcp_call', output: 'evidence' }],
+      },
+    });
+    const first = preparation.get(message);
+    expect(preparation.get(message)).toBe(first);
+    expect(createToolHistoryPreparation().get(message)).not.toBe(first);
+  });
+
+  test('restores text and sidecar ordering from recorded streaming positions', () => {
+    const message = new AIMessage({
+      content: [
+        { type: 'text', text: 'before' },
+        { type: 'text', text: 'after' },
+      ],
+      additional_kwargs: {
+        tool_outputs: [{ type: 'mcp_call', id: 'tool', output: 'result' }],
+        __openai_responses_replay_positions__: [
+          { kind: 'text', itemId: 'm1', outputIndex: 0, contentIndex: 0 },
+          { kind: 'output', itemId: 'tool', outputIndex: 1 },
+          { kind: 'text', itemId: 'm2', outputIndex: 2, contentIndex: 0 },
+        ],
+      },
+    });
+    const projection = createToolHistoryPreparation().get(message)!;
+    expect(projection.contributions.map((entry) => entry.kind)).toEqual([
+      'text',
+      'provider-item',
+      'text',
+    ]);
+    expect(projection.contributions.map((entry) => entry.outputIndex)).toEqual([
+      0, 1, 2,
+    ]);
+  });
+
+  test('does not suppress calls whose IDs match but arguments differ', () => {
+    const mirrors: ToolHistoryCallMirrors = new Map();
+    recordToolHistoryCallMirror(mirrors, {
+      type: 'tool_use',
+      id: 'call',
+      name: 'lookup',
+      input: { query: 'a' },
+    });
+    expect(
+      isToolHistoryCallMirror(mirrors, 'call', 'lookup', { query: 'a' })
+    ).toBe(true);
+    expect(
+      isToolHistoryCallMirror(mirrors, 'call', 'lookup', { query: 'b' })
+    ).toBe(false);
+    recordToolHistoryCallMirror(mirrors, {
+      type: 'tool_use',
+      id: 'call',
+      name: 'lookup',
+      input: { query: 'a' },
+    });
+    expect(
+      isToolHistoryCallMirror(mirrors, 'call', 'lookup', { query: 'a' })
+    ).toBe(false);
+  });
+});

--- a/src/messages/toolHistoryProjection.test.ts
+++ b/src/messages/toolHistoryProjection.test.ts
@@ -9,6 +9,28 @@ import {
 } from './toolHistoryProjection';
 
 describe('Ordered Tool History Projection', () => {
+  test('projects computer actions as model-authored calls', () => {
+    const action = { type: 'click', x: 10, y: 20 };
+    const message = new AIMessage({
+      content: '',
+      response_metadata: {
+        output: [
+          { type: 'computer_call', id: 'item', call_id: 'call', action },
+        ],
+      },
+    });
+    expect(createToolHistoryPreparation().get(message)?.contributions).toEqual([
+      {
+        kind: 'call',
+        actor: 'model',
+        name: 'computer',
+        callId: 'call',
+        itemId: 'item',
+        outputIndex: 0,
+        arguments: action,
+      },
+    ]);
+  });
   test('keeps source precedence and does not mutate provider evidence', () => {
     const output = [
       { type: 'message', content: [{ type: 'output_text', text: 'answer' }] },

--- a/src/messages/toolHistoryProjection.ts
+++ b/src/messages/toolHistoryProjection.ts
@@ -169,7 +169,7 @@ export type ResponsesHistoryContribution = ToolHistoryPosition &
         readonly actor: 'model';
         readonly name: string;
         readonly callId?: string;
-        readonly arguments: string;
+        readonly arguments: unknown;
       }
     | {
         readonly kind: 'image';
@@ -286,6 +286,18 @@ function* projectResponsesItems(
           };
         }
       }
+      continue;
+    }
+    if (type === 'computer_call') {
+      const callId = readData(item, 'call_id');
+      yield {
+        ...position,
+        kind: 'call',
+        actor: 'model',
+        name: 'computer',
+        arguments: readData(item, 'action'),
+        ...(typeof callId === 'string' && { callId }),
+      };
       continue;
     }
     if (type === 'function_call' || type === 'custom_tool_call') {

--- a/src/messages/toolHistoryProjection.ts
+++ b/src/messages/toolHistoryProjection.ts
@@ -1,0 +1,448 @@
+import { isProxy } from 'node:util/types';
+import type { BaseMessage, ContentBlock } from '@langchain/core/messages';
+import { getProviderToolCallPartDescriptor } from './toolResultTypes';
+import { serializeStructuredValueBounded } from '@/utils/toolContent';
+
+interface ToolHistoryCallMirror {
+  readonly name?: string;
+  readonly arguments: string;
+}
+
+export type ToolHistoryCallMirrors = Map<string, ToolHistoryCallMirror | null>;
+
+/** Only complete argument representations can establish that a call is a mirror. */
+export function recordToolHistoryCallMirror(
+  mirrors: ToolHistoryCallMirrors,
+  block: unknown
+): void {
+  const descriptor = getProviderToolCallPartDescriptor(block);
+  if (descriptor == null) {
+    return;
+  }
+  if (mirrors.has(descriptor.callId)) {
+    mirrors.set(descriptor.callId, null);
+    return;
+  }
+  const call =
+    readData(block, 'tool_call') ??
+    readData(block, 'toolUse') ??
+    readData(block, 'toolCall') ??
+    block;
+  const args = readData(call, 'args') ?? readData(call, 'input');
+  const serialized = serializeStructuredValueBounded(args, 8000);
+  mirrors.set(
+    descriptor.callId,
+    serialized.truncated
+      ? null
+      : {
+        name: descriptor.name,
+        arguments: serialized.content,
+      }
+  );
+}
+
+export function isToolHistoryCallMirror(
+  mirrors: ToolHistoryCallMirrors | undefined,
+  id: unknown,
+  name: unknown,
+  args: unknown
+): boolean {
+  if (typeof id !== 'string') {
+    return false;
+  }
+  const mirror = mirrors?.get(id);
+  if (mirror == null || mirror.name !== name) {
+    return false;
+  }
+  const serialized = serializeStructuredValueBounded(args, 8000);
+  return !serialized.truncated && serialized.content === mirror.arguments;
+}
+
+export const OPENAI_RESPONSES_REPLAY_POSITIONS_KEY =
+  '__openai_responses_replay_positions__';
+
+export type ResponsesReplayPosition = {
+  contentIndex?: number;
+  itemId: string;
+  kind: 'message' | 'output' | 'reasoning' | 'text';
+  outputIndex: number;
+};
+
+export function isResponsesReplayPosition(
+  value: unknown
+): value is ResponsesReplayPosition {
+  const kind = readData(value, 'kind');
+  const itemId = readData(value, 'itemId');
+  const outputIndex = readData(value, 'outputIndex');
+  const contentIndex = readData(value, 'contentIndex');
+  return (
+    (kind === 'message' ||
+      kind === 'output' ||
+      kind === 'reasoning' ||
+      kind === 'text') &&
+    typeof itemId === 'string' &&
+    itemId.length > 0 &&
+    typeof outputIndex === 'number' &&
+    Number.isSafeInteger(outputIndex) &&
+    outputIndex >= 0 &&
+    (contentIndex == null ||
+      (typeof contentIndex === 'number' &&
+        Number.isSafeInteger(contentIndex) &&
+        contentIndex >= 0))
+  );
+}
+
+/** Provider evidence is selected once; a sidecar never replaces message content. */
+export interface ResponsesHistorySource {
+  readonly coverage: 'complete-output' | 'tool-sidecar';
+  readonly items: unknown[];
+  readonly message?: BaseMessage;
+}
+
+export interface OrderedToolHistoryProjection {
+  readonly source: ResponsesHistorySource;
+  readonly contributions: readonly ResponsesHistoryContribution[];
+  readonly hasToolContent: boolean;
+  readonly truncated: boolean;
+}
+
+export interface ToolHistoryPreparation {
+  get(message: BaseMessage): OrderedToolHistoryProjection | undefined;
+}
+
+/** A preparation owns this cache; changed messages must be copy-on-write. */
+export function createToolHistoryPreparation(): ToolHistoryPreparation {
+  const projections = new WeakMap<BaseMessage, OrderedToolHistoryProjection>();
+  let remainingWork = 100_000;
+  return {
+    get(message): OrderedToolHistoryProjection | undefined {
+      const cached = projections.get(message);
+      if (cached != null) {
+        return cached;
+      }
+      const source = getResponsesHistorySource(message);
+      if (source == null || source.items.length === 0) {
+        return undefined;
+      }
+      const contributions: ResponsesHistoryContribution[] = [];
+      let hasToolContent = false;
+      let truncated = false;
+      for (const contribution of projectResponsesHistory(source, () => {
+        if (remainingWork <= 0) {
+          truncated = true;
+          return false;
+        }
+        remainingWork--;
+        return true;
+      })) {
+        contributions.push(contribution);
+        hasToolContent ||=
+          contribution.kind !== 'text' &&
+          !(
+            contribution.kind === 'provider-item' &&
+            contribution.providerType === 'reasoning'
+          );
+      }
+      const projection = {
+        source,
+        contributions,
+        hasToolContent: hasToolContent || truncated,
+        truncated,
+      };
+      projections.set(message, projection);
+      return projection;
+    },
+  };
+}
+
+export interface ToolHistoryPosition {
+  readonly outputIndex: number;
+  readonly contentIndex?: number;
+  readonly itemId?: string;
+}
+
+export type ResponsesHistoryContribution = ToolHistoryPosition &
+  (
+    | { readonly kind: 'text'; readonly actor: 'model'; readonly text: string }
+    | {
+        readonly kind: 'call';
+        readonly actor: 'model';
+        readonly name: string;
+        readonly callId?: string;
+        readonly arguments: string;
+      }
+    | {
+        readonly kind: 'image';
+        readonly actor: 'tool';
+        readonly image: ContentBlock.Multimodal.Image;
+      }
+    | {
+        readonly kind: 'provider-item';
+        readonly actor: 'model' | 'tool';
+        readonly providerType: string;
+        readonly value: unknown;
+      }
+  );
+
+function readData(value: unknown, key: string): unknown {
+  if (value == null || typeof value !== 'object' || isProxy(value)) {
+    return undefined;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(value, key);
+  return descriptor != null && 'value' in descriptor
+    ? descriptor.value
+    : undefined;
+}
+
+function readArray(value: unknown): unknown[] | undefined {
+  return Array.isArray(value) && !isProxy(value) ? value : undefined;
+}
+
+export function getResponsesHistorySource(
+  message: BaseMessage
+): ResponsesHistorySource | undefined {
+  const output = readArray(readData(message.response_metadata, 'output'));
+  if (output != null && output.length > 0) {
+    return { coverage: 'complete-output', items: output, message };
+  }
+  const sidecar = readArray(
+    readData(message.additional_kwargs, 'tool_outputs')
+  );
+  return sidecar != null
+    ? { coverage: 'tool-sidecar', items: sidecar, message }
+    : undefined;
+}
+
+/** Complete generated images retain their actual format across replay and folding. */
+export function getGeneratedImageMimeType(data: string): string {
+  const bytes = Buffer.from(data.slice(0, 16), 'base64');
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    bytes[0] === 0x52 &&
+    bytes[1] === 0x49 &&
+    bytes[2] === 0x46 &&
+    bytes[3] === 0x46 &&
+    bytes[8] === 0x57 &&
+    bytes[9] === 0x45 &&
+    bytes[10] === 0x42 &&
+    bytes[11] === 0x50
+  ) {
+    return 'image/webp';
+  }
+  return 'image/png';
+}
+
+/**
+ * Lazy traversal bounds outer items and nested content together. The caller's
+ * shared work allowance also spans subsequent messages. False stops before the
+ * next provider value is inspected; payload serialization remains consumer policy.
+ */
+function* projectResponsesItems(
+  source: ResponsesHistorySource,
+  consumeWork: () => boolean
+): Generator<ResponsesHistoryContribution> {
+  for (let outputIndex = 0; outputIndex < source.items.length; outputIndex++) {
+    if (!consumeWork()) {
+      return;
+    }
+    const item = readData(source.items, String(outputIndex));
+    const type = readData(item, 'type');
+    if (typeof type !== 'string') {
+      continue;
+    }
+    const id = readData(item, 'id');
+    const position: ToolHistoryPosition = {
+      outputIndex,
+      ...(typeof id === 'string' && { itemId: id }),
+    };
+    if (type === 'message') {
+      const content = readArray(readData(item, 'content'));
+      if (content == null) {
+        continue;
+      }
+      for (
+        let contentIndex = 0;
+        contentIndex < content.length;
+        contentIndex++
+      ) {
+        if (!consumeWork()) {
+          return;
+        }
+        const part = readData(content, String(contentIndex));
+        const partType = readData(part, 'type');
+        const text = readData(
+          part,
+          partType === 'refusal' ? 'refusal' : 'text'
+        );
+        if (typeof text === 'string' && text.length > 0) {
+          yield {
+            ...position,
+            contentIndex,
+            kind: 'text',
+            actor: 'model',
+            text,
+          };
+        }
+      }
+      continue;
+    }
+    if (type === 'function_call' || type === 'custom_tool_call') {
+      const name = readData(item, 'name');
+      const args = readData(
+        item,
+        type === 'custom_tool_call' ? 'input' : 'arguments'
+      );
+      const callId = readData(item, 'call_id');
+      yield {
+        ...position,
+        kind: 'call',
+        actor: 'model',
+        name: typeof name === 'string' ? name : '',
+        arguments: typeof args === 'string' ? args : '',
+        ...(typeof callId === 'string' && { callId }),
+      };
+      continue;
+    }
+    if (type === 'image_generation_call') {
+      const data = readData(item, 'result');
+      if (
+        readData(item, 'status') === 'completed' &&
+        typeof data === 'string' &&
+        data
+      ) {
+        yield {
+          ...position,
+          kind: 'image',
+          actor: 'tool',
+          image: {
+            type: 'image',
+            mimeType: getGeneratedImageMimeType(data),
+            data,
+            ...(typeof id === 'string' && { id }),
+            metadata: { status: 'completed' },
+          },
+        };
+      }
+      if (
+        readData(item, 'status') !== 'completed' ||
+        typeof data !== 'string' ||
+        !data
+      ) {
+        yield {
+          ...position,
+          kind: 'provider-item',
+          actor: 'tool',
+          providerType: type,
+          value: {
+            type,
+            status: readData(item, 'status'),
+            result: '[image unavailable]',
+          },
+        };
+      }
+      continue;
+    }
+    yield {
+      ...position,
+      kind: 'provider-item',
+      actor:
+        type === 'reasoning' || type === 'mcp_approval_request'
+          ? 'model'
+          : 'tool',
+      providerType: type,
+      value: item,
+    };
+  }
+}
+
+/** Streaming positions order sidecar evidence only when text positions map exactly. */
+export function* projectResponsesHistory(
+  source: ResponsesHistorySource,
+  consumeWork: () => boolean
+): Generator<ResponsesHistoryContribution> {
+  if (source.coverage === 'complete-output' || source.message == null) {
+    yield* projectResponsesItems(source, consumeWork);
+    return;
+  }
+  const positions = readArray(
+    readData(
+      source.message.additional_kwargs,
+      OPENAI_RESPONSES_REPLAY_POSITIONS_KEY
+    )
+  );
+  const outputPositions = new Map<string, number>();
+  const textPositions: ResponsesReplayPosition[] = [];
+  const seenPositions = new Set<string>();
+  for (let index = 0; positions != null && index < positions.length; index++) {
+    if (!consumeWork()) {
+      return;
+    }
+    const position = readData(positions, String(index));
+    if (!isResponsesReplayPosition(position)) {
+      continue;
+    }
+    if (position.kind === 'output') {
+      outputPositions.set(position.itemId, position.outputIndex);
+    } else if (position.kind === 'text') {
+      const key = `${position.itemId}:${position.outputIndex}:${position.contentIndex ?? 0}`;
+      if (!seenPositions.has(key)) {
+        seenPositions.add(key);
+        textPositions.push(position);
+      }
+    }
+  }
+  textPositions.sort(
+    (left, right) =>
+      left.outputIndex - right.outputIndex ||
+      (left.contentIndex ?? 0) - (right.contentIndex ?? 0)
+  );
+  const text: string[] = [];
+  const content = source.message.content;
+  if (typeof content === 'string' && content) {
+    text.push(content);
+  } else if (Array.isArray(content)) {
+    for (let index = 0; index < content.length; index++) {
+      if (!consumeWork()) {
+        return;
+      }
+      const block = readData(content, String(index));
+      const value = readData(block, 'text');
+      if (typeof value === 'string' && value) {
+        text.push(value);
+      }
+    }
+  }
+  const contributions: ResponsesHistoryContribution[] = [];
+  for (let index = 0; index < text.length; index++) {
+    const position =
+      text.length === textPositions.length ? textPositions[index] : undefined;
+    contributions.push({
+      kind: 'text',
+      actor: 'model',
+      text: text[index],
+      outputIndex: position?.outputIndex ?? -1,
+      contentIndex: position?.contentIndex ?? index,
+      ...(position != null && { itemId: position.itemId }),
+    });
+  }
+  for (const contribution of projectResponsesItems(source, consumeWork)) {
+    contributions.push({
+      ...contribution,
+      outputIndex:
+        contribution.itemId != null
+          ? (outputPositions.get(contribution.itemId) ??
+            Number.MAX_SAFE_INTEGER)
+          : Number.MAX_SAFE_INTEGER,
+    });
+  }
+  contributions.sort(
+    (left, right) =>
+      left.outputIndex - right.outputIndex ||
+      (left.contentIndex ?? 0) - (right.contentIndex ?? 0)
+  );
+  for (const contribution of contributions) {
+    yield contribution;
+  }
+}

--- a/src/messages/toolResultTypes.test.ts
+++ b/src/messages/toolResultTypes.test.ts
@@ -599,6 +599,17 @@ describe('provider tool-result pairing index', () => {
     expect(consumeProviderToolResultPair(result(), calls)).toBe(false);
   });
 
+  it('deduplicates three equivalent wire representations and consumes once', () => {
+    const calls: ProviderToolCallIndex = new Map();
+    appendProviderToolCallDescriptor(calls, call('ai_tool_calls'));
+    appendProviderToolCallDescriptor(calls, call('raw_tool_calls'));
+    appendProviderToolCallDescriptor(calls, call('tool_call'));
+
+    expect(calls.get('call-id')).not.toBeNull();
+    expect(consumeProviderToolResultPair(result(), calls)).toBe(true);
+    expect(consumeProviderToolResultPair(result(), calls)).toBe(false);
+  });
+
   it('marks same-representation duplicates and conflicts ambiguous', () => {
     const duplicateCalls: ProviderToolCallIndex = new Map();
     appendProviderToolCallDescriptor(duplicateCalls, call('tool_call'));

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -33,7 +33,7 @@ export interface ProviderToolResultPartDescriptor {
 
 export interface ProviderToolCallIndexEntry {
   readonly descriptor: ProviderToolCallPartDescriptor;
-  secondarySourceType?: string;
+  secondarySourceTypes?: Set<string>;
 }
 
 export type ProviderToolCallIndex = Map<
@@ -753,6 +753,33 @@ export function getProviderToolResultPartDescriptor(
   return undefined;
 }
 
+const PROVIDER_TOOL_CALL_CONTENT_TYPES: ReadonlySet<string> = new Set([
+  'tool_call',
+  'tool_use',
+  'server_tool_use',
+  'mcp_tool_use',
+  'server_tool_call',
+  'toolCall',
+  'toolUse',
+  'executableCode',
+]);
+
+export function isProviderToolCallContentPart(part: unknown): boolean {
+  const record = getRecord(part);
+  const type = record == null ? undefined : readString(record, 'type');
+  return type != null && PROVIDER_TOOL_CALL_CONTENT_TYPES.has(type);
+}
+
+export function isProviderToolContentPart(part: unknown): boolean {
+  const record = getRecord(part);
+  const type = record == null ? undefined : readString(record, 'type');
+  return (
+    type != null &&
+    (PROVIDER_TOOL_CALL_CONTENT_TYPES.has(type) ||
+      TOOL_RESULT_ENVELOPE_FIELDS[type] != null)
+  );
+}
+
 function optionalName(
   record: Record<string, unknown>
 ): { readonly name?: string } | undefined {
@@ -1071,17 +1098,16 @@ export function appendProviderToolCallDescriptor(
   if (existing === null) {
     return;
   }
-  const isDualRepresentation =
-    existing.secondarySourceType == null &&
-    existing.descriptor.sourceType !== descriptor.sourceType &&
-    (existing.descriptor.sourceType === 'ai_tool_calls' ||
-      descriptor.sourceType === 'ai_tool_calls');
-  if (
+  const sourceTypes =
+    existing.secondarySourceTypes ??
+    new Set<string>([existing.descriptor.sourceType]);
+  const isEquivalentRepresentation =
     existing.descriptor.kind === descriptor.kind &&
     existing.descriptor.name === descriptor.name &&
-    isDualRepresentation
-  ) {
-    existing.secondarySourceType = descriptor.sourceType;
+    !sourceTypes.has(descriptor.sourceType);
+  if (isEquivalentRepresentation) {
+    sourceTypes.add(descriptor.sourceType);
+    existing.secondarySourceTypes = sourceTypes;
     return;
   }
   index.set(descriptor.callId, null);

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -776,7 +776,7 @@ export function isProviderToolContentPart(part: unknown): boolean {
   return (
     type != null &&
     (PROVIDER_TOOL_CALL_CONTENT_TYPES.has(type) ||
-      TOOL_RESULT_ENVELOPE_FIELDS[type] != null)
+      Object.prototype.hasOwnProperty.call(TOOL_RESULT_ENVELOPE_FIELDS, type))
   );
 }
 

--- a/src/messages/toolResultTypes.ts
+++ b/src/messages/toolResultTypes.ts
@@ -1,6 +1,5 @@
 import { isProxy } from 'node:util/types';
 import type {
-  AIMessage,
   BaseMessage,
   ChatMessage,
   ToolMessage,
@@ -1291,11 +1290,19 @@ export function appendProviderMessageToolCalls(
     return 0;
   }
   let recognized = 0;
-  for (const toolCall of (message as AIMessage).tool_calls ?? []) {
-    const descriptor = getProviderAIMessageToolCallDescriptor(toolCall);
-    if (descriptor != null) {
-      appendProviderToolCallDescriptor(calls, descriptor);
-      recognized += 1;
+  const toolCalls = getBoundedProviderPairingArrayProperty(
+    message,
+    'tool_calls'
+  );
+  if (toolCalls != null) {
+    for (let index = 0; index < toolCalls.length; index++) {
+      const descriptor = getProviderAIMessageToolCallDescriptor(
+        toolCalls[index]
+      );
+      if (descriptor != null) {
+        appendProviderToolCallDescriptor(calls, descriptor);
+        recognized += 1;
+      }
     }
   }
 
@@ -1304,8 +1311,8 @@ export function appendProviderMessageToolCalls(
     'tool_calls'
   );
   if (rawToolCalls != null) {
-    for (const toolCall of rawToolCalls) {
-      const descriptor = getRawToolCallDescriptor(toolCall);
+    for (let index = 0; index < rawToolCalls.length; index++) {
+      const descriptor = getRawToolCallDescriptor(rawToolCalls[index]);
       if (descriptor != null) {
         appendProviderToolCallDescriptor(calls, descriptor);
         recognized += 1;

--- a/src/scripts/bench-tool-history-projection.ts
+++ b/src/scripts/bench-tool-history-projection.ts
@@ -1,0 +1,111 @@
+/* eslint-disable no-console */
+import { performance } from 'node:perf_hooks';
+import { AIMessage, HumanMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
+import { projectToolStreamContentForProvider } from '@/messages/core';
+import { foldToolBlocksForToollessAgent } from '@/messages/format';
+
+const iterations = 100;
+const samples = 5;
+
+function prepare(messages: BaseMessage[], shared: boolean): number {
+  const history = createToolHistoryPreparation();
+  const folded = foldToolBlocksForToollessAgent(
+    messages,
+    undefined,
+    false,
+    history
+  );
+  const replayed = projectToolStreamContentForProvider(
+    messages,
+    'native',
+    8000,
+    shared ? history : createToolHistoryPreparation()
+  );
+  return folded.length + replayed.length;
+}
+
+function measure(messages: BaseMessage[], shared: boolean): number {
+  const start = performance.now();
+  let checksum = 0;
+  for (let iteration = 0; iteration < iterations; iteration++) {
+    checksum += prepare(messages, shared);
+  }
+  if (checksum !== messages.length * iterations * 2) {
+    throw new Error('Unexpected projection output count');
+  }
+  return performance.now() - start;
+}
+
+function median(values: number[]): number {
+  return [...values].sort((left, right) => left - right)[
+    Math.floor(values.length / 2)
+  ];
+}
+
+const plain = Array.from(
+  { length: 500 },
+  (_, index) => new HumanMessage(`plain text ${index}`)
+);
+const tools = Array.from(
+  { length: 100 },
+  (_, index) =>
+    new AIMessage({
+      content: `Answer ${index}`,
+      response_metadata: {
+        model_provider: 'openai',
+        preempted: true,
+        output: [
+          {
+            type: 'code_interpreter_call',
+            id: `tool-${index}`,
+            status: 'completed',
+            outputs: [{ type: 'logs', logs: `result-${index}` }],
+          },
+          {
+            type: 'message',
+            id: `message-${index}`,
+            content: [{ type: 'output_text', text: `Answer ${index}` }],
+          },
+        ],
+      },
+    })
+);
+
+for (const scenario of [
+  { name: 'plain-500', messages: plain },
+  { name: 'tools-100', messages: tools },
+]) {
+  measure(scenario.messages, false);
+  measure(scenario.messages, true);
+  const separate: number[] = [];
+  const shared: number[] = [];
+  for (let sample = 0; sample < samples; sample++) {
+    if (sample % 2 === 0) {
+      separate.push(measure(scenario.messages, false));
+      shared.push(measure(scenario.messages, true));
+    } else {
+      shared.push(measure(scenario.messages, true));
+      separate.push(measure(scenario.messages, false));
+    }
+  }
+  const history = createToolHistoryPreparation();
+  let projections = 0;
+  for (const message of scenario.messages) {
+    if (history.get(message) != null) {
+      projections++;
+    }
+  }
+  console.log(
+    JSON.stringify({
+      scenario: scenario.name,
+      iterations,
+      separateMs: Number(median(separate).toFixed(2)),
+      sharedMs: Number(median(shared).toFixed(2)),
+      projections,
+      sourceArrayPreserved:
+        foldToolBlocksForToollessAgent(scenario.messages) === scenario.messages,
+    })
+  );
+}


### PR DESCRIPTION
## Summary

I consolidated tool-history interpretation for #526 and preserved tool evidence across tool-less handoffs and serving-provider fallback.

- Share a preparation-scoped Ordered Tool History Projection across folding and sealed Responses replay.
- Separate source ordering, coverage, identity, and media facts from the actual serving provider/model policy.
- Prepare every fallback from the pruned source before primary wire shaping, honoring explicit Chat-mode overrides over Responses defaults.
- Reuse serving-policy, artifact, cache, and synthetic-compaction helpers in primary and fallback paths.
- Preserve MCP approvals, completed generated images, mixed Gemini/client-tool calls, and original provenance through fallback folding.
- Bound nested traversal and serialized arguments, and suppress only proven equivalent call representations.
- Reuse the provider taxonomy for alternation pairing and document the architecture and benchmark.

This updates #527 directly; no stacked prerequisite or checkpoint-format change is required.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- Ran `npx tsc --noEmit` and ESLint on changed source/tests.
- Ran the final 17-suite projection, folding, request preparation, graph overflow, pruning, and tracing check: 601 passed, 1 skipped.
- Ran preemption seal/restart and pairing tests: 112 passed.
- Ran `npx tsx src/scripts/bench-tool-history-projection.ts`: plain-text histories allocate no projection objects and preserve array identity; shared tool-heavy preparation measured 1105 ms versus 1150 ms with separate caches per 100 preparations. See `docs/tool-history-projection.md` for scope and caveats.
- Added regressions exercising fallback folding before origin tracking and real graph failover in both directions, including a failed intermediate fallback; media and original source identity survive.
- Added fallback regressions for artifact text/media, legacy strings, Anthropic/OpenRouter/Bedrock cache markers, orphan cleanup, smaller-window compaction, and computer-call attribution.
- Completed two Codex review cycles and fixed every reported finding. The final follow-up is self-reviewed; no third cycle was requested.

### **Test Configuration**:

- Base: `origin/main` at `8fb7464c`.
- Local dependencies reused from the existing checkout; CI supplies the clean dependency installation.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] I have made pertinent documentation changes
- [x] I have written tests demonstrating that my changes are effective
- [x] Local unit tests pass with my changes
