### PR TITLE
perf: defer eager tool argument parsing until stream seal

### DIFF
--- a/docs/eager-tool-readiness-benchmark.md
+++ b/docs/eager-tool-readiness-benchmark.md
@@ -1,0 +1,26 @@
+# Eager tool readiness parsing
+
+On Node v24.16.0 / macOS, compared main `945119d4584ca2ee7bfac9f50b68eb5995b3a21a` with the seal-first readiness change. The same opt-in benchmark test was copied into the baseline checkout. Four separate Jest processes ran sequentially in candidate / baseline / baseline / candidate order after the other local checks completed.
+
+Each process reports the median of seven samples after two warmups. Each sample streams deterministic JSON arguments and a subsequent tool index through the real `ChatModelStreamHandler`, exercising argument reconciliation, readiness, and eager dispatch. Graph bookkeeping and external dispatch use the existing test fixtures. No model, network, production provider parsing, or full LibreChat request is measured. Each sample asserts that the first call prestarted.
+
+Ranges below are the two process medians, in milliseconds. Input sizes refer to SQL string content before its JSON envelope.
+
+| Input | Chunk size | Baseline elapsed | Candidate elapsed | Baseline CPU | Candidate CPU |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 128 B | 64 B | 0.213–0.293 | 0.172–0.192 | 0.381–0.445 | 0.338–0.402 |
+| 128 B | 256 B | 0.081–0.124 | 0.076–0.085 | 0.083–0.155 | 0.077–0.094 |
+| 8 KiB | 64 B | 3.488–3.552 | 2.151–2.226 | 4.483–4.625 | 3.195–3.488 |
+| 8 KiB | 256 B | 0.927–0.930 | 0.559–0.668 | 0.932–0.935 | 0.559–0.686 |
+| 48 KiB | 64 B | 46.579–47.605 | 23.229–25.351 | 53.479–54.837 | 33.493–37.595 |
+| 48 KiB | 256 B | 11.864–12.156 | 6.106–6.679 | 11.934–12.243 | 6.221–6.753 |
+
+The larger fixtures show about 28–51% lower handler elapsed time and 22–49% lower process CPU across these ranges. Tiny cases are dominated by timing variability. These results exceed the proposed 10% local-handler improvement gate, but do not establish an end-to-end user latency percentage, concurrent-load performance, or a retained-memory reduction. Process CPU includes runtime/GC work.
+
+Reproduce on each checkout with the identical benchmark fixture:
+
+```sh
+BENCH_EAGER_READINESS=1 npx jest src/__tests__/stream.eagerArgsDivergence.test.ts --runInBand -t 'benchmarks tool stream'
+```
+
+The behavioral regression test separately asserts that readiness does not parse unsealed arguments and parses a sealed argument string once before dispatch. Provider fragment reconciliation still parses its own buffers; that compatibility-sensitive behavior is unchanged.

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -47,6 +47,7 @@ import { ChatModelStreamHandler } from '@/stream';
 import { ToolNode } from '@/tools/ToolNode';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
+import * as eagerArgs from '@/tools/eagerEventExecution';
 
 function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   const runSteps = new Map<string, t.RunStep>();
@@ -135,7 +136,7 @@ function createDummyTool(name: string): StructuredToolInterface {
 
 function installToolExecuteResponder(): {
   toolExecuteCalls: t.ToolExecuteBatchRequest[];
-  } {
+} {
   const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
   jest
     .spyOn(events, 'safeDispatchCustomEvent')
@@ -259,6 +260,93 @@ function canonicalToolCall(
 }
 
 describe('eager args divergence (LibreChat#14371)', () => {
+  it('defers readiness parsing until a seal and reuses the parsed request', async () => {
+    const graph = createGraph();
+    const { toolExecuteCalls } = installToolExecuteResponder();
+    const handler = new ChatModelStreamHandler();
+    const metadata = { langgraph_node: 'agent' };
+    const parse = jest.spyOn(eagerArgs, 'coerceRecordArgs');
+    await streamChunks({
+      handler,
+      graph,
+      metadata,
+      toolCallChunks: toToolCallChunks('call_1', 'db_query', [
+        '{"sql":',
+        '"select 1"}',
+      ]),
+    });
+    expect(toolExecuteCalls).toHaveLength(0);
+    expect(parse).not.toHaveBeenCalled();
+    await streamNextToolIndex({ handler, graph, metadata, callId: 'call_2' });
+    expect(toolExecuteCalls).toHaveLength(1);
+    expect(toolExecuteCalls[0].toolCalls[0].args).toEqual({ sql: 'select 1' });
+    expect(
+      parse.mock.calls.filter(([value]) => typeof value === 'string')
+    ).toEqual([['{"sql":"select 1"}']]);
+  });
+
+  const benchmark = process.env.BENCH_EAGER_READINESS === '1' ? it : it.skip;
+  benchmark(
+    'benchmarks tool stream handling with deterministic arguments',
+    async () => {
+      installToolExecuteResponder();
+      for (const size of [128, 8192, 49152]) {
+        const payload = JSON.stringify({
+          sql: Array.from(
+            { length: Math.ceil(size / 16) },
+            (_, i) => `column_${i.toString(16).padStart(8, '0')} `
+          )
+            .join('')
+            .slice(0, size),
+        });
+        for (const chunkSize of [64, 256]) {
+          const fragments: string[] = [];
+          for (let i = 0; i < payload.length; i += chunkSize) {
+            fragments.push(payload.slice(i, i + chunkSize));
+          }
+          const samples: number[] = [];
+          const cpuSamples: number[] = [];
+          for (let round = 0; round < 9; round++) {
+            const graph = createGraph();
+            const handler = new ChatModelStreamHandler();
+            const metadata = { langgraph_node: 'agent' };
+            const chunks = toToolCallChunks('call_1', 'db_query', fragments);
+            const cpuStart = process.cpuUsage();
+            const start = performance.now();
+            await streamChunks({
+              handler,
+              graph,
+              metadata,
+              toolCallChunks: chunks,
+            });
+            await streamNextToolIndex({
+              handler,
+              graph,
+              metadata,
+              callId: 'call_2',
+            });
+            const elapsed = performance.now() - start;
+            const cpu = process.cpuUsage(cpuStart);
+            if (round >= 2) {
+              samples.push(elapsed);
+              cpuSamples.push((cpu.user + cpu.system) / 1000);
+            }
+            expect(graph.eagerEventToolExecutions.has('call_1')).toBe(true);
+            jest.clearAllMocks();
+          }
+          process.stdout.write(
+            JSON.stringify({
+              size,
+              chunkSize,
+              elapsedMs: samples.sort((a, b) => a - b)[3],
+              cpuMs: cpuSamples.sort((a, b) => a - b)[3],
+            }) + '\n'
+          );
+        }
+      }
+    }
+  );
+
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -511,7 +599,9 @@ describe('eager args divergence (LibreChat#14371)', () => {
       {
         chunk: {
           content: '',
-          tool_calls: [{ id: 'call_1', name: 'db_query', args: { sql: 'SELECT 1;' } }],
+          tool_calls: [
+            { id: 'call_1', name: 'db_query', args: { sql: 'SELECT 1;' } },
+          ],
           response_metadata: { finish_reason: 'tool_calls' },
         } as unknown as t.StreamChunk,
       },

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -136,7 +136,7 @@ function createDummyTool(name: string): StructuredToolInterface {
 
 function installToolExecuteResponder(): {
   toolExecuteCalls: t.ToolExecuteBatchRequest[];
-} {
+  } {
   const toolExecuteCalls: t.ToolExecuteBatchRequest[] = [];
   jest
     .spyOn(events, 'safeDispatchCustomEvent')

--- a/src/__tests__/stream.eagerArgsDivergence.test.ts
+++ b/src/__tests__/stream.eagerArgsDivergence.test.ts
@@ -43,11 +43,11 @@ import {
   StreamLimitExceededError,
 } from '@/llm/streamLimits';
 import { GraphEvents, Providers, StepTypes } from '@/common';
+import * as eagerArgs from '@/tools/eagerEventExecution';
 import { ChatModelStreamHandler } from '@/stream';
 import { ToolNode } from '@/tools/ToolNode';
 import { HandlerRegistry } from '@/events';
 import * as events from '@/utils/events';
-import * as eagerArgs from '@/tools/eagerEventExecution';
 
 function createGraph(overrides: Partial<StandardGraph> = {}): StandardGraph {
   const runSteps = new Map<string, t.RunStep>();

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1014,18 +1014,6 @@ function pruneEagerToolCallChunkStates(args: {
   }
 }
 
-function isEagerToolChunkStateComplete(
-  state: t.EagerEventToolCallChunkState
-): boolean {
-  return (
-    state.id != null &&
-    state.id !== '' &&
-    state.name != null &&
-    state.name !== '' &&
-    coerceRecordArgs(state.argsText) != null
-  );
-}
-
 function mergeToolCallArgsText(existing: string, incoming: string): string {
   if (incoming === '') {
     return existing;
@@ -1180,6 +1168,7 @@ function getStreamedReadyToolCalls(args: {
     key: string;
     state: t.EagerEventToolCallChunkState;
     sealedByAdapter: boolean;
+    parsedArgs: ToolCall['args'];
   }> = [];
 
   for (const [key, state] of graph.eagerEventToolCallChunks) {
@@ -1190,7 +1179,12 @@ function getStreamedReadyToolCalls(args: {
       graph.eagerEventToolCallChunks.delete(key);
       continue;
     }
-    if (!isEagerToolChunkStateComplete(state)) {
+    if (
+      state.id == null ||
+      state.id === '' ||
+      state.name == null ||
+      state.name === ''
+    ) {
       continue;
     }
     const isSealedByLaterChunk =
@@ -1209,10 +1203,15 @@ function getStreamedReadyToolCalls(args: {
       isSealedByLaterChunk ||
       isSealedExplicitly
     ) {
+      const parsedArgs = coerceRecordArgs(state.argsText);
+      if (parsedArgs == null) {
+        continue;
+      }
       readyEntries.push({
         key,
         state,
         sealedByAdapter: isSealedExplicitly || seal?.kind === 'all',
+        parsedArgs,
       });
     }
   }
@@ -1232,11 +1231,7 @@ function getStreamedReadyToolCalls(args: {
 
   return readyEntries
     .sort((left, right) => (left.state.index ?? 0) - (right.state.index ?? 0))
-    .flatMap(({ state, sealedByAdapter }) => {
-      const args = coerceRecordArgs(state.argsText);
-      if (args == null) {
-        return [];
-      }
+    .flatMap(({ state, sealedByAdapter, parsedArgs }) => {
       // The final request's args come from LangChain's canonical verbatim
       // concatenation of fragments, while `argsText` reconciles provider
       // quirks with lossy heuristics that can also swallow legitimately
@@ -1267,7 +1262,7 @@ function getStreamedReadyToolCalls(args: {
         {
           id: state.id,
           name: state.name ?? '',
-          args,
+          args: parsedArgs,
         },
       ];
     });


### PR DESCRIPTION
## Summary

Streaming eager-tool readiness parsed each growing argument buffer before checking whether the provider had sealed the call, then parsed accepted arguments again. Check the existing seal conditions first and retain the parsed object through request construction. Large streamed tool calls spend less CPU time checking readiness; invocation arguments, ordering, fallback, and seal timing remain the same.

LibreChat's existing direct Run integration exercises this path when streamed eager execution is enabled. No LibreChat code or configuration change is needed beyond adopting the SDK release.

## Validation

- Type checking and 351 streaming/eager execution/stream-limit/Langfuse/deterministic-trace tests pass.
- Added a regression asserting no readiness parse or invocation before a seal, then one string parse and the expected invocation arguments at the seal.
- Opt-in benchmark replays deterministic tool chunks through the real ChatModelStreamHandler with the existing in-memory graph fixture and mocked external dispatch. Compared against main `945119d4584ca2ee7bfac9f50b68eb5995b3a21a`, 8–48 KiB inputs show 28–51% lower handler elapsed time and 22–49% lower process CPU in sequential local comparisons. See `docs/eager-tool-readiness-benchmark.md` for all measurements and methodology. This is not an end-to-end LibreChat or network/model latency claim.
- Run: `BENCH_EAGER_READINESS=1 npx jest src/__tests__/stream.eagerArgsDivergence.test.ts --runInBand -t 'benchmarks tool stream'`.

Provider fragment reconciliation is unchanged and still performs its own parsing. No persistent cache or new public interface is introduced.
