### PR TITLE
perf: cache active AgentSession log projections

### DIFF
--- a/docs/session-projection-benchmark.md
+++ b/docs/session-projection-benchmark.md
@@ -1,0 +1,37 @@
+# Session projection cache
+
+`AgentSession` now reuses an in-memory index and the active message-entry projection across continuations. The indexed entry count is the append revision; the active leaf identifies the projected branch. Reads index only newly appended log entries, extend the active projection along the new parent chain, or rebuild when the leaf switches branches. A summary discards the preceding projection.
+
+Every read still materializes fresh LangChain messages. Full message materialization remains O(active messages); this change makes **log indexing and path traversal** incremental, not the entire agent turn. `Run` callers that do not use `AgentSession`, including LibreChat's direct `Run` integrations, do not automatically benefit.
+
+## Compatibility
+
+- No persisted format or public signature changes.
+- Existing mutable entry access through `AgentSession.getSessionStore()` permanently disables caching for that store and its shared-entry fork family. Subsequent reads use the original full derivation, including mutations made through previously retained references.
+- Reopened stores have independent caches. Forks share an ownership flag because their entry objects are shared.
+- Each read returns fresh message wrappers and summary objects. Existing nested content/metadata reference semantics are preserved.
+- Duplicate IDs in legacy logs fall back to the existing derivation.
+- No trace events, provider payloads, token accounting, or summary content are changed.
+
+## Reproduce
+
+```sh
+npx tsx src/scripts/bench-session-projection.ts
+```
+
+The benchmark compares `deriveMessages(store.getPath())` with `deriveSessionMessages(store)` on the same real JSONL store, asserts output equivalence, and alternates measurement order. Warm timings are medians of seven batches after warm-up. Delta timings are medians of 30 single reads, each after a real appended message. Both include fresh message construction; disk writes, model calls, and network latency are excluded. The generated tool-rich log has three records per original message. Compacted scenarios retain 40 messages after a summary while keeping the older log records.
+
+## Local results, 2026-09-07
+
+Node 24, macOS. Values are milliseconds per projection; they are microbenchmark results, not end-to-end request speedups.
+
+| Original messages | Compacted | Full warm read | Cached warm read | Full delta read | Cached delta read |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 100 | No | 0.017 | 0.005 | 0.024 | 0.011 |
+| 1,000 | No | 0.181 | 0.060 | 0.179 | 0.064 |
+| 10,000 | No | 3.369 | 0.756 | 3.466 | 0.946 |
+| 100 | Yes | 0.018 | 0.002 | 0.035 | 0.008 |
+| 1,000 | Yes | 0.167 | 0.002 | 0.310 | 0.009 |
+| 10,000 | Yes | 3.395 | 0.002 | 3.598 | 0.013 |
+
+First cache reads still build an O(log size) index, and the index adds one map entry per log record. Cold-start timings are printed separately but are not claimed as a gain. The cache holds one active projection per store, not one per historical branch. Public mutable-store users deliberately retain baseline performance.

--- a/src/scripts/bench-session-projection.ts
+++ b/src/scripts/bench-session-projection.ts
@@ -1,0 +1,170 @@
+/* eslint-disable no-console */
+import assert from 'node:assert/strict';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { HumanMessage } from '@langchain/core/messages';
+import type { SessionEntry, SessionHeader } from '../session/types';
+import { JsonlSessionStore } from '../session/JsonlSessionStore';
+import { deriveSessionMessages } from '../session/sessionProjection';
+import { deriveMessages } from '../session/deriveMessages';
+
+function fixture(turns: number, compacted: boolean): SessionEntry[] {
+  const entries: SessionEntry[] = [];
+  let parentId: string | null = null;
+  for (let i = 0; i < turns; i++) {
+    const timestamp = new Date(1_700_000_000_000 + i).toISOString();
+    const id = `message-${i}`;
+    if (compacted && i === turns - 40) {
+      entries.push({
+        type: 'summary',
+        id: 'summary',
+        parentId,
+        timestamp,
+        data: {
+          text: 'Earlier work is summarized here.',
+          tokenCount: 8,
+          retainedEntryIds: [],
+          summarizedEntryIds: [],
+        },
+      });
+      parentId = 'summary';
+    }
+    entries.push({
+      type: 'message',
+      id,
+      parentId,
+      timestamp,
+      data: {
+        role: i % 2 === 0 ? 'assistant' : 'tool',
+        message:
+          i % 2 === 0
+            ? {
+                messageType: 'ai',
+                content: '',
+                toolCalls: [
+                  { id: `call-${i}`, name: 'inspect', args: { path: 'src' } },
+                ],
+              }
+            : {
+                messageType: 'tool',
+                content: 'Repository evidence. '.repeat(30),
+                toolCallId: `call-${i - 1}`,
+              },
+      },
+    });
+    entries.push({
+      type: 'session_state',
+      id: `state-${i}`,
+      parentId: id,
+      timestamp,
+      data: { leafId: id },
+    });
+    entries.push({
+      type: 'run_event',
+      id: `event-${i}`,
+      parentId: id,
+      timestamp,
+      data: { event: 'run.completed' },
+    });
+    parentId = id;
+  }
+  return entries;
+}
+
+function median(values: number[]): number {
+  return values.sort((a, b) => a - b)[Math.floor(values.length / 2)];
+}
+
+function measure(run: () => void, iterations: number): number {
+  const start = performance.now();
+  for (let i = 0; i < iterations; i++) {
+    run();
+  }
+  return (performance.now() - start) / iterations;
+}
+
+async function main(): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'bench-session-projection-'));
+  try {
+    const rows = [];
+    for (const compacted of [false, true]) {
+      for (const turns of [100, 1_000, 10_000]) {
+        const path = join(dir, `${turns}-${compacted}.jsonl`);
+        const header: SessionHeader = {
+          type: 'session',
+          version: 1,
+          id: 'benchmark',
+          timestamp: '2023-01-01T00:00:00.000Z',
+          cwd: dir,
+        };
+        await writeFile(
+          path,
+          [header, ...fixture(turns, compacted)]
+            .map((entry) => JSON.stringify(entry))
+            .join('\n') + '\n'
+        );
+        const store = await JsonlSessionStore.openPath(path);
+        const baseline = () => deriveMessages(store.getPath());
+        const cached = () => deriveSessionMessages(store);
+        const coldStart = performance.now();
+        const first = cached();
+        const firstReadMs = performance.now() - coldStart;
+        assert.deepStrictEqual(first, baseline());
+        const iterations = Math.max(10, Math.floor(10_000 / turns));
+        measure(baseline, iterations);
+        measure(cached, iterations);
+        const before: number[] = [];
+        const after: number[] = [];
+        for (let round = 0; round < 7; round++) {
+          const order =
+            round % 2 === 0 ? [baseline, cached] : [cached, baseline];
+          for (const run of order) {
+            (run === baseline ? before : after).push(measure(run, iterations));
+          }
+        }
+        const beforeMs = median(before);
+        const afterMs = median(after);
+        rows.push({
+          messages: turns,
+          compacted,
+          firstReadMs: +firstReadMs.toFixed(3),
+          fullMs: +beforeMs.toFixed(3),
+          warmMs: +afterMs.toFixed(3),
+          speedup: +(beforeMs / afterMs).toFixed(2),
+        });
+        const deltaBefore: number[] = [];
+        const deltaAfter: number[] = [];
+        for (let turn = 0; turn < 30; turn++) {
+          await store.appendMessage(new HumanMessage(`follow-up ${turn}`));
+          const order =
+            turn % 2 === 0 ? [baseline, cached] : [cached, baseline];
+          for (const run of order) {
+            (run === baseline ? deltaBefore : deltaAfter).push(measure(run, 1));
+          }
+        }
+        assert.deepStrictEqual(cached(), baseline());
+        console.log(
+          JSON.stringify({
+            messages: turns,
+            compacted,
+            deltaFullMs: median(deltaBefore),
+            deltaCachedMs: median(deltaAfter),
+          })
+        );
+      }
+    }
+    console.table(rows);
+    console.log(
+      'Times include fresh message construction; delta times exclude filesystem writes. No model/network latency measured.'
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((error: Error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/session/AgentSession.ts
+++ b/src/session/AgentSession.ts
@@ -21,9 +21,12 @@ import type {
   SessionEntry,
   SessionForkOptions,
 } from './types';
-import { isFadingTier } from '@/messages/fading';
 import type { HookRegistry } from '@/hooks';
 import type * as t from '@/types';
+import {
+  deriveSessionMessages,
+  releaseSessionProjection,
+} from './sessionProjection';
 import { createSummarizeNode } from '@/summarization/node';
 import { resolveStreamLimits } from '@/llm/streamLimits';
 import { JsonlSessionStore } from './JsonlSessionStore';
@@ -31,6 +34,7 @@ import { AgentContext } from '@/agents/AgentContext';
 import { ContentTypes, GraphEvents } from '@/common';
 import { createRunId, createSessionId } from './ids';
 import { deriveMessages } from './deriveMessages';
+import { isFadingTier } from '@/messages/fading';
 import { createRunHandlers } from './handlers';
 import { Run } from '@/run';
 
@@ -377,7 +381,9 @@ function fadingGenerationKey(scopeKey: string, agentKey: string): string {
 
 function fadingGenerationScope(generationKey: string): string {
   const parsed: unknown = JSON.parse(generationKey);
-  return Array.isArray(parsed) && typeof parsed[0] === 'string' ? parsed[0] : '';
+  return Array.isArray(parsed) && typeof parsed[0] === 'string'
+    ? parsed[0]
+    : '';
 }
 
 /** What a run saw when it started, so its capture can tell stale from current. */
@@ -404,10 +410,7 @@ function mergeFadingTier(
   if (incoming == null) {
     return { ...current };
   }
-  const budgetTokens = Math.min(
-    current.budgetTokens,
-    incoming.budgetTokens
-  );
+  const budgetTokens = Math.min(current.budgetTokens, incoming.budgetTokens);
   const masked = current.masked || incoming.masked;
   const latched =
     current.latched === true ||
@@ -1010,6 +1013,9 @@ export class AgentSession {
   }
 
   getSessionStore(): JsonlSessionStore | undefined {
+    if (this.store) {
+      releaseSessionProjection(this.store);
+    }
     return this.store;
   }
 
@@ -1017,7 +1023,10 @@ export class AgentSession {
     return this.checkpointing.checkpointer;
   }
 
-  private getFadingState(threadId: string, checkpointNs = ''): {
+  private getFadingState(
+    threadId: string,
+    checkpointNs = ''
+  ): {
     fadingTier?: t.FadingTier;
     fadingTiers?: t.FadingTiers;
   } {
@@ -1058,8 +1067,7 @@ export class AgentSession {
 
   private trimAlternateFadingStates(): void {
     while (
-      this.alternateThreadFadingState.size >
-      MAX_ALTERNATE_THREAD_FADING_STATES
+      this.alternateThreadFadingState.size > MAX_ALTERNATE_THREAD_FADING_STATES
     ) {
       const oldestThreadId = this.alternateThreadFadingState.keys().next();
       if (oldestThreadId.done === true) {
@@ -1172,7 +1180,10 @@ export class AgentSession {
     };
     const advanceGeneration = (agentKey: string): void => {
       const key = fadingGenerationKey(scopeKey, agentKey);
-      this.fadingGenerations.set(key, (this.fadingGenerations.get(key) ?? 0) + 1);
+      this.fadingGenerations.set(
+        key,
+        (this.fadingGenerations.get(key) ?? 0) + 1
+      );
     };
     const mergeCapturedTier = (
       existing: t.FadingTier | undefined,
@@ -1218,7 +1229,11 @@ export class AgentSession {
       if (didResetTier) {
         advanceGeneration('');
       }
-      nextTier = mergeCapturedTier(current.fadingTier, incomingTier, didResetTier);
+      nextTier = mergeCapturedTier(
+        current.fadingTier,
+        incomingTier,
+        didResetTier
+      );
     }
     if (threadId === this.threadId && checkpointNs === '') {
       this.fadingTier = nextTier;
@@ -1408,8 +1423,8 @@ export class AgentSession {
       handlerResult.events.push(streamEvent);
       onEvent?.(streamEvent);
     };
-    const sessionState = deriveMessages(
-      isSessionThread ? (this.store?.getPath() ?? []) : []
+    const sessionState = deriveSessionMessages(
+      isSessionThread ? this.store : undefined
     );
     const fadingState = this.getFadingState(threadId, checkpointNs);
     let run: Run<t.IState> | undefined;
@@ -1690,7 +1705,9 @@ export class AgentSession {
       throw new Error('Cannot compact an ephemeral session');
     }
     const activePath = path ?? store.getPath();
-    const sessionState = deriveMessages(activePath);
+    const sessionState = path
+      ? deriveMessages(path)
+      : deriveSessionMessages(store);
     const messageEntries = activePath.filter(isMessageEntry);
     if (sessionState.messages.length === 0) {
       return undefined;
@@ -1819,8 +1836,8 @@ export class AgentSession {
       threadId,
       userHandlers: this.runConfig.customHandlers,
     });
-    const sessionState = deriveMessages(
-      isSessionThread ? (this.store?.getPath() ?? []) : []
+    const sessionState = deriveSessionMessages(
+      isSessionThread ? this.store : undefined
     );
     const fadingState = this.getFadingState(threadId, checkpointNs);
     let run: Run<t.IState> | undefined;

--- a/src/session/JsonlSessionStore.ts
+++ b/src/session/JsonlSessionStore.ts
@@ -35,6 +35,10 @@ import {
   serializeMessage,
   toJsonValue,
 } from './messageSerialization';
+import {
+  initializeSessionProjection,
+  shareSessionProjectionOwnership,
+} from './sessionProjection';
 import { createEntryId, createSessionId, createTimestamp } from './ids';
 
 const SESSION_VERSION = 1;
@@ -126,6 +130,7 @@ export class JsonlSessionStore {
     this.path = params.path;
     this.header = params.header;
     this.entries = sortEntries(params.entries);
+    initializeSessionProjection(this, this.entries);
   }
 
   static getDefaultRoot(): string {
@@ -573,6 +578,7 @@ export class JsonlSessionStore {
       name: options.name ?? this.header.name,
       parentSession: this.path,
     });
+    shareSessionProjectionOwnership(this, newStore);
     const pathEntries = target ? this.getPath(target.id) : [];
     for (const entry of pathEntries) {
       await newStore.appendExistingEntry(entry);

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -143,6 +143,41 @@ describe('JsonlSessionStore', () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it('uses cached session history across runs and falls back after mutable store exposure', async () => {
+    const mockRun = createMockRun('answer');
+    mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      sessionPath: join(dir, 'cached.jsonl'),
+      runId: 'template-run',
+      checkpointing: false,
+      graphConfig: {
+        type: 'standard',
+        llmConfig: { provider: 'openAI' as never, model: 'test-model' },
+        instructions: 'test',
+      },
+    });
+    const getPath = jest.spyOn(JsonlSessionStore.prototype, 'getPath');
+    await session.run('first');
+    const firstMessages = getProcessedMessages(mockRun);
+    firstMessages[0].content = 'run-local change';
+    mockRun.processStream.mockClear();
+    await session.run('second');
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['first', 'answer', 'second']);
+    expect(getPath).not.toHaveBeenCalled();
+    const store = session.getSessionStore()!;
+    const entry = store.getPath()[0];
+    if (entry.type === 'message') {
+      entry.data.message.content = 'external edit';
+    }
+    mockRun.processStream.mockClear();
+    await session.run('third');
+    expect(getProcessedMessages(mockRun)[0].content).toBe('external edit');
+    expect(getPath).toHaveBeenCalledTimes(2);
+  });
+
   it('opens a file whose session_state line carries null data', async () => {
     const path = join(dir, 'null-state.jsonl');
     const store = await JsonlSessionStore.create({
@@ -1295,9 +1330,17 @@ describe('JsonlSessionStore', () => {
     });
     await store.appendFadingState({
       threadId: store.header.id,
-      fadingTier: { v: 1, budgetTokens: 'abc', masked: true } as unknown as t.FadingTier,
+      fadingTier: {
+        v: 1,
+        budgetTokens: 'abc',
+        masked: true,
+      } as unknown as t.FadingTier,
       fadingTiers: {
-        default: { v: 1, budgetTokens: Number.NaN, masked: true } as t.FadingTier,
+        default: {
+          v: 1,
+          budgetTokens: Number.NaN,
+          masked: true,
+        } as t.FadingTier,
       },
     });
     const fadingTier: t.FadingTier = {
@@ -2071,9 +2114,7 @@ describe('JsonlSessionStore', () => {
       .mockReturnValueOnce({})
       .mockReturnValueOnce({ default: staleTier })
       .mockReturnValue({});
-    mockRun.didResetFadingTier
-      .mockReturnValueOnce(true)
-      .mockReturnValue(false);
+    mockRun.didResetFadingTier.mockReturnValueOnce(true).mockReturnValue(false);
     mockRun.getFadingTierResetAgentIds
       .mockReturnValueOnce(['default'])
       .mockReturnValue([]);
@@ -2185,9 +2226,12 @@ describe('JsonlSessionStore', () => {
     const resetResult = new Promise<t.MessageContentComplex[]>((resolve) => {
       releaseReset = () => resolve([{ type: 'text', text: 'reset' }]);
     });
-    const escalationResult = new Promise<t.MessageContentComplex[]>((resolve) => {
-      releaseEscalation = () => resolve([{ type: 'text', text: 'escalated' }]);
-    });
+    const escalationResult = new Promise<t.MessageContentComplex[]>(
+      (resolve) => {
+        releaseEscalation = () =>
+          resolve([{ type: 'text', text: 'escalated' }]);
+      }
+    );
     mockRun.processStream
       .mockImplementationOnce(async () => {
         markResetStarted();
@@ -2261,9 +2305,7 @@ describe('JsonlSessionStore', () => {
       await session.run(`alternate ${i}`, { threadId: `thread-${i}` });
     }
     expect(
-      session
-        .getSessionStore()
-        ?.getFadingStates(session.threadId, 64)
+      session.getSessionStore()?.getFadingStates(session.threadId, 64)
     ).toHaveLength(65);
     const reopened = await createAgentSession({
       cwd: dir,

--- a/src/session/__tests__/JsonlSessionStore.test.ts
+++ b/src/session/__tests__/JsonlSessionStore.test.ts
@@ -178,6 +178,56 @@ describe('JsonlSessionStore', () => {
     expect(getPath).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps the unexposed cache coherent through compaction, HITL resume, branching, and reopening', async () => {
+    mockSummarizer('summary of prior work');
+    const mockRun = createMockRun('answer');
+    const configs = mockRunCreate(mockRun);
+    const session = await createAgentSession({
+      cwd: dir,
+      sessionPath: join(dir, 'cache-transitions.jsonl'),
+      runId: 'template-run',
+      graphConfig: {
+        type: 'standard',
+        llmConfig: { provider: 'openAI' as never, model: 'test-model' },
+        instructions: 'test',
+      },
+    });
+    await session.run('first');
+    await session.compact({ retainRecentTurns: 0 });
+    const getPath = jest.spyOn(JsonlSessionStore.prototype, 'getPath');
+    await session.resumeInterrupt([]);
+    const resumeConfig = configs.at(-1)!.graphConfig;
+    expect(
+      'initialSummary' in resumeConfig && resumeConfig.initialSummary
+    ).toEqual({
+      text: 'summary of prior work',
+      tokenCount: expect.any(Number),
+    });
+    mockRun.processStream.mockClear();
+    await session.run('after resume');
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['answer', 'after resume']);
+    expect(getPath).not.toHaveBeenCalled();
+
+    const diskSnapshot = await JsonlSessionStore.openPath(session.sessionPath!);
+    const summary = diskSnapshot
+      .getPath()
+      .find((entry) => entry.type === 'summary')!;
+    await session.branch(summary.id);
+    mockRun.processStream.mockClear();
+    await session.run('alternate');
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['alternate']);
+    await session.resumeSession(session.sessionPath);
+    mockRun.processStream.mockClear();
+    await session.run('reopened');
+    expect(
+      getProcessedMessages(mockRun).map((message) => message.content)
+    ).toEqual(['alternate', 'answer', 'reopened']);
+  });
+
   it('opens a file whose session_state line carries null data', async () => {
     const path = join(dir, 'null-state.jsonl');
     const store = await JsonlSessionStore.create({

--- a/src/session/__tests__/sessionProjection.test.ts
+++ b/src/session/__tests__/sessionProjection.test.ts
@@ -1,0 +1,236 @@
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdtemp, rm, appendFile } from 'fs/promises';
+import {
+  AIMessage,
+  HumanMessage,
+  ToolMessage,
+  RemoveMessage,
+} from '@langchain/core/messages';
+import type { SessionEntry } from '../types';
+import {
+  deriveSessionMessages,
+  releaseSessionProjection,
+} from '../sessionProjection';
+import { JsonlSessionStore } from '../JsonlSessionStore';
+import { deriveMessages } from '../deriveMessages';
+
+describe('session projection cache', () => {
+  let dir: string;
+  let store: JsonlSessionStore;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'session-projection-test-'));
+    store = await JsonlSessionStore.create({
+      cwd: dir,
+      path: join(dir, 'session.jsonl'),
+    });
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  function expectEquivalent(target = store): void {
+    expect(deriveSessionMessages(target)).toEqual(
+      deriveMessages(target.getPath())
+    );
+  }
+
+  it('matches empty, appended, and tool-rich histories with fresh message instances', async () => {
+    expectEquivalent();
+    const messages = [
+      new HumanMessage('Inspect the repository'),
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call-1', name: 'inspect', args: { path: 'src' } }],
+      }),
+      new ToolMessage({
+        content: [{ type: 'text', text: 'result' }],
+        tool_call_id: 'call-1',
+      }),
+      new AIMessage({
+        content: 'Done',
+        invalid_tool_calls: [{ name: 'bad', args: '{', error: 'invalid' }],
+      }),
+      new RemoveMessage({ id: 'removed' }),
+    ];
+    for (const message of messages) {
+      await store.appendMessage(message);
+      expectEquivalent();
+    }
+    const first = deriveSessionMessages(store);
+    const second = deriveSessionMessages(store);
+    expect(first).toEqual(second);
+    expect(first.messages).not.toBe(second.messages);
+    for (let i = 0; i < first.messages.length; i++) {
+      expect(first.messages[i]).not.toBe(second.messages[i]);
+    }
+    first.messages[0].content = 'run-local edit';
+    first.messages[0].id = 'run-local id';
+    first.messages.pop();
+    expectEquivalent();
+  });
+
+  it('preserves nested mutation semantics while recreating each message wrapper', async () => {
+    await store.appendMessage(
+      new AIMessage({
+        content: '',
+        tool_calls: [{ id: 'call', name: 'inspect', args: { path: 'old' } }],
+      })
+    );
+    const message = deriveSessionMessages(store).messages[0] as AIMessage;
+    message.tool_calls![0].args.path = 'changed';
+    expectEquivalent();
+  });
+
+  it('does not rebuild the full path for warm reads or append-only continuations', async () => {
+    await store.appendMessage(new HumanMessage('start'));
+    deriveSessionMessages(store);
+    const getPath = jest.spyOn(store, 'getPath');
+    for (let i = 0; i < 10; i++) {
+      await store.appendRunEvent('run.started');
+      await store.appendMessage(new AIMessage(`answer ${i}`));
+      await store.appendCheckpoint({
+        source: 'resume',
+        threadId: 'thread',
+        checkpointId: `checkpoint-${i}`,
+      });
+      deriveSessionMessages(store);
+      deriveSessionMessages(store);
+    }
+    expect(getPath).not.toHaveBeenCalled();
+    expectEquivalent();
+  });
+
+  it('matches successive summaries, retained messages, and summary mutation isolation', async () => {
+    await store.appendMessage(new HumanMessage('old'));
+    deriveSessionMessages(store);
+    for (let i = 0; i < 3; i++) {
+      const summary = await store.appendEntryForCompaction({
+        text: `summary ${i}`,
+        tokenCount: i + 20,
+        retainedEntryIds: [],
+        summarizedEntryIds: [],
+      });
+      expectEquivalent();
+      const result = deriveSessionMessages(store);
+      result.initialSummary!.text = 'caller edit';
+      expectEquivalent();
+      await store.appendMessage(new HumanMessage(`retained ${i}`), summary.id);
+      await store.appendCompactionEntry({
+        summaryEntryId: summary.id,
+        retainedEntryIds: [],
+        summarizedEntryIds: [],
+      });
+      await store.appendFadingState(null);
+      expectEquivalent();
+    }
+  });
+
+  it('rebuilds for branches, cleared or missing leaves, and roots with no shared prefix', async () => {
+    const first = await store.appendMessage(new HumanMessage('first'));
+    const second = await store.appendMessage(new AIMessage('second'));
+    deriveSessionMessages(store);
+    await store.branch(first.id);
+    expectEquivalent();
+    await store.appendMessage(new AIMessage('alternate'));
+    expectEquivalent();
+    await store.setLeaf(second.id);
+    expectEquivalent();
+    await store.setLeaf(null);
+    expectEquivalent();
+    await store.setLeaf('missing');
+    expectEquivalent();
+    await store.appendMessage(new HumanMessage('new root'), null);
+    expectEquivalent();
+    await store.branch(first.id, { position: 'before' });
+    expectEquivalent();
+  });
+
+  it('handles leaf selection of non-message entries', async () => {
+    const first = await store.appendMessage(new HumanMessage('first'));
+    const event = await store.appendRunEvent('run.completed');
+    await store.setLeaf(event.id);
+    expectEquivalent();
+    await store.appendMessage(new HumanMessage('after event'));
+    expectEquivalent();
+    await store.setLeaf(first.id);
+    expectEquivalent();
+  });
+
+  it('reopens from disk without reusing another store projection', async () => {
+    await store.appendMessage(new HumanMessage('persisted'));
+    deriveSessionMessages(store);
+    const reopened = await JsonlSessionStore.openPath(store.path);
+    expectEquivalent(reopened);
+    await reopened.appendMessage(new AIMessage('continued'));
+    expectEquivalent(reopened);
+    expectEquivalent();
+  });
+
+  it('permanently falls back after mutable store exposure, including retained references', async () => {
+    const entry = await store.appendMessage(new HumanMessage('original'));
+    deriveSessionMessages(store);
+    releaseSessionProjection(store);
+    const getPath = jest.spyOn(store, 'getPath');
+    expectEquivalent();
+    entry.data.message.content = 'edited later';
+    entry.parentId = null;
+    expectEquivalent();
+    const state = store.getEntries().at(-1)!;
+    if (state.type === 'session_state') {
+      state.data.leafId = null;
+    }
+    expectEquivalent();
+    expect(getPath).toHaveBeenCalledTimes(6);
+  });
+
+  it.each(['source', 'child'] as const)(
+    'disables shared-entry fork caches when the %s is exposed',
+    async (exposed) => {
+      const entry = await store.appendMessage(new HumanMessage('shared'));
+      deriveSessionMessages(store);
+      const child = await store.clone();
+      try {
+        expectEquivalent(child);
+        releaseSessionProjection(exposed === 'source' ? store : child);
+        entry.id = 'changed-id';
+        expectEquivalent();
+        expectEquivalent(child);
+      } finally {
+        await rm(child.path);
+      }
+    }
+  );
+
+  it('inherits an already exposed source when creating a new fork', async () => {
+    const entry = await store.appendMessage(new HumanMessage('shared'));
+    releaseSessionProjection(store);
+    const child = await store.clone();
+    try {
+      expectEquivalent(child);
+      entry.id = 'changed-after-child-read';
+      expectEquivalent(child);
+    } finally {
+      await rm(child.path);
+    }
+  });
+
+  it('falls back for duplicate entry IDs in legacy logs', async () => {
+    const entry = await store.appendMessage(new HumanMessage('first'));
+    const duplicate: SessionEntry = {
+      ...entry,
+      timestamp: '2099-01-01T00:00:00.000Z',
+      data: {
+        ...entry.data,
+        message: { ...entry.data.message, content: 'duplicate' },
+      },
+    };
+    await appendFile(store.path, `${JSON.stringify(duplicate)}\n`);
+    const reopened = await JsonlSessionStore.openPath(store.path);
+    const getPath = jest.spyOn(reopened, 'getPath');
+    expectEquivalent(reopened);
+    expect(getPath).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/session/sessionProjection.ts
+++ b/src/session/sessionProjection.ts
@@ -1,0 +1,126 @@
+import type { DerivedSessionMessages } from './deriveMessages';
+import type { SessionEntry, SessionStateEntry } from './types';
+import type { JsonlSessionStore } from './JsonlSessionStore';
+import { deriveMessages } from './deriveMessages';
+
+interface SessionProjection {
+  entries: readonly SessionEntry[];
+  ownership: { exposed: boolean };
+  indexedCount: number;
+  byId: Map<string, SessionEntry>;
+  lastState?: SessionStateEntry;
+  lastMessage?: SessionEntry;
+  leaf?: SessionEntry;
+  projected: SessionEntry[];
+}
+
+const projections = new WeakMap<JsonlSessionStore, SessionProjection>();
+
+/** Internal: only AgentSession's unexposed stores may reuse log topology. */
+export function initializeSessionProjection(
+  store: JsonlSessionStore,
+  entries: readonly SessionEntry[]
+): void {
+  projections.set(store, {
+    entries,
+    ownership: { exposed: false },
+    indexedCount: 0,
+    byId: new Map(),
+    projected: [],
+  });
+}
+
+/** Forks share entry references, so exposing either disables the whole family. */
+export function shareSessionProjectionOwnership(
+  source: JsonlSessionStore,
+  target: JsonlSessionStore
+): void {
+  const sourceProjection = projections.get(source);
+  const targetProjection = projections.get(target);
+  if (sourceProjection && targetProjection) {
+    targetProjection.ownership = sourceProjection.ownership;
+  }
+}
+
+export function releaseSessionProjection(store: JsonlSessionStore): void {
+  const projection = projections.get(store);
+  if (projection) {
+    projection.ownership.exposed = true;
+    projection.byId.clear();
+    projection.projected = [];
+    projection.leaf = undefined;
+  }
+}
+
+function indexAppends(projection: SessionProjection): boolean {
+  for (
+    ;
+    projection.indexedCount < projection.entries.length;
+    projection.indexedCount++
+  ) {
+    const entry = projection.entries[projection.indexedCount];
+    if (projection.byId.has(entry.id)) {
+      return false;
+    }
+    projection.byId.set(entry.id, entry);
+    if (entry.type === 'session_state') {
+      projection.lastState = entry;
+    } else if (entry.type === 'message' || entry.type === 'summary') {
+      projection.lastMessage = entry;
+    }
+  }
+  return true;
+}
+
+function projectLeaf(projection: SessionProjection): void {
+  const leafId = projection.lastState
+    ? projection.lastState.data.leafId
+    : projection.lastMessage?.id;
+  const leaf =
+    leafId != null && leafId !== '' ? projection.byId.get(leafId) : undefined;
+  if (leaf === projection.leaf) {
+    return;
+  }
+  const delta: SessionEntry[] = [];
+  let current = leaf;
+  while (current && current !== projection.leaf) {
+    if (current.type === 'message' || current.type === 'summary') {
+      delta.push(current);
+    }
+    if (current.type === 'summary') {
+      current = undefined;
+      break;
+    }
+    current =
+      current.parentId == null
+        ? undefined
+        : projection.byId.get(current.parentId);
+  }
+  if (!current) {
+    projection.projected = [];
+  }
+  for (let i = delta.length - 1; i >= 0; i--) {
+    projection.projected.push(delta[i]);
+  }
+  projection.leaf = leaf;
+}
+
+/** Reuses log topology, but materializes fresh mutable messages for every run. */
+export function deriveSessionMessages(
+  store: JsonlSessionStore | undefined
+): DerivedSessionMessages {
+  if (!store) {
+    return { messages: [] };
+  }
+  const projection = projections.get(store);
+  if (!projection || projection.ownership.exposed) {
+    releaseSessionProjection(store);
+    return deriveMessages(store.getPath());
+  }
+  if (!indexAppends(projection)) {
+    releaseSessionProjection(store);
+    return deriveMessages(store.getPath());
+  }
+  projectLeaf(projection);
+  return deriveMessages(projection.projected);
+}


### PR DESCRIPTION
## Summary

Warm `AgentSession` continuations rebuilt the full JSONL entry index and parent path before deriving messages. Reuse the index by append revision and extend the active message-entry projection when the leaf advances. Branch changes rebuild the active projection; summaries discard the preceding projection. Every run still receives freshly constructed LangChain messages.

Preserves existing mutable-store behavior: obtaining `getSessionStore()` disables caching for the store and its shared-entry fork family. Reopened stores start independently; duplicate legacy entry IDs fall back to full derivation. There are no persisted-format or public-signature changes.

This improves SDK `AgentSession` projection CPU time. LibreChat integrations that call `Run` directly do not automatically benefit. Full message materialization remains O(active messages); only indexing and path traversal become incremental.

## Validation

- 83 session tests pass, including full-derivation equivalence, tool messages, compaction summaries, branches, resume/checkpoints, mutation isolation, shared fork ownership, legacy duplicate IDs, and `AgentSession` integration tests with the cache active through compaction, HITL resume, branching, and reopening.
- 203 tracing tests, type check, focused lint, package build, and circular-dependency check pass.
- Reproducible benchmark: `npx tsx src/scripts/bench-session-projection.ts`.
- At 10,000 original tool-rich messages, warm projection measured 3.37 → 0.76 ms. After compaction to 40 retained messages, a delta continuation measured 3.60 → 0.013 ms. Timings include fresh message construction and exclude filesystem writes/model/network latency.
- Details and limitations: `docs/session-projection-benchmark.md`.

Inspired by DeepSeek Harness's revision-driven session projections; scoped to the current SDK session implementation.
