### PR TITLE
🧠 refactor: Centralize Reasoning Block Classification

### DIFF
--- a/src/llm/anthropic/utils/message_inputs.ts
+++ b/src/llm/anthropic/utils/message_inputs.ts
@@ -39,6 +39,7 @@ import {
   serializeStructuredValueBounded,
 } from '@/utils/toolContent';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import { isReasoningContentBlock } from '@/messages/reasoningTypes';
 import { Constants } from '@/common';
 
 type StandardTextBlock = Data.StandardTextBlock;
@@ -656,7 +657,6 @@ function _formatContent(message: BaseMessage) {
    * cross-provider handoff (e.g. Bedrock → Anthropic) we drop them rather than
    * forwarding an unusable block. The receiving model produces its own thinking.
    */
-  const foreignReasoningTypes = ['reasoning_content', 'reasoning', 'think'];
   /**
    * Google server-side tool blocks (`toolCall`/`toolResponse` parts from e.g.
    * URL context or Google Search). Only Google can execute these and validate
@@ -1049,7 +1049,7 @@ function _formatContent(message: BaseMessage) {
         };
       } else if (
         isAIMessage(message) &&
-        foreignReasoningTypes.some((t) => t === contentPart.type)
+        isReasoningContentBlock(contentPart)
       ) {
         // Foreign reasoning on an ASSISTANT turn (Bedrock `reasoning_content`,
         // Google `reasoning`, LibreChat `think`) carries provider-specific
@@ -1240,12 +1240,6 @@ function messagesHaveCacheControl(
   );
 }
 
-/** Anthropic rejects cache_control on these reasoning blocks. */
-const NON_CACHEABLE_PAYLOAD_BLOCK_TYPES = new Set([
-  'thinking',
-  'redacted_thinking',
-]);
-
 /**
  * Place one ephemeral `cache_control` on the last cacheable block of the final
  * message of an already-converted Anthropic payload. Used to re-anchor the tail
@@ -1287,8 +1281,9 @@ function reanchorTailCacheControl(
 
   let anchor = -1;
   for (let i = 0; i < content.length; i++) {
-    const type = (content[i] as { type?: string }).type;
-    if (type == null || NON_CACHEABLE_PAYLOAD_BLOCK_TYPES.has(type)) {
+    const block = content[i] as { type?: string };
+    const type = block.type;
+    if (type == null || isReasoningContentBlock(block)) {
       continue;
     }
     if (

--- a/src/llm/bedrock/utils/message_inputs.ts
+++ b/src/llm/bedrock/utils/message_inputs.ts
@@ -30,6 +30,7 @@ import type {
 } from '../types';
 import { serializeStructuredValueBounded } from '@/utils/toolContent';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
+import { isReasoningContentBlock } from '@/messages/reasoningTypes';
 
 /**
  * Reasoning blocks from other providers, relative to Bedrock. Bedrock's native
@@ -37,13 +38,6 @@ import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
  * signatures Bedrock cannot validate, so they are dropped on a cross-provider
  * handoff (e.g. Anthropic → Bedrock) rather than crashing the conversion.
  */
-const FOREIGN_REASONING_TYPES = [
-  'thinking',
-  'redacted_thinking',
-  'reasoning',
-  'think',
-];
-
 /**
  * Google server-side tool blocks (`toolCall`/`toolResponse` parts from e.g.
  * URL context or Google Search). Only Google can execute these and validate
@@ -797,7 +791,7 @@ function convertAIMessageToConverseMessage(msg: BaseMessage): BedrockMessage {
           contentBlocks.push({
             cachePoint,
           } as BedrockContentBlock);
-        } else if (FOREIGN_REASONING_TYPES.some((t) => t === block.type)) {
+        } else if (isReasoningContentBlock(block)) {
           // Reasoning from another provider (Anthropic `thinking`/
           // `redacted_thinking`, Google `reasoning`, LibreChat `think`).
           // Bedrock's native reasoning is `reasoning_content` (handled above); a

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -56,6 +56,7 @@ import {
   serializeToolCallInput,
 } from '@/messages/prune';
 import { toLangChainContent } from '@/messages/langchain';
+import { isReasoningContentBlock } from '@/messages/reasoningTypes';
 
 export type { OpenAICallOptions, OpenAIChatInput };
 
@@ -361,7 +362,7 @@ export function _convertMessagesToOpenAIParams(
       role = 'developer';
     }
 
-    let hasAnthropicThinkingBlock: boolean = false;
+    let hasReasoningBlock = false;
 
     let content: unknown;
     if (
@@ -384,8 +385,8 @@ export function _convertMessagesToOpenAIParams(
       content = message.content;
     } else {
       content = message.content.map((m) => {
-        if ('type' in m && m.type === 'thinking') {
-          hasAnthropicThinkingBlock = true;
+        if (isReasoningContentBlock(m)) {
+          hasReasoningBlock = true;
           return m;
         }
         if (isDataContentBlock(m)) {
@@ -416,7 +417,7 @@ export function _convertMessagesToOpenAIParams(
       completionParam.tool_calls = message.tool_calls.map(
         convertLangChainToolCallToBoundedOpenAI
       );
-      completionParam.content = hasAnthropicThinkingBlock ? content : '';
+      completionParam.content = hasReasoningBlock ? content : '';
       if (
         options?.includeReasoningDetails === true &&
         message.additional_kwargs.reasoning_details != null

--- a/src/llm/openai/utils/index.ts
+++ b/src/llm/openai/utils/index.ts
@@ -56,7 +56,7 @@ import {
   serializeToolCallInput,
 } from '@/messages/prune';
 import { toLangChainContent } from '@/messages/langchain';
-import { isReasoningContentBlock } from '@/messages/reasoningTypes';
+import { isAnthropicThinkingContentBlock } from '@/messages/reasoningTypes';
 
 export type { OpenAICallOptions, OpenAIChatInput };
 
@@ -385,7 +385,7 @@ export function _convertMessagesToOpenAIParams(
       content = message.content;
     } else {
       content = message.content.map((m) => {
-        if (isReasoningContentBlock(m)) {
+        if (isAnthropicThinkingContentBlock(m)) {
           hasReasoningBlock = true;
           return m;
         }

--- a/src/messages/budget.ts
+++ b/src/messages/budget.ts
@@ -20,7 +20,7 @@ import {
 } from './toolResultTypes';
 import { getProviderMessageProvenance } from './provenance';
 import { apportionTokenCounts } from '@/utils/tokens';
-import { isReasoningContentBlock } from './core';
+import { isReasoningContentBlock } from './reasoningTypes';
 import { emitAgentLog } from '@/utils/events';
 import { ContentTypes } from '@/common';
 
@@ -74,13 +74,6 @@ function warnUnavailableToolShare(
     'Tool-message context share unavailable: the token counter must return finite, non-negative counts within the safe range',
     { error: error instanceof Error ? error.message : String(error) }
   );
-}
-
-/** `isReasoningContentBlock` matches every provider reasoning block by prefix
- *  but deliberately excludes LibreChat's `think`, which this gauge must treat
- *  the same way: reasoning attached to the turn, not visible conversation. */
-function isReasoningPart(part: MessageContentComplex): boolean {
-  return part.type === ContentTypes.THINK || isReasoningContentBlock(part);
 }
 
 function isBlankTextPart(part: string | MessageContentComplex): boolean {
@@ -191,7 +184,7 @@ function scanInvocation(
       continue;
     }
     previousPart = part;
-    if (isReasoningPart(part)) {
+    if (isReasoningContentBlock(part)) {
       continue;
     }
     toolOnly &&= isBlankTextPart(part);

--- a/src/messages/cache.ts
+++ b/src/messages/cache.ts
@@ -4,6 +4,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import type { AnthropicMessage } from '@/types/messages';
 import { hasComputerCallOutputMarker } from '@/utils/toolContent';
 import { toLangChainContent } from './langchain';
+import { isReasoningContentBlock } from './reasoningTypes';
 import { ContentTypes } from '@/common/enum';
 
 type MessageWithContent = {
@@ -412,27 +413,25 @@ function isCachePoint(block: unknown): boolean {
  * loses tail caching, so all of these are excluded.
  */
 const NON_ANCHORABLE_BLOCK_TYPES = new Set([
-  'thinking',
-  'redacted_thinking',
-  'reasoning_content',
-  'reasoning',
-  'think',
   'input_json_delta',
 ]);
 
 /**
  * A block can anchor the tail cache breakpoint when it is a real content block
  * that the Anthropic API accepts `cache_control` on and that survives provider
- * conversion. Reasoning / dropped-delta blocks are excluded (see
- * {@link NON_ANCHORABLE_BLOCK_TYPES}), and empty text blocks are not cacheable,
- * so both are skipped.
+ * conversion. Reasoning and dropped-delta blocks are excluded, and empty text
+ * blocks are not cacheable, so all are skipped.
  */
 function isTailCacheableBlock(block: MessageContentComplex): boolean {
   if (isCachePoint(block)) {
     return false;
   }
   const type = (block as { type?: string }).type;
-  if (type == null || NON_ANCHORABLE_BLOCK_TYPES.has(type)) {
+  if (
+    type == null ||
+    isReasoningContentBlock(block) ||
+    NON_ANCHORABLE_BLOCK_TYPES.has(type)
+  ) {
     return false;
   }
   if (type === 'text') {

--- a/src/messages/core.ts
+++ b/src/messages/core.ts
@@ -31,6 +31,7 @@ import {
 } from './provenance';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { stripAnthropicCacheControl } from './cache';
+import { isReasoningContentBlock } from './reasoningTypes';
 import { ContentTypes, Providers } from '@/common';
 import { toLangChainContent } from './langchain';
 
@@ -227,8 +228,7 @@ function getAdditionalReasoningContent(
 /**
  * True when a content block is a provider reasoning block: Anthropic
  * `thinking` / `redacted_thinking`, Google `reasoning`, Bedrock
- * `reasoning_content`, and the streamed delta variants that prefix each of
- * those names.
+ * `reasoning_content`, LibreChat `think`, and their known streamed variants.
  *
  * Shared rather than re-derived because two very different readers must agree
  * on the same answer: the stream classifier, which decides what the host has
@@ -236,38 +236,18 @@ function getAdditionalReasoningContent(
  * holds anything worth keeping. A turn the host renders as thinking-only must
  * never look like a visible answer to the gate.
  *
- * Prefix matching, not equality, because providers stream these as suffixed
- * delta types. `reasoning_content` needs no clause of its own — it already
- * carries the `reasoning` prefix.
+ * Exact matching prevents unrelated custom block types that happen to share a
+ * prefix from being silently classified as hidden reasoning.
  */
-export function isReasoningContentBlock(block: { type?: string }): boolean {
-  const type = block.type;
-  if (type == null) {
-    return false;
-  }
-  return (
-    type.startsWith(ContentTypes.THINKING) ||
-    type.startsWith(ContentTypes.REASONING) ||
-    type === 'redacted_thinking'
-  );
-}
+export { isReasoningContentBlock } from './reasoningTypes';
 
 function hasReasoningContent(content: BaseMessage['content']): boolean {
   if (!Array.isArray(content)) {
     return false;
   }
-  return content.some((item) => {
-    if (typeof item !== 'object' || !('type' in item)) {
-      return false;
-    }
-    return (
-      item.type === ContentTypes.THINK ||
-      item.type === ContentTypes.THINKING ||
-      item.type === ContentTypes.REASONING ||
-      item.type === ContentTypes.REASONING_CONTENT ||
-      item.type === 'redacted_thinking'
-    );
-  });
+  return content.some(
+    (item) => typeof item === 'object' && isReasoningContentBlock(item)
+  );
 }
 
 export function modifyDeltaProperties(

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -72,6 +72,7 @@ import {
 } from '@/common';
 import { normalizeAnthropicToolCallId } from '@/llm/anthropic/utils/message_inputs';
 import { toLangChainContent, toLangChainMessageFields } from './langchain';
+import { isReasoningContentBlock } from './reasoningTypes';
 import { flattenLegacyContent, isLegacyConvertible } from './content';
 import { HARD_MAX_TOOL_RESULT_CHARS } from '@/utils/truncation';
 import { emitAgentLog } from '@/utils/events';
@@ -484,13 +485,7 @@ function hasMeaningfulAssistantContent(part: MessageContentComplex): boolean {
   ) {
     return false;
   }
-  if (
-    part.type === ContentTypes.THINK ||
-    part.type === ContentTypes.THINKING ||
-    part.type === ContentTypes.REASONING ||
-    part.type === ContentTypes.REASONING_CONTENT ||
-    part.type === 'redacted_thinking'
-  ) {
+  if (isReasoningContentBlock(part)) {
     return extractReasoningContent(part).trim().length > 0;
   }
   return part.type != null && part.type !== '';
@@ -1983,13 +1978,7 @@ function formatAssistantMessage(
           'tool',
           sourcePartIndices
         );
-      } else if (
-        part.type === ContentTypes.THINK ||
-        part.type === ContentTypes.THINKING ||
-        part.type === ContentTypes.REASONING ||
-        part.type === ContentTypes.REASONING_CONTENT ||
-        part.type === 'redacted_thinking'
-      ) {
+      } else if (isReasoningContentBlock(part)) {
         if (
           part.type === ContentTypes.THINK &&
           compactionSemanticIndex != null &&
@@ -4182,12 +4171,7 @@ export function ensureThinkingBlockInMessages(
         const type = readFoldedDataProperty(c, 'type');
         if (type === 'tool_use') {
           hasToolUse = true;
-        } else if (
-          type === ContentTypes.THINKING ||
-          type === ContentTypes.REASONING_CONTENT ||
-          type === ContentTypes.REASONING ||
-          type === 'redacted_thinking'
-        ) {
+        } else if (isReasoningContentBlock({ type })) {
           hasThinkingBlock = true;
         }
         if (hasToolUse && hasThinkingBlock) {
@@ -4482,16 +4466,7 @@ function chainHasThinkingBlock(
 
       if (Array.isArray(prevAiMsg.content) && prevAiMsg.content.length > 0) {
         const content = prevAiMsg.content as ExtendedMessageContent[];
-        if (
-          content.some(
-            (c) =>
-              typeof c === 'object' &&
-              (c.type === ContentTypes.THINKING ||
-                c.type === ContentTypes.REASONING_CONTENT ||
-                c.type === ContentTypes.REASONING ||
-                c.type === 'redacted_thinking')
-          )
-        ) {
+        if (content.some((c) => isReasoningContentBlock(c))) {
           return true;
         }
       }

--- a/src/messages/format.ts
+++ b/src/messages/format.ts
@@ -438,8 +438,16 @@ function extractReasoningContent(
     const thinking = (part as ThinkingContentText).thinking;
     return typeof thinking === 'string' ? thinking : '';
   }
+  if (part.type === 'thinking_delta') {
+    const thinking = readFoldedDataProperty(part, 'thinking');
+    return typeof thinking === 'string' ? thinking : '';
+  }
   if (part.type === ContentTypes.REASONING) {
     const reasoning = (part as GoogleReasoningContentText).reasoning;
+    return typeof reasoning === 'string' ? reasoning : '';
+  }
+  if (part.type === 'reasoning-delta') {
+    const reasoning = readFoldedDataProperty(part, 'reasoning');
     return typeof reasoning === 'string' ? reasoning : '';
   }
   if (part.type === ContentTypes.REASONING_CONTENT) {

--- a/src/messages/formatAgentMessages.test.ts
+++ b/src/messages/formatAgentMessages.test.ts
@@ -5956,6 +5956,31 @@ describe('formatAgentMessages', () => {
     );
   });
 
+  it('preserves reasoning text from persisted stream delta blocks', () => {
+    const payload: TPayload = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking_delta', thinking: 'First thought. ' },
+          { type: 'reasoning-delta', reasoning: 'Second thought.' },
+          { type: ContentTypes.TEXT, text: 'Answer.' },
+        ],
+      },
+    ];
+
+    const result = formatAgentMessages(
+      payload,
+      undefined,
+      undefined,
+      undefined,
+      { preserveReasoningContent: true }
+    );
+
+    expect(result.messages[0].additional_kwargs.reasoning_content).toBe(
+      'First thought. Second thought.'
+    );
+  });
+
   it('should not reconstruct reasoning_content when preserveReasoningContent is explicitly false for DeepSeek', () => {
     const payload: TPayload = [
       {

--- a/src/messages/reasoningTypes.test.ts
+++ b/src/messages/reasoningTypes.test.ts
@@ -1,0 +1,22 @@
+import { isReasoningContentBlock } from './reasoningTypes';
+
+describe('isReasoningContentBlock', () => {
+  it.each([
+    'think',
+    'thinking',
+    'thinking_delta',
+    'redacted_thinking',
+    'reasoning',
+    'reasoning-delta',
+    'reasoning_content',
+  ])('recognizes %s blocks', (type) => {
+    expect(isReasoningContentBlock({ type })).toBe(true);
+  });
+
+  it.each(['text', 'thinker', 'reasoning_label', 'reasoning.text', undefined])(
+    'rejects %s blocks',
+    (type) => {
+      expect(isReasoningContentBlock({ type })).toBe(false);
+    }
+  );
+});

--- a/src/messages/reasoningTypes.ts
+++ b/src/messages/reasoningTypes.ts
@@ -15,3 +15,9 @@ export function isReasoningContentBlock(block: { type?: unknown }): boolean {
     REASONING_CONTENT_BLOCK_TYPES.has(block.type)
   );
 }
+
+export function isAnthropicThinkingContentBlock(block: {
+  type?: unknown;
+}): boolean {
+  return block.type === 'thinking';
+}

--- a/src/messages/reasoningTypes.ts
+++ b/src/messages/reasoningTypes.ts
@@ -1,0 +1,17 @@
+const REASONING_CONTENT_BLOCK_TYPES: ReadonlySet<string> = new Set([
+  'think',
+  'thinking',
+  'thinking_delta',
+  'redacted_thinking',
+  'reasoning',
+  'reasoning-delta',
+  'reasoning_content',
+]);
+
+/** Identifies every persisted or streamed reasoning content-block shape. */
+export function isReasoningContentBlock(block: { type?: unknown }): boolean {
+  return (
+    typeof block.type === 'string' &&
+    REASONING_CONTENT_BLOCK_TYPES.has(block.type)
+  );
+}


### PR DESCRIPTION
## Summary

- I centralize persisted and streamed reasoning block classification behind one exact-match predicate.
- I replace private provider and message-pipeline type lists with that shared taxonomy.
- I add regression coverage for supported variants and prefix lookalikes.

Addresses #526.

## Testing

- [x] `npx tsc --noEmit`
- [x] focused ESLint on all touched files (no errors)
- [x] `npx jest src/messages/reasoningTypes.test.ts src/messages/budget.test.ts src/messages/ensureThinkingBlock.test.ts src/messages/tailCacheConversion.test.ts src/llm/anthropic/utils/cross-provider-reasoning.test.ts src/llm/bedrock/utils/cross-provider-reasoning.test.ts --runInBand`
- [x] focused OpenAI reasoning/tool-call conversion test
- [x] `git diff --check`