### PR TITLE
🧷 fix: Bind Resumes to Reviewed Tool Proposals

### DIFF
--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -22,7 +22,9 @@ allowed action or repeat a sibling whose completed result was checkpointed.
    review; a valid approval uses the arguments actually reviewed.
 6. A child checkpoint fork receives a new execution scope. Only the trusted
    subagent adapter rebinds evidence from the manifest's proven source scope
-   into that destination. Unrelated child and parent scopes are unchanged.
+   into that destination, including durable pending writes that have not yet
+   been consumed. Each child restores its own pending evidence. Unrelated child
+   and parent scopes are unchanged; a mismatched executing owner fails closed.
 7. Completed batches release their process-local acceleration cache. That cache
    is not the durable source of truth: selecting a checkpoint replaces any
    newer local result for that batch, including when the checkpoint is empty.
@@ -30,6 +32,11 @@ allowed action or repeat a sibling whose completed result was checkpointed.
    Restored outputs and pending calls keep their original execution and
    completion indices, with or without a hook registry. Historical per-call
    turn entries are not copied into the active batch's checkpoint.
+9. Batch identity binds the assistant message and tool proposals, not transcript
+   length: additional resume messages cannot repeat completed work. The
+   pre-batch output-reference snapshot and turn counter are restored before
+   resolution. Cached messages are rebound to the active reference scope;
+   completed siblings cannot change what pending siblings originally resolved.
 
 The private checkpoint record is versioned. Its codec preserves LangChain
 messages; Command outputs are reconstructed before graph execution. Malformed

--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -1,0 +1,73 @@
+# Tool approval replay contract
+
+An approval belongs to an execution, not to a JavaScript object or the current
+hook registry. Reconstructing a `Run` must not turn a rejected action into an
+allowed action or repeat a sibling whose completed result was checkpointed.
+
+## Ownership and lifecycle
+
+1. The ToolNode resolves execution arguments and evaluates current policy.
+2. An `ask` records the exact tool-call identity, arguments and decision
+   allowlist. The originating execution owns that review. Parent nodes carry
+   child evidence through the trusted subagent adapter but do not consume it.
+3. Before publishing a pause, the direct batch waits for its started siblings
+   to settle. Completed results, hook context, reference content and completion
+   delivery state accompany the interrupt in the checkpoint. Only the active
+   batch is included; another thread's in-flight results are not copied.
+4. `Run.resume` obtains private evidence from the checkpoint, not host-supplied
+   configurable fields. Public interrupts do not expose the private records.
+5. A fresh ToolNode restores completed siblings and consumes the reviewed
+   decision for pending calls. Current denial still wins. Changed proposals or
+   disallowed decisions fail closed. Removing a hook cannot remove a pending
+   review; a valid approval uses the arguments actually reviewed.
+6. A child checkpoint fork receives a new execution scope. Only the trusted
+   subagent adapter rebinds evidence from the manifest's proven source scope
+   into that destination. Unrelated child and parent scopes are unchanged.
+7. Completed batches release their process-local acceleration cache. That cache
+   is not the durable source of truth.
+
+The private checkpoint record is versioned. Its codec preserves LangChain
+messages; Command outputs are reconstructed before graph execution. Malformed
+records fail closed. The replay module has no HTTP, database or host UI dependency.
+
+## Recovery guarantees and host obligations
+
+This protocol guarantees replay of **checkpointed completed work** when resuming
+an approval pause. Rebuilding a Run/ToolNode with the same checkpointer is a
+supported operation; retaining the old hooks or instances is not required.
+
+This is not a distributed exactly-once transaction for arbitrary external tools.
+A process can die after an external side effect but before a checkpoint commits.
+That outcome is ambiguous: absence of a saved result does not prove the tool did
+not run. Hosts must serialize ownership of a running thread, and tools requiring
+retry safety must use a durable operation/idempotency key or reconcile with their
+external system. A deliberate checkpoint fork is a new branch, not an ordinary
+duplicate submission. The SDK must not advertise arbitrary shell commands or
+third-party tools as exactly-once across that crash window.
+
+## Compatibility and rollout
+
+- New consumers accept legacy approval payloads without the private record.
+  Reviewed rejection and allowlist restrictions still apply. Unreviewed direct
+  siblings fail closed when their prior policy cannot be reconstructed.
+- Existing public approval payload and resume-decision shapes are unchanged.
+- Old SDK consumers cannot restore the new completion record. Do not route a
+  paused run between SDK versions indiscriminately: drain or version-pin paused
+  runs during rollout and before rollback. A durable checkpointer alone is not
+  an execution-owner lease.
+
+## Focused acceptance coverage
+
+- Fresh Run and ToolNode: direct and event approval with rewritten arguments,
+  with the former hook registry absent.
+- Fresh runtime with a different Run ID: mixed direct/event pause, preserving
+  one side effect, its returned result, and one completion event.
+- Repeated terminal resume: no additional execution.
+- Nested checkpoint forks: rejection remains effective without the former
+  hooks, and parent siblings remain independent of child approval evidence.
+- Codec and validation: messages, Commands, nested ownership, absent legacy
+  state and malformed records.
+
+External-side-effect crash reconciliation and concurrent independent host
+ownership require the host/tool contract above; these tests do not prove those
+external guarantees.

--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -24,7 +24,12 @@ allowed action or repeat a sibling whose completed result was checkpointed.
    subagent adapter rebinds evidence from the manifest's proven source scope
    into that destination. Unrelated child and parent scopes are unchanged.
 7. Completed batches release their process-local acceleration cache. That cache
-   is not the durable source of truth.
+   is not the durable source of truth: selecting a checkpoint replaces any
+   newer local result for that batch, including when the checkpoint is empty.
+8. The checkpoint also retains per-tool usage counters and active-call turns.
+   Restored outputs and pending calls keep their original execution and
+   completion indices, with or without a hook registry. Historical per-call
+   turn entries are not copied into the active batch's checkpoint.
 
 The private checkpoint record is versioned. Its codec preserves LangChain
 messages; Command outputs are reconstructed before graph execution. Malformed
@@ -70,7 +75,10 @@ third-party tools as exactly-once across that crash window.
 - Nested checkpoint forks: rejection remains effective without the former
   hooks, and parent siblings remain independent of child approval evidence.
 - Codec and validation: messages, Commands, nested ownership, absent legacy
-  state and malformed records.
+  state and malformed records. Restored results require a proposal binding;
+  custom payloads that resemble private wrappers preserve their public shape.
+- Older-checkpoint selection overrides a newer local cache; empty execution
+  scopes remain isolated anonymous invocations.
 
 External-side-effect crash reconciliation and concurrent independent host
 ownership require the host/tool contract above; these tests do not prove those

--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -36,6 +36,10 @@ This protocol guarantees replay of **checkpointed completed work** when resuming
 an approval pause. Rebuilding a Run/ToolNode with the same checkpointer is a
 supported operation; retaining the old hooks or instances is not required.
 
+Standalone ToolNode callers must supply a stable `configurable.thread_id` (or
+the SDK-managed approval execution scope) to identify a replay. Anonymous
+invocations are independent operations and never share completed-result state.
+
 This is not a distributed exactly-once transaction for arbitrary external tools.
 A process can die after an external side effect but before a checkpoint commits.
 That outcome is ambiguous: absence of a saved result does not prove the tool did

--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -24,7 +24,9 @@ allowed action or repeat a sibling whose completed result was checkpointed.
    subagent adapter rebinds evidence from the manifest's proven source scope
    into that destination, including durable pending writes that have not yet
    been consumed. Each child restores its own pending evidence. Unrelated child
-   and parent scopes are unchanged; a mismatched executing owner fails closed.
+   and parent scopes are unchanged. A foreign owner is accepted only as transit
+   through a trusted child tool, a matching parent batch record, and a validated
+   descendant manifest; changing tool-call IDs cannot bypass ownership checks.
 7. Completed batches release their process-local acceleration cache. That cache
    is not the durable source of truth: selecting a checkpoint replaces any
    newer local result for that batch, including when the checkpoint is empty.
@@ -34,9 +36,15 @@ allowed action or repeat a sibling whose completed result was checkpointed.
    turn entries are not copied into the active batch's checkpoint.
 9. Batch identity binds the assistant message and tool proposals, not transcript
    length: additional resume messages cannot repeat completed work. The
-   pre-batch output-reference snapshot and turn counter are restored before
-   resolution. Cached messages are rebound to the active reference scope;
-   completed siblings cannot change what pending siblings originally resolved.
+   pre-batch output-reference snapshot is a frozen input view, distinct from
+   the graph's shared live registry. Replay retains its original batch turn
+   without lowering the shared counter or discarding concurrent outputs.
+   Cached messages are rebound to the active reference scope; completed siblings
+   cannot change what pending siblings originally resolved. Current reference
+   size limits also apply to the frozen view.
+10. Direct calls without IDs use their original proposal position in the private
+    completion record. Filtering completed named calls cannot shift that identity;
+    successful ID-less outputs survive pauses without repeating their side effects.
 
 The private checkpoint record is versioned. Its codec preserves LangChain
 messages; Command outputs are reconstructed before graph execution. Malformed

--- a/src/hitl/approvalReview.test.ts
+++ b/src/hitl/approvalReview.test.ts
@@ -40,6 +40,28 @@ describe('approval review evidence', () => {
     ).toBeDefined();
   });
 
+  it('snapshots nested approval data before exposing it as evidence', () => {
+    const payload = {
+      type: 'tool_approval' as const,
+      action_requests: [
+        {
+          ...request,
+          arguments: { command: 'reviewed', options: { cwd: '/safe' } },
+        },
+      ],
+      review_configs: [reviewConfig],
+    };
+    const evidence = createToolApprovalReviewEvidence('interrupt_1', payload);
+
+    payload.action_requests[0].arguments.command = 'mutated';
+    payload.action_requests[0].arguments.options.cwd = '/unsafe';
+
+    expect(evidence?.payload.action_requests[0].arguments).toEqual({
+      command: 'reviewed',
+      options: { cwd: '/safe' },
+    });
+  });
+
   it.each([
     {
       label: 'null request',
@@ -68,13 +90,16 @@ describe('approval review evidence', () => {
       action_requests: [request, request],
       review_configs: [reviewConfig, reviewConfig],
     },
-  ])('rejects a malformed $label payload', ({ action_requests, review_configs }) => {
-    expect(
-      createToolApprovalReviewEvidence('interrupt_1', {
-        type: 'tool_approval',
-        action_requests,
-        review_configs,
-      })
-    ).toBeUndefined();
-  });
+  ])(
+    'rejects a malformed $label payload',
+    ({ action_requests, review_configs }) => {
+      expect(
+        createToolApprovalReviewEvidence('interrupt_1', {
+          type: 'tool_approval',
+          action_requests,
+          review_configs,
+        })
+      ).toBeUndefined();
+    }
+  );
 });

--- a/src/hitl/approvalReview.test.ts
+++ b/src/hitl/approvalReview.test.ts
@@ -30,6 +30,16 @@ describe('approval review evidence', () => {
     });
   });
 
+  it('preserves an empty allowlist as fail-closed review evidence', () => {
+    expect(
+      createToolApprovalReviewEvidence('interrupt_1', {
+        type: 'tool_approval',
+        action_requests: [request],
+        review_configs: [{ ...reviewConfig, allowed_decisions: [] }],
+      })
+    ).toBeDefined();
+  });
+
   it.each([
     {
       label: 'null request',

--- a/src/hitl/approvalReview.test.ts
+++ b/src/hitl/approvalReview.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals';
+import { createToolApprovalReviewEvidence } from './approvalReview';
+
+describe('approval review evidence', () => {
+  const request = {
+    tool_call_id: 'call_1',
+    name: 'bash',
+    arguments: { command: 'git status' },
+  };
+  const reviewConfig = {
+    tool_call_id: 'call_1',
+    action_name: 'bash',
+    allowed_decisions: ['approve', 'reject'],
+  };
+
+  it('accepts a complete one-to-one approval payload', () => {
+    expect(
+      createToolApprovalReviewEvidence('interrupt_1', {
+        type: 'tool_approval',
+        action_requests: [request],
+        review_configs: [reviewConfig],
+      })
+    ).toEqual({
+      interruptId: 'interrupt_1',
+      payload: {
+        type: 'tool_approval',
+        action_requests: [request],
+        review_configs: [reviewConfig],
+      },
+    });
+  });
+
+  it.each([
+    {
+      label: 'null request',
+      action_requests: [null],
+      review_configs: [reviewConfig],
+    },
+    {
+      label: 'missing arguments',
+      action_requests: [{ tool_call_id: 'call_1', name: 'bash' }],
+      review_configs: [reviewConfig],
+    },
+    {
+      label: 'mismatched review identity',
+      action_requests: [request],
+      review_configs: [{ ...reviewConfig, tool_call_id: 'call_2' }],
+    },
+    {
+      label: 'unknown decision',
+      action_requests: [request],
+      review_configs: [
+        { ...reviewConfig, allowed_decisions: ['approve', 'execute_anyway'] },
+      ],
+    },
+    {
+      label: 'duplicate tool-call ids',
+      action_requests: [request, request],
+      review_configs: [reviewConfig, reviewConfig],
+    },
+  ])('rejects a malformed $label payload', ({ action_requests, review_configs }) => {
+    expect(
+      createToolApprovalReviewEvidence('interrupt_1', {
+        type: 'tool_approval',
+        action_requests,
+        review_configs,
+      })
+    ).toBeUndefined();
+  });
+});

--- a/src/hitl/approvalReview.ts
+++ b/src/hitl/approvalReview.ts
@@ -1,0 +1,143 @@
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type {
+  ToolApprovalInterruptPayload,
+  ToolApprovalRequest,
+  ToolApprovalReviewConfig,
+} from '@/types/hitl';
+import { stableStringify } from '@/tools/eagerEventExecution';
+import { isToolApprovalInterrupt } from '@/types/hitl';
+
+/**
+ * Private resume-only config entry populated from the checkpointed interrupt.
+ * Hosts must never need to construct or inspect this value.
+ */
+export const TOOL_APPROVAL_REVIEW_CONFIG_KEY =
+  '__librechat_tool_approval_review';
+
+export interface ToolApprovalReviewEvidence {
+  interruptId: string;
+  payload: ToolApprovalInterruptPayload;
+}
+
+export interface ReviewedToolApproval {
+  request: ToolApprovalRequest;
+  reviewConfig: ToolApprovalReviewConfig;
+}
+
+function hasValidApprovalShape(payload: ToolApprovalInterruptPayload): boolean {
+  return (
+    Array.isArray(payload.action_requests) &&
+    Array.isArray(payload.review_configs)
+  );
+}
+
+/** Build trusted review evidence from the interrupt restored by `Run`. */
+export function createToolApprovalReviewEvidence(
+  interruptId: string | undefined,
+  payload: unknown
+): ToolApprovalReviewEvidence | undefined {
+  if (
+    typeof interruptId !== 'string' ||
+    interruptId.length === 0 ||
+    !isToolApprovalInterrupt(payload) ||
+    !hasValidApprovalShape(payload)
+  ) {
+    return undefined;
+  }
+  return { interruptId, payload };
+}
+
+/** Read only well-shaped evidence from a ToolNode's runnable config. */
+export function getToolApprovalReviewEvidence(
+  config: RunnableConfig
+): ToolApprovalReviewEvidence | undefined {
+  const candidate = config.configurable?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
+  if (candidate == null || typeof candidate !== 'object') {
+    return undefined;
+  }
+  const { interruptId, payload } = candidate as {
+    interruptId?: unknown;
+    payload?: unknown;
+  };
+  return createToolApprovalReviewEvidence(
+    typeof interruptId === 'string' ? interruptId : undefined,
+    payload
+  );
+}
+
+export function getReviewedToolApproval(
+  payload: ToolApprovalInterruptPayload | undefined,
+  toolCallId: string | undefined
+): ReviewedToolApproval | undefined {
+  if (payload == null || toolCallId == null || toolCallId === '') {
+    return undefined;
+  }
+  const request = payload.action_requests.find(
+    (candidate) => candidate.tool_call_id === toolCallId
+  );
+  const reviewConfig = payload.review_configs.find(
+    (candidate) => candidate.tool_call_id === toolCallId
+  );
+  if (request == null || reviewConfig == null) {
+    return undefined;
+  }
+  return { request, reviewConfig };
+}
+
+function decisionsEqual(
+  left: ReadonlyArray<string>,
+  right: ReadonlyArray<string>
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  const sortedLeft = [...left].sort();
+  const sortedRight = [...right].sort();
+  return sortedLeft.every((value, index) => value === sortedRight[index]);
+}
+
+/**
+ * Bind a resume decision to the exact proposal the reviewer saw. Description
+ * text is deliberately excluded: it explains policy but cannot change the
+ * side effect. Tool identity, normalized arguments and available decisions
+ * are execution-authoritative.
+ */
+export function toolApprovalProposalMatches(
+  current: ReviewedToolApproval,
+  reviewed: ReviewedToolApproval
+): boolean {
+  return (
+    current.request.tool_call_id === reviewed.request.tool_call_id &&
+    current.request.name === reviewed.request.name &&
+    current.reviewConfig.tool_call_id === reviewed.reviewConfig.tool_call_id &&
+    current.reviewConfig.action_name === reviewed.reviewConfig.action_name &&
+    stableStringify(current.request.arguments) ===
+      stableStringify(reviewed.request.arguments) &&
+    decisionsEqual(
+      current.reviewConfig.allowed_decisions,
+      reviewed.reviewConfig.allowed_decisions
+    )
+  );
+}
+
+/** Preserve batch order as part of the decision-to-request binding. */
+export function toolApprovalPayloadMatches(
+  current: ToolApprovalInterruptPayload,
+  reviewed: ToolApprovalInterruptPayload
+): boolean {
+  if (
+    current.action_requests.length !== reviewed.action_requests.length ||
+    current.review_configs.length !== reviewed.review_configs.length
+  ) {
+    return false;
+  }
+  return current.action_requests.every((request, index) => {
+    const currentReviewConfig = current.review_configs[index];
+    const reviewedRequest = reviewed.action_requests[index];
+    const reviewedReviewConfig = reviewed.review_configs[index];
+    return toolApprovalProposalMatches(
+      { request, reviewConfig: currentReviewConfig },
+      { request: reviewedRequest, reviewConfig: reviewedReviewConfig }
+    );
+  });
+}

--- a/src/hitl/approvalReview.ts
+++ b/src/hitl/approvalReview.ts
@@ -17,6 +17,7 @@ export const TOOL_APPROVAL_REVIEW_CONFIG_KEY =
 export interface ToolApprovalReviewEvidence {
   interruptId: string;
   payload: ToolApprovalInterruptPayload;
+  owner?: string;
 }
 
 export interface ReviewedToolApproval {
@@ -80,7 +81,8 @@ function hasValidApprovalShape(payload: ToolApprovalInterruptPayload): boolean {
 /** Build trusted review evidence from the interrupt restored by `Run`. */
 export function createToolApprovalReviewEvidence(
   interruptId: string | undefined,
-  payload: unknown
+  payload: unknown,
+  owner?: string
 ): ToolApprovalReviewEvidence | undefined {
   if (
     typeof interruptId !== 'string' ||
@@ -93,24 +95,39 @@ export function createToolApprovalReviewEvidence(
   return {
     interruptId,
     payload: cloneToolApprovalInterruptPayload(payload),
+    ...(owner == null ? {} : { owner }),
   };
 }
 
 /** Read only well-shaped evidence from a ToolNode's runnable config. */
 export function getToolApprovalReviewEvidence(
-  config: RunnableConfig
+  config: RunnableConfig,
+  owner?: string
 ): ToolApprovalReviewEvidence | undefined {
   const candidate = config.configurable?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
   if (candidate == null || typeof candidate !== 'object') {
     return undefined;
   }
-  const { interruptId, payload } = candidate as {
+  const {
+    interruptId,
+    payload,
+    owner: evidenceOwner,
+  } = candidate as {
     interruptId?: unknown;
     payload?: unknown;
+    owner?: unknown;
   };
+  if (
+    evidenceOwner != null &&
+    (typeof evidenceOwner !== 'string' ||
+      (owner != null && owner !== evidenceOwner))
+  ) {
+    return undefined;
+  }
   return createToolApprovalReviewEvidence(
     typeof interruptId === 'string' ? interruptId : undefined,
-    payload
+    payload,
+    typeof evidenceOwner === 'string' ? evidenceOwner : undefined
   );
 }
 

--- a/src/hitl/approvalReview.ts
+++ b/src/hitl/approvalReview.ts
@@ -60,7 +60,6 @@ function hasValidApprovalShape(payload: ToolApprovalInterruptPayload): boolean {
       reviewConfig.tool_call_id !== toolCallId ||
       reviewConfig.action_name !== toolName ||
       !Array.isArray(allowedDecisions) ||
-      allowedDecisions.length === 0 ||
       !allowedDecisions.every(
         (decision) =>
           typeof decision === 'string' && APPROVAL_DECISIONS.has(decision)

--- a/src/hitl/approvalReview.ts
+++ b/src/hitl/approvalReview.ts
@@ -24,11 +24,53 @@ export interface ReviewedToolApproval {
   reviewConfig: ToolApprovalReviewConfig;
 }
 
+const APPROVAL_DECISIONS = new Set(['approve', 'reject', 'edit', 'respond']);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function hasValidApprovalShape(payload: ToolApprovalInterruptPayload): boolean {
-  return (
-    Array.isArray(payload.action_requests) &&
-    Array.isArray(payload.review_configs)
-  );
+  if (
+    !Array.isArray(payload.action_requests) ||
+    !Array.isArray(payload.review_configs) ||
+    payload.action_requests.length !== payload.review_configs.length
+  ) {
+    return false;
+  }
+
+  const toolCallIds = new Set<string>();
+  return payload.action_requests.every((request, index) => {
+    const reviewConfig = payload.review_configs[index];
+    if (!isRecord(request) || !isRecord(reviewConfig)) {
+      return false;
+    }
+    const toolCallId = request.tool_call_id;
+    const toolName = request.name;
+    const allowedDecisions = reviewConfig.allowed_decisions;
+    if (
+      typeof toolCallId !== 'string' ||
+      toolCallId.length === 0 ||
+      toolCallIds.has(toolCallId) ||
+      typeof toolName !== 'string' ||
+      toolName.length === 0 ||
+      !isRecord(request.arguments) ||
+      (request.description != null &&
+        typeof request.description !== 'string') ||
+      reviewConfig.tool_call_id !== toolCallId ||
+      reviewConfig.action_name !== toolName ||
+      !Array.isArray(allowedDecisions) ||
+      allowedDecisions.length === 0 ||
+      !allowedDecisions.every(
+        (decision) =>
+          typeof decision === 'string' && APPROVAL_DECISIONS.has(decision)
+      )
+    ) {
+      return false;
+    }
+    toolCallIds.add(toolCallId);
+    return true;
+  });
 }
 
 /** Build trusted review evidence from the interrupt restored by `Run`. */

--- a/src/hitl/approvalReview.ts
+++ b/src/hitl/approvalReview.ts
@@ -26,6 +26,11 @@ export interface ReviewedToolApproval {
 
 const APPROVAL_DECISIONS = new Set(['approve', 'reject', 'edit', 'respond']);
 
+/** Detach approval payloads from host- or transport-owned object graphs. */
+export function cloneToolApprovalInterruptPayload<T>(payload: T): T {
+  return isToolApprovalInterrupt(payload) ? structuredClone(payload) : payload;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -85,7 +90,10 @@ export function createToolApprovalReviewEvidence(
   ) {
     return undefined;
   }
-  return { interruptId, payload };
+  return {
+    interruptId,
+    payload: cloneToolApprovalInterruptPayload(payload),
+  };
 }
 
 /** Read only well-shaped evidence from a ToolNode's runnable config. */

--- a/src/run.ts
+++ b/src/run.ts
@@ -71,9 +71,13 @@ import {
 } from '@/langfuseConfig';
 import {
   cloneToolApprovalInterruptPayload,
-  createToolApprovalReviewEvidence,
   TOOL_APPROVAL_REVIEW_CONFIG_KEY,
 } from '@/hitl/approvalReview';
+import {
+  TOOL_BATCH_REPLAY_KEY,
+  restoreToolReplayConfig,
+  stripToolBatchReplayState,
+} from '@/tools/toolBatchReplay';
 import {
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
@@ -1268,6 +1272,7 @@ export class Run<_T extends t.BaseGraphState> {
       configurable: { ...callerConfig.configurable },
     };
     delete config.configurable?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
+    delete config.configurable?.[TOOL_BATCH_REPLAY_KEY];
     if (!isResume) {
       delete config.configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
       delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
@@ -1281,12 +1286,8 @@ export class Run<_T extends t.BaseGraphState> {
       const publicPayload = stripSubagentResumeManifest(
         stripRunStepResumeState(this._interrupt?.payload)
       );
-      const reviewEvidence = createToolApprovalReviewEvidence(
-        this._interrupt?.interruptId,
-        publicPayload
-      );
-      if (reviewEvidence != null && config.configurable != null) {
-        config.configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = reviewEvidence;
+      if (config.configurable != null) {
+        restoreToolReplayConfig(config.configurable, this._interrupt?.interruptId, publicPayload);
       }
       if (graph.getStopContinuationExecutionId() === '') {
         graph.startStopContinuationExecution(nanoid());
@@ -1895,9 +1896,9 @@ export class Run<_T extends t.BaseGraphState> {
     return {
       ...this._interrupt,
       payload: cloneToolApprovalInterruptPayload(
-        stripSubagentResumeManifest(
+        stripToolBatchReplayState(stripSubagentResumeManifest(
           stripRunStepResumeState(this._interrupt.payload)
-        )
+        ))
       ),
     } as t.RunInterruptResult<TPayload>;
   }
@@ -2024,6 +2025,7 @@ export class Run<_T extends t.BaseGraphState> {
     );
     const resumeConfigurable = { ...callerConfig.configurable };
     delete resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
+    delete resumeConfigurable[TOOL_BATCH_REPLAY_KEY];
     delete resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
     delete resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
     resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY] = nanoid();
@@ -2033,13 +2035,7 @@ export class Run<_T extends t.BaseGraphState> {
     const publicPayload = stripSubagentResumeManifest(
       stripRunStepResumeState(interrupt?.payload)
     );
-    const reviewEvidence = createToolApprovalReviewEvidence(
-      interrupt?.interruptId,
-      publicPayload
-    );
-    if (reviewEvidence != null) {
-      resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = reviewEvidence;
-    }
+    restoreToolReplayConfig(resumeConfigurable, interrupt?.interruptId, publicPayload);
     const manifestConfig = {
       ...callerConfig,
       configurable: resumeConfigurable,

--- a/src/run.ts
+++ b/src/run.ts
@@ -39,7 +39,6 @@ import {
 } from '@/common';
 import {
   requireValidSubagentResumeManifest,
-  stripSubagentResumeManifest,
   SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from '@/tools/subagent/SubagentReplay';
@@ -77,6 +76,7 @@ import {
   TOOL_BATCH_REPLAY_KEY,
   restoreToolReplayConfig,
   stripToolBatchReplayState,
+  getPublicToolInterruptPayload,
 } from '@/tools/toolBatchReplay';
 import {
   resolveLangfuseDestinationKey,
@@ -273,9 +273,7 @@ function isLangGraphResumeMapForInterrupt(
 }
 
 function getInterruptHookSessionId(payload: unknown): string | undefined {
-  const publicPayload = stripSubagentResumeManifest(
-    stripRunStepResumeState(payload)
-  );
+  const publicPayload = getPublicToolInterruptPayload(payload);
   if (
     publicPayload == null ||
     typeof publicPayload !== 'object' ||
@@ -1283,9 +1281,7 @@ export class Run<_T extends t.BaseGraphState> {
         config,
         (inputs as Command).update
       );
-      const publicPayload = stripSubagentResumeManifest(
-        stripRunStepResumeState(this._interrupt?.payload)
-      );
+      const publicPayload = stripRunStepResumeState(this._interrupt?.payload);
       if (config.configurable != null) {
         restoreToolReplayConfig(config.configurable, this._interrupt?.interruptId, publicPayload);
       }
@@ -1896,9 +1892,7 @@ export class Run<_T extends t.BaseGraphState> {
     return {
       ...this._interrupt,
       payload: cloneToolApprovalInterruptPayload(
-        stripToolBatchReplayState(stripSubagentResumeManifest(
-          stripRunStepResumeState(this._interrupt.payload)
-        ))
+        getPublicToolInterruptPayload(this._interrupt.payload)
       ),
     } as t.RunInterruptResult<TPayload>;
   }
@@ -2020,9 +2014,9 @@ export class Run<_T extends t.BaseGraphState> {
   ): Promise<t.RunStreamConfig> {
     await this.restoreInterruptFromCheckpoint(callerConfig, resumeUpdate);
     const interrupt = this._interrupt;
-    const resumeManifest = requireValidSubagentResumeManifest(
-      stripRunStepResumeState(interrupt?.payload)
-    );
+    const replayPayload = stripRunStepResumeState(interrupt?.payload);
+    const resumeManifest = requireValidSubagentResumeManifest(replayPayload) ??
+      requireValidSubagentResumeManifest(stripToolBatchReplayState(replayPayload));
     const resumeConfigurable = { ...callerConfig.configurable };
     delete resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
     delete resumeConfigurable[TOOL_BATCH_REPLAY_KEY];
@@ -2032,9 +2026,7 @@ export class Run<_T extends t.BaseGraphState> {
     if (resumeManifest != null) {
       resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] = resumeManifest;
     }
-    const publicPayload = stripSubagentResumeManifest(
-      stripRunStepResumeState(interrupt?.payload)
-    );
+    const publicPayload = stripRunStepResumeState(interrupt?.payload);
     restoreToolReplayConfig(resumeConfigurable, interrupt?.interruptId, publicPayload);
     const manifestConfig = {
       ...callerConfig,

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,6 +70,7 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
+  cloneToolApprovalInterruptPayload,
   createToolApprovalReviewEvidence,
   TOOL_APPROVAL_REVIEW_CONFIG_KEY,
 } from '@/hitl/approvalReview';
@@ -173,9 +174,7 @@ function materializeStopContinuation(
   return messages;
 }
 
-function advanceCheckpointCursor(
-  config: t.RunStreamConfig
-): t.RunStreamConfig {
+function advanceCheckpointCursor(config: t.RunStreamConfig): t.RunStreamConfig {
   const configurable = { ...config.configurable };
   delete configurable.checkpoint_id;
   delete configurable.checkpoint_map;
@@ -190,9 +189,7 @@ function assertFinalAdmissionSucceeded(result: AggregatedHookResult): void {
     result.errors.length > 0
       ? result.errors.join('; ')
       : 'one or more internal finalizers failed';
-  throw new Error(
-    `StopFinalize terminal admission failed: ${detail}`
-  );
+  throw new Error(`StopFinalize terminal admission failed: ${detail}`);
 }
 
 const CUSTOM_GRAPH_EVENTS = new Set<string>([
@@ -427,7 +424,7 @@ function overwriteResumeRunStepState(
   const update = Array.isArray(command.update)
     ? [
       ...command.update.filter(([key]) => key !== 'runStepState'),
-      ['runStepState', overwrite] as [string, unknown],
+        ['runStepState', overwrite] as [string, unknown],
     ]
     : { ...(command.update ?? {}), runStepState: overwrite };
   const resumed = new Command({
@@ -1529,7 +1526,7 @@ export class Run<_T extends t.BaseGraphState> {
               this._interrupt = {
                 interruptId: first.id ?? '',
                 threadId,
-                payload: first.value,
+                payload: cloneToolApprovalInterruptPayload(first.value),
               };
             }
           }
@@ -1573,7 +1570,8 @@ export class Run<_T extends t.BaseGraphState> {
           stopReason = OUTPUT_TRUNCATED_HALT_REASON;
         }
 
-        const stopMessages = graph.getRunMessages() ?? stateInputs?.messages ?? [];
+        const stopMessages =
+          graph.getRunMessages() ?? stateInputs?.messages ?? [];
         const stopContinuationCount = graph.getStopContinuationCount();
         const continuationBudgetRemaining = Math.max(
           0,
@@ -1896,8 +1894,10 @@ export class Run<_T extends t.BaseGraphState> {
     }
     return {
       ...this._interrupt,
-      payload: stripSubagentResumeManifest(
-        stripRunStepResumeState(this._interrupt.payload)
+      payload: cloneToolApprovalInterruptPayload(
+        stripSubagentResumeManifest(
+          stripRunStepResumeState(this._interrupt.payload)
+        )
       ),
     } as t.RunInterruptResult<TPayload>;
   }
@@ -2156,7 +2156,7 @@ export class Run<_T extends t.BaseGraphState> {
     const threadId = callerConfig.configurable?.thread_id;
     this._interrupt = {
       interruptId: persistedInterrupt.id,
-      payload: persistedInterrupt.value,
+      payload: cloneToolApprovalInterruptPayload(persistedInterrupt.value),
       ...(typeof threadId === 'string' ? { threadId } : {}),
       ...(typeof checkpointId === 'string' ? { checkpointId } : {}),
       ...(typeof checkpointNs === 'string' ? { checkpointNs } : {}),

--- a/src/run.ts
+++ b/src/run.ts
@@ -22,7 +22,6 @@ import type {
 } from '@langchain/core/messages';
 import type { StringPromptValue } from '@langchain/core/prompt_values';
 import type { RunnableConfig } from '@langchain/core/runnables';
-import { isFadingTier } from '@/messages/fading';
 import type { AggregatedHookResult, HookRegistry } from '@/hooks';
 import type { MultiAgentGraph } from '@/graphs/MultiAgentGraph';
 import type { StandardGraph } from '@/graphs/Graph';
@@ -71,6 +70,10 @@ import {
   resolveToolOutputTracingConfig,
 } from '@/langfuseConfig';
 import {
+  createToolApprovalReviewEvidence,
+  TOOL_APPROVAL_REVIEW_CONFIG_KEY,
+} from '@/hitl/approvalReview';
+import {
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
 } from '@/langfuseSpanRegistry';
@@ -104,6 +107,7 @@ import { seedRunInitialSessions } from '@/utils/toolSessions';
 import { getTraceIdSeed } from '@/langfuseRuntimeContext';
 import { resolveClientOptionsModel } from '@/llm/request';
 import { createGraph } from '@/graphs/createGraph';
+import { isFadingTier } from '@/messages/fading';
 import { resolveMaxSeals } from '@/llm/preempt';
 import { isBuiltRuntime } from '@/lazyRequire';
 import { initializeModel } from '@/llm/init';
@@ -1266,6 +1270,7 @@ export class Run<_T extends t.BaseGraphState> {
       recursionLimit,
       configurable: { ...callerConfig.configurable },
     };
+    delete config.configurable?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
     if (!isResume) {
       delete config.configurable?.[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
       delete config.configurable?.[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
@@ -1276,6 +1281,16 @@ export class Run<_T extends t.BaseGraphState> {
         config,
         (inputs as Command).update
       );
+      const publicPayload = stripSubagentResumeManifest(
+        stripRunStepResumeState(this._interrupt?.payload)
+      );
+      const reviewEvidence = createToolApprovalReviewEvidence(
+        this._interrupt?.interruptId,
+        publicPayload
+      );
+      if (reviewEvidence != null && config.configurable != null) {
+        config.configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = reviewEvidence;
+      }
       if (graph.getStopContinuationExecutionId() === '') {
         graph.startStopContinuationExecution(nanoid());
         overwriteLegacyResumeState = this.hasCheckpointer;
@@ -2008,11 +2023,22 @@ export class Run<_T extends t.BaseGraphState> {
       stripRunStepResumeState(interrupt?.payload)
     );
     const resumeConfigurable = { ...callerConfig.configurable };
+    delete resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
     delete resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY];
     delete resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY];
     resumeConfigurable[SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY] = nanoid();
     if (resumeManifest != null) {
       resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] = resumeManifest;
+    }
+    const publicPayload = stripSubagentResumeManifest(
+      stripRunStepResumeState(interrupt?.payload)
+    );
+    const reviewEvidence = createToolApprovalReviewEvidence(
+      interrupt?.interruptId,
+      publicPayload
+    );
+    if (reviewEvidence != null) {
+      resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = reviewEvidence;
     }
     const manifestConfig = {
       ...callerConfig,

--- a/src/specs/ask-user-question-batch.test.ts
+++ b/src/specs/ask-user-question-batch.test.ts
@@ -27,10 +27,11 @@ import { ToolNode } from '@/tools/ToolNode';
  * When such a tool shares a tool-call batch with a NON-idempotent
  * sibling (send_email, billing), LangGraph's resume contract — re-run
  * the whole interrupted node from the top — would otherwise execute the
- * sibling once on the first pass and AGAIN on resume, duplicating the
- * side effect. Declaring the interrupter in `interruptingToolNames`
- * schedules it ahead of its siblings, so the batch unwinds before any
- * sibling runs and the sibling executes exactly once (on resume).
+ * sibling before the pause. Settled-result replay prevents a second
+ * execution on resume, while declaring the interrupter in
+ * `interruptingToolNames` provides the stronger ordering guarantee: the
+ * batch unwinds before any sibling runs and the sibling executes only after
+ * resume.
  *
  * Runs entirely in-memory (StateGraph + MemorySaver) — no LLM, no Run
  * machinery — so it exercises the ToolNode batch-execution change
@@ -141,8 +142,8 @@ describe('ask_user_question batched with a sibling tool', () => {
     }
   });
 
-  describe('baseline (no guard) — documents the defect the guard closes', () => {
-    it('double-executes an unguarded direct sibling on resume', async () => {
+  describe('baseline (no guard) — replay-safe without deferred ordering', () => {
+    it('reuses an unguarded direct sibling that settled before resume', async () => {
       const sideEffect = jest.fn(() => 'EXECUTED');
       const node = new ToolNode({
         tools: [makeAskTool(), makeSideEffectTool(sideEffect)],
@@ -160,8 +161,8 @@ describe('ask_user_question batched with a sibling tool', () => {
       expect(sideEffect).toHaveBeenCalledTimes(1);
 
       await graph.invoke(new Command({ resume: { answer: 'yes' } }), config);
-      // LangGraph re-runs the batch → the side effect fires a SECOND time.
-      expect(sideEffect).toHaveBeenCalledTimes(2);
+      // LangGraph re-runs the batch, but ToolNode reuses the settled result.
+      expect(sideEffect).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/specs/tool-error-resume.test.ts
+++ b/src/specs/tool-error-resume.test.ts
@@ -133,7 +133,7 @@ describe('Direct tool schema error across interrupt/resume', () => {
     return run;
   }
 
-  test('error completion dispatches exactly once; resume-pass handler reports false instead of throwing', async () => {
+  test('error completion dispatches exactly once; a rebuilt run restores the settled error', async () => {
     const saver = new MemorySaver();
     const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const staticSpy = jest.spyOn(StandardGraph, 'handleToolCallErrorStatic');
@@ -159,22 +159,18 @@ describe('Direct tool schema error across interrupt/resume', () => {
         'did not match expected schema'
       );
 
-      /** Pass 2: fresh instance (host restart shape), resume with the
-       *  answer. The batch re-executes; the strict tool fails again before
-       *  any run step is registered on the rebuilt graph. */
+      /** Pass 2: reconstruct the runtime and restore the checkpointed error
+       * rather than executing the already-settled lifecycle again. */
       const run2 = await buildRun(saver, 'run-pass-2');
       await run2.processStream(
         new Command({ resume: { answer: 'blue' } }) as unknown as t.IState,
         threadConfig
       );
 
-      /** The handler reported "not dispatched" (no run step yet) rather than
-       *  throwing — so nothing was logged and no duplicate completion event
-       *  reached the client. */
       const resumeResults = await Promise.all(
         staticSpy.mock.results.map((r) => r.value as Promise<boolean>)
       );
-      expect(resumeResults).toContain(false);
+      expect(resumeResults).toEqual([true]);
       const handlerFailures = errorSpy.mock.calls.filter((args) =>
         String(args[0]).includes('Error in errorHandler')
       );

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -124,6 +124,7 @@ import {
   getToolBatchReplayScope,
   attachToolBatchReplayState,
   restoreToolBatchReplayState,
+  getToolBatchReplayState,
 } from '@/tools/toolBatchReplay';
 
 function stripToolApprovalReviewConfig(
@@ -898,12 +899,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           this.executingAgentId ?? this.agentId ?? ''
         );
         const restoredBatches = await restoreToolBatchReplayState(config, replayOwner);
-        for (const { batch, results } of restoredBatches) {
+        if (activeReplayKey != null && getToolBatchReplayState(config.configurable) != null) {
+          this.settledDirectResultsByBatch.delete(activeReplayKey);
+        }
+        for (const { batch, results, turnState } of restoredBatches) {
           if (batch !== activeReplayKey) {
             continue;
           }
-          if (!this.settledDirectResultsByBatch.has(batch)) {
-            this.settledDirectResultsByBatch.set(batch, new Map(results));
+          this.settledDirectResultsByBatch.set(batch, new Map(results));
+          if (turnState != null) {
+            this.restoreSubagentResumeState(turnState);
           }
         }
         const state = input as T & Pick<t.BaseGraphState, 'runStepState'>;
@@ -917,15 +922,19 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           }
           const resumeState = createRunStepResumeState?.();
           const activeResults = activeReplayKey == null ? undefined : this.settledDirectResultsByBatch.get(activeReplayKey);
-          const activeBatches = activeReplayKey == null || activeResults == null
+          const activeBatches = activeReplayKey == null
             ? new Map<string, Map<string, SettledDirectToolResult>>()
-            : new Map([[activeReplayKey, activeResults]]);
+            : new Map([[activeReplayKey, activeResults ?? new Map<string, SettledDirectToolResult>()]]);
+          const turnState = this.createSubagentResumeState();
+          const activeCallIds = new Set(assistantBatch?.message.tool_calls?.map((call) => call.id));
+          turnState.directPathTurns = turnState.directPathTurns.filter(({ toolCallId }) => activeCallIds.has(toolCallId));
           throw new GraphInterrupt(
             await Promise.all(error.interrupts.map(async (pendingInterrupt) => {
               const value = await attachToolBatchReplayState(
                 pendingInterrupt.value,
                 replayOwner,
-                activeBatches
+                activeBatches,
+                turnState
               );
               return {
                 ...pendingInterrupt,
@@ -1600,6 +1609,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           }
           return next;
         })();
+      this.recordToolUsageTurn(call.name, usageCount, call.id);
+      if (batchContext.replayBatchKey != null && call.id != null && call.id !== '') {
+        this.directPathTurns.set(call.id, usageCount);
+      }
       let args = call.args;
       if (resolveFn != null) {
         const { resolved, unresolved } = resolveFn(runId, args);
@@ -4595,6 +4608,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       result: SettledDirectToolResult
     ): SettledDirectToolResult => {
       baseContext.additionalContextsSink?.push(...result.additionalContexts);
+      const turn = result.turn;
+      if (turn != null) {
+        this.recordToolUsageTurn(call.name, turn, call.id);
+      }
       const refMeta = isBaseMessage(result.output) ? result.output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
       if (refMeta?._refKey != null && result.referenceContent != null) {
         this.toolOutputRegistry?.set(baseContext.batchScopeId, refMeta._refKey, result.referenceContent);
@@ -4617,8 +4634,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? settledBatchResults?.get(call.id)
           : undefined;
       if (cachedResult != null) {
-        if (cachedResult.proposal != null && (cachedResult.proposal.name !== call.name ||
-          !recordArgsEqual(cachedResult.proposal.args, call.args as Record<string, unknown>))) {
+        if (cachedResult.proposal.name !== call.name ||
+          !recordArgsEqual(cachedResult.proposal.args, call.args as Record<string, unknown>)) {
           throw new Error('Cannot change an already completed tool call during approval replay');
         }
         return restoreResult(call, cachedResult);
@@ -4635,6 +4652,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           : baseContext.resolvedArgsByCallId?.get(call.id);
       const result: SettledDirectToolResult = {
         proposal: structuredClone({ name: call.name, args: call.args as Record<string, unknown> }),
+        turn: call.id == null ? undefined : this.toolCallTurns.get(call.id) ?? this.directPathTurns.get(call.id),
         output,
         additionalContexts,
         ...(resolvedArgs == null ? {} : { resolvedArgs }),

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -890,7 +890,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const messages = Array.isArray(input) ? input as BaseMessage[] :
           (input as { messages?: BaseMessage[] }).messages;
         const assistantBatch = messages == null ? undefined : findAssistantBatch(messages);
-        const activeReplayKey = assistantBatch == null ? undefined : getAssistantBatchReplayKey(
+        const activeReplayKey = assistantBatch == null || getToolBatchReplayScope(config) == null ? undefined : getAssistantBatchReplayKey(
           assistantBatch, getToolBatchReplayScope(config)
         );
         const replayOwner = getToolBatchReplayOwner(
@@ -4895,7 +4895,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ? findAssistantBatch(sendMessages as BaseMessage[])
         : undefined;
       const sendReplayBatchKey =
-        sendAssistantBatch == null
+        sendAssistantBatch == null || getToolBatchReplayScope(config) == null
           ? undefined
           : getAssistantBatchReplayKey(
             sendAssistantBatch,
@@ -4962,7 +4962,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         throw new Error('ToolNode only accepts AIMessages as input.');
       }
       const aiMessage = assistantBatch.message;
-      replayBatchKey = getAssistantBatchReplayKey(
+      replayBatchKey = getToolBatchReplayScope(config) == null ? undefined : getAssistantBatchReplayKey(
         assistantBatch,
         getToolBatchReplayScope(config)
       );
@@ -5195,7 +5195,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             : [];
 
         const settledDirectResults =
-          this.settledDirectResultsByBatch.get(replayBatchKey);
+          replayBatchKey == null ? undefined : this.settledDirectResultsByBatch.get(replayBatchKey);
         const unhandledDirectCalls: ToolCall[] = [];
         const unhandledDirectOutputs: (BaseMessage | Command)[] = [];
         for (let i = 0; i < directCalls.length; i++) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1334,11 +1334,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     runInput?: RunToolBatchContext<T>['runInput']
   ): Promise<unknown> {
     const lgConfig = config as LangGraphRunnableConfig;
+    const isTrustedSubagentHop =
+      call.name === Constants.SUBAGENT &&
+      (tool as ReplayableSubagentTool)[SUBAGENT_REPLAY_CONTROLLER] != null;
     const toolConfig: RunnableConfig = {
       ...config,
-      configurable: stripToolApprovalReviewConfig(
-        config.configurable as Record<string, unknown> | undefined
-      ),
+      configurable: isTrustedSubagentHop
+        ? config.configurable
+        : stripToolApprovalReviewConfig(
+          config.configurable as Record<string, unknown> | undefined
+        ),
     };
     const runtime: ToolRuntime<T> = {
       ...toolConfig,
@@ -2067,12 +2072,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
 
     if (
-      hookRegistry == null ||
-      (!hasPreHook &&
-        pendingApproval == null &&
-        reviewedApproval == null &&
-        !hasPostHook &&
-        !hasFailureHook)
+      !hasPreHook &&
+      pendingApproval == null &&
+      reviewedApproval == null &&
+      !hasPostHook &&
+      !hasFailureHook
     ) {
       const output = await this.runTool(call, replayConfig, batchContext);
       return output instanceof ToolMessage ? persistOutput(output) : output;
@@ -2146,25 +2150,32 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     let effectiveCall = call;
     if (hasPreHook || pendingApproval != null || reviewedApproval != null) {
-      const preResult = await executeHooks({
-        registry: hookRegistry,
-        input: {
-          hook_event_name: 'PreToolUse',
-          runId,
-          threadId,
-          agentId: this.agentId,
-          executingAgentId: this.executingAgentId,
-          toolName: call.name,
-          toolInput: resolvedArgs,
-          toolUseId: call.id ?? '',
-          stepId,
-          turn,
-        },
-        sessionId: runId,
-        matchQuery: call.name,
-        onceReplayKey: approvalReplayKey,
-        onceReplaySessionId: approvalReplaySessionId,
-      }).catch(() => undefined);
+      const preResult: AggregatedHookResult | undefined =
+        hookRegistry == null
+          ? {
+            additionalContexts: [],
+            injectedMessages: [],
+            errors: [],
+          }
+          : await executeHooks({
+            registry: hookRegistry,
+            input: {
+              hook_event_name: 'PreToolUse',
+              runId,
+              threadId,
+              agentId: this.agentId,
+              executingAgentId: this.executingAgentId,
+              toolName: call.name,
+              toolInput: resolvedArgs,
+              toolUseId: call.id ?? '',
+              stepId,
+              turn,
+            },
+            sessionId: runId,
+            matchQuery: call.name,
+            onceReplayKey: approvalReplayKey,
+            onceReplaySessionId: approvalReplaySessionId,
+          }).catch(() => undefined);
 
       if (preResult != null) {
         // Forward any additionalContext strings hooks returned into
@@ -2278,7 +2289,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 t.ToolApprovalDecision[] | t.ToolApprovalDecisionMap
               >(payload)
           );
-          hookRegistry.clearPendingToolApproval(
+          hookRegistry?.clearPendingToolApproval(
             approvalReplaySessionId,
             approvalReplayKey
           );
@@ -2611,12 +2622,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     call: ToolCall;
     resolvedArgs: Record<string, unknown>;
     reason: string;
-    hookRegistry: HookRegistry;
+    hookRegistry: HookRegistry | undefined;
     runId: string;
     threadId: string | undefined;
   }): ToolMessage {
     const { call, resolvedArgs, reason, hookRegistry, runId, threadId } = args;
-    if (hookRegistry.hasHookFor('PermissionDenied', runId) === true) {
+    if (hookRegistry?.hasHookFor('PermissionDenied', runId) === true) {
       executeHooks({
         registry: hookRegistry,
         input: {
@@ -3063,10 +3074,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ) != null
     );
     if (
-      hookRegistry != null &&
-      (hookRegistry.hasHookFor('PreToolUse', runId) ||
-        hasPendingApproval ||
-        approvalReviewEvidence != null)
+      hookRegistry?.hasHookFor('PreToolUse', runId) === true ||
+      hasPendingApproval ||
+      approvalReviewEvidence != null
     ) {
       /**
        * Pull each call's prestarted eager record BEFORE awaiting the hooks:
@@ -3094,38 +3104,41 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           }
         }
       }
-      const preResults = await Promise.all(
-        preToolCalls.map((entry) => {
-          const toolUseId = entry.call.id;
-          const approvalReplayKey =
-            toolUseId == null
-              ? undefined
-              : createToolApprovalReplayKey(
-                config,
-                this.executingAgentId ?? this.agentId ?? '',
-                toolUseId
-              );
-          return executeHooks({
-            registry: hookRegistry,
-            input: {
-              hook_event_name: 'PreToolUse',
-              runId,
-              threadId,
-              agentId: this.agentId,
-              executingAgentId: this.executingAgentId,
-              toolName: entry.call.name,
-              toolInput: entry.args,
-              toolUseId: entry.call.id!,
-              stepId: entry.stepId,
-              turn: this.toolUsageCount.get(entry.call.name) ?? 0,
-            },
-            sessionId: runId,
-            matchQuery: entry.call.name,
-            onceReplayKey: approvalReplayKey,
-            onceReplaySessionId: approvalReplaySessionId,
-          }).catch((): AggregatedHookResult => HOOK_FALLBACK);
-        })
-      );
+      const preResults =
+        hookRegistry == null
+          ? preToolCalls.map(() => HOOK_FALLBACK)
+          : await Promise.all(
+            preToolCalls.map((entry) => {
+              const toolUseId = entry.call.id;
+              const approvalReplayKey =
+                toolUseId == null
+                  ? undefined
+                  : createToolApprovalReplayKey(
+                    config,
+                    this.executingAgentId ?? this.agentId ?? '',
+                    toolUseId
+                  );
+              return executeHooks({
+                registry: hookRegistry,
+                input: {
+                  hook_event_name: 'PreToolUse',
+                  runId,
+                  threadId,
+                  agentId: this.agentId,
+                  executingAgentId: this.executingAgentId,
+                  toolName: entry.call.name,
+                  toolInput: entry.args,
+                  toolUseId: entry.call.id!,
+                  stepId: entry.stepId,
+                  turn: this.toolUsageCount.get(entry.call.name) ?? 0,
+                },
+                sessionId: runId,
+                matchQuery: entry.call.name,
+                onceReplayKey: approvalReplayKey,
+                onceReplaySessionId: approvalReplaySessionId,
+              }).catch((): AggregatedHookResult => HOOK_FALLBACK);
+            })
+          );
 
       type PendingEntry = (typeof preToolCalls)[number];
 
@@ -3206,7 +3219,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             item.contentString,
             config
           );
-          if (hookRegistry.hasHookFor('PermissionDenied', runId)) {
+          if (
+            hookRegistry?.hasHookFor('PermissionDenied', runId) === true
+          ) {
             executeHooks({
               registry: hookRegistry,
               input: {
@@ -3384,7 +3399,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
 
         for (const { entry } of askEntries) {
-          hookRegistry.clearPendingToolApproval(
+          hookRegistry?.clearPendingToolApproval(
             approvalReplaySessionId,
             createToolApprovalReplayKey(
               config,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -128,6 +128,7 @@ import {
   attachToolBatchReplayState,
   restoreToolBatchReplayState,
   getToolBatchReplayState,
+  isChildToolApprovalOwner,
 } from '@/tools/toolBatchReplay';
 
 function stripToolApprovalReviewConfig(
@@ -250,6 +251,8 @@ type RunToolBatchContext<T = unknown> = {
   additionalContextsSink?: string[];
   /** Stable identity of the assistant tool-call batch across HITL replay. */
   replayBatchKey?: string;
+  /** Positions in the original proposal, before completed calls are filtered. */
+  replayCallPositions?: ReadonlyMap<ToolCall, number>;
   /** Tool-call identities owned by this ToolNode invocation. */
   approvalScopeCallIds?: ReadonlySet<string>;
   /**
@@ -280,6 +283,13 @@ function withSubagentReplayBatch(
 }
 
 type SettledDirectToolResult = SettledToolBatchResult;
+
+/** Positional identity is safe within the immutable full-proposal batch key. */
+function directReplayKey(call: ToolCall, batchIndex: number): string {
+  return call.id == null || call.id === ''
+    ? JSON.stringify(['position', batchIndex])
+    : JSON.stringify(['id', call.id]);
+}
 
 /**
  * Batch-local record of who owns each failed call's completion event.
@@ -900,10 +910,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         );
         const reviewEvidence = getToolApprovalReviewEvidence(config);
         if (reviewEvidence?.owner != null && reviewEvidence.owner !== replayOwner) {
-          const reviewedIds = new Set(reviewEvidence.payload.action_requests.map((request) => request.tool_call_id));
           const calls = this.isSendInput(input) ? [input.lg_tool_call] : assistantBatch?.message.tool_calls ?? [];
-          const ownsReviewedCall = calls.some((call) => reviewedIds.has(call.id ?? ''));
-          if (ownsReviewedCall) {
+          const trustedParentCallIds = new Set(calls.filter((call) =>
+            call.name === Constants.SUBAGENT &&
+            (this.toolMap.get(call.name) as ReplayableSubagentTool | undefined)?.[SUBAGENT_REPLAY_CONTROLLER] != null
+          ).map((call) => call.id ?? ''));
+          const ownsParentBatch = getToolBatchReplayState(config.configurable)?.records.some(
+            (record) => record.owner === replayOwner && record.batch === activeReplayKey
+          ) === true;
+          if (!ownsParentBatch || !isChildToolApprovalOwner(config, reviewEvidence.owner, trustedParentCallIds)) {
             throw new Error('Tool approval execution owner changed before resume — failing closed');
           }
         }
@@ -3135,11 +3150,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           unresolvedByCallId.set(call.id, pre.unresolved);
         }
       } else if (registry != null) {
-        const { resolved, unresolved } = registry.resolve(
-          registryRunId,
-          originalArgs,
-          { substituteIntentKey: this.toolDeclaresBusinessIntent(call.name) }
-        );
+        const options = { substituteIntentKey: this.toolDeclaresBusinessIntent(call.name) };
+        const { resolved, unresolved } = preBatchSnapshot != null
+          ? preBatchSnapshot.resolve(originalArgs, options)
+          : registry.resolve(registryRunId, originalArgs, options);
         resolvedArgs = resolved as Record<string, unknown>;
         if (unresolved.length > 0 && call.id != null) {
           unresolvedByCallId.set(call.id, unresolved);
@@ -4602,17 +4616,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           new Map<string, SettledDirectToolResult>());
     const cacheResult = (
       call: ToolCall,
+      position: number,
       result: SettledDirectToolResult
     ): void => {
       if (
         baseContext.replayBatchKey == null ||
-        call.id == null ||
-        call.id === '' ||
         settledBatchResults == null
       ) {
         return;
       }
-      settledBatchResults.set(call.id, result);
+      settledBatchResults.set(directReplayKey(call, baseContext.replayCallPositions?.get(call) ?? batchIndices[position]), result);
       this.settledDirectResultsByBatch.set(
         baseContext.replayBatchKey,
         settledBatchResults
@@ -4650,10 +4663,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       call: ToolCall,
       position: number
     ): Promise<SettledDirectToolResult> => {
-      const cachedResult =
-        typeof call.id === 'string'
-          ? settledBatchResults?.get(call.id)
-          : undefined;
+      const cachedResult = settledBatchResults?.get(directReplayKey(call, baseContext.replayCallPositions?.get(call) ?? batchIndices[position]));
       if (cachedResult != null) {
         if (cachedResult.proposal.name !== call.name ||
           !recordArgsEqual(cachedResult.proposal.args, call.args as Record<string, unknown>)) {
@@ -4682,7 +4692,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (refMeta?._refKey != null) {
         result.referenceContent = this.toolOutputRegistry?.get(refMeta._refScope, refMeta._refKey);
       }
-      cacheResult(call, result);
+      cacheResult(call, position, result);
       return restoreResult(call, result);
     };
 
@@ -4899,11 +4909,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      */
     const incomingRunId = config.configurable?.run_id as string | undefined;
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
-    if (referenceReplay.state != null) {
-      this.toolOutputRegistry?.restoreState(batchScopeId, referenceReplay.state);
-    }
-    referenceReplay.state = this.toolOutputRegistry?.snapshotState(batchScopeId);
-    const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
+    const resumedReferenceState = referenceReplay.state;
+    const replayInputSnapshot = resumedReferenceState == null ? undefined :
+      this.toolOutputRegistry?.resumeBatch(batchScopeId, resumedReferenceState);
+    referenceReplay.state = resumedReferenceState ?? this.toolOutputRegistry?.snapshotState(batchScopeId);
+    const turn = resumedReferenceState?.turnCounter ?? this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
     let replayBatchKey: string | undefined;
     /** Hoisted from the messages-state branch so the Command tail can carry
@@ -4921,6 +4931,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           batchIndices: [0],
           turn,
           batchScopeId,
+          preBatchSnapshot: replayInputSnapshot,
         });
       }
       // Same per-batch sink the message-state branches use so
@@ -4951,6 +4962,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           batchIndex: 0,
           turn,
           batchScopeId,
+          preBatchSnapshot: replayInputSnapshot,
           resolvedArgsByCallId,
           errorOwnership,
           additionalContextsSink: directAdditionalContexts,
@@ -5019,6 +5031,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.applyToolExecutionOverrides();
       }
 
+      const replayCallPositions = new Map((aiMessage.tool_calls ?? []).map((call, i) => [call, i]));
       const filteredCalls =
         aiMessage.tool_calls?.filter((call) => {
           /**
@@ -5028,7 +5041,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
            *    which are executed by the provider's API and don't require invocation
            */
           return (
-            (call.id == null || !toolMessageIds.has(call.id)) &&
+            (call.id == null || call.id === '' || !toolMessageIds.has(call.id)) &&
             !(
               call.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ??
               false
@@ -5156,6 +5169,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             batchIndices: eventEntries.map((entry) => entry.batchIndex),
             turn,
             batchScopeId,
+            preBatchSnapshot: replayInputSnapshot,
           });
         }
 
@@ -5192,7 +5206,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
          * same-turn direct outputs.
          */
         const preBatchSnapshot =
-          this.toolOutputRegistry?.snapshot(batchScopeId);
+          replayInputSnapshot ?? this.toolOutputRegistry?.snapshot(batchScopeId);
         if (preBatchSnapshot != null) {
           for (const entry of eventEntries) {
             if (entry.call.id != null) {
@@ -5231,6 +5245,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 preBatchSnapshot,
                 additionalContextsSink: directAdditionalContexts,
                 replayBatchKey,
+                replayCallPositions,
                 approvalScopeCallIds,
                 runInput: input as T,
               }
@@ -5242,9 +5257,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const unhandledDirectCalls: ToolCall[] = [];
         const unhandledDirectOutputs: (BaseMessage | Command)[] = [];
         for (let i = 0; i < directCalls.length; i++) {
-          const callId = directCalls[i].id;
-          const settled =
-            callId == null ? undefined : settledDirectResults?.get(callId);
+          const settled = settledDirectResults?.get(directReplayKey(directCalls[i], replayCallPositions.get(directCalls[i])!));
           if (settled?.completionHandled === true) {
             continue;
           }
@@ -5260,11 +5273,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             resolvedArgsByCallId,
             errorOwnership
           );
-          for (const call of unhandledDirectCalls) {
-            if (call.id == null) {
-              continue;
-            }
-            const settled = settledDirectResults?.get(call.id);
+          for (let i = 0; i < directCalls.length; i++) {
+            const settled = settledDirectResults?.get(directReplayKey(directCalls[i], replayCallPositions.get(directCalls[i])!));
             if (settled != null) {
               settled.completionHandled = true;
             }
@@ -5317,7 +5327,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // leak a sibling's just-registered output into a sister
         // call's args mid-await (Codex P1 #18).
         const preBatchSnapshot =
-          this.toolOutputRegistry?.snapshot(batchScopeId);
+          replayInputSnapshot ?? this.toolOutputRegistry?.snapshot(batchScopeId);
         const directAdditionalContexts: string[] = [];
         const approvalScopeCallIds = new Set(
           filteredCalls.flatMap((call) => (call.id == null ? [] : [call.id]))
@@ -5334,6 +5344,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             preBatchSnapshot,
             additionalContextsSink: directAdditionalContexts,
             replayBatchKey,
+            replayCallPositions,
             approvalScopeCallIds,
             runInput: input as T,
           }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -127,10 +127,7 @@ function stripToolApprovalReviewConfig(
   ) {
     return configurable;
   }
-  const {
-    [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: _review,
-    ...rest
-  } = configurable;
+  const { [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: _review, ...rest } = configurable;
   return rest;
 }
 
@@ -267,6 +264,7 @@ type SettledDirectToolResult = {
   output: BaseMessage | Command;
   additionalContexts: string[];
   resolvedArgs?: Record<string, unknown>;
+  completionHandled?: boolean;
 };
 
 /**
@@ -724,10 +722,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * the Run ends.
    */
   private directPathTurns: Map<string, number> = new Map();
-  /** Terminal results from interrupting siblings that must survive a
-   * LangGraph replay of the containing ToolNode. Includes the sidecar data
-   * the fresh batch needs for hook-context injection and completion events. */
-  private settledInterruptingResults = new Map<
+  /** Terminal direct results that must survive a LangGraph replay of the
+   * containing ToolNode. Includes the sidecar data the fresh batch needs for
+   * hook-context injection and completion-event deduplication. */
+  private settledDirectResultsByBatch = new Map<
     string,
     Map<string, SettledDirectToolResult>
   >();
@@ -1173,14 +1171,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    */
   clearDirectPathTurns(): void {
     this.directPathTurns.clear();
-    this.settledInterruptingResults.clear();
+    this.settledDirectResultsByBatch.clear();
   }
 
   /** Returns the live caller projection used by direct and event execution. */
   private getCallerCapabilityProjection(): CallerCapabilityProjection {
-    const discoveredToolNames = new Set(
-      this.getDiscoveredToolNames?.() ?? []
-    );
+    const discoveredToolNames = new Set(this.getDiscoveredToolNames?.() ?? []);
     return resolveCallerCapabilityProjection(
       mergeCallerCapabilityDefinitions(
         this.toolDefinitions?.values(),
@@ -1221,9 +1217,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private getProgrammaticTools(): t.ProgrammaticCache {
     const toolMap: t.ToolMap = new Map();
     const toolDefs: t.LCTool[] = [];
-    const discoveredToolNames = new Set(
-      this.getDiscoveredToolNames?.() ?? []
-    );
+    const discoveredToolNames = new Set(this.getDiscoveredToolNames?.() ?? []);
     const executableCapabilities = resolveCallerCapabilityProjection(
       this.toolRegistry?.values() ?? [],
       (toolDef) => isToolDefinitionActive(toolDef, discoveredToolNames)
@@ -1342,7 +1336,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       configurable: isTrustedSubagentHop
         ? config.configurable
         : stripToolApprovalReviewConfig(
-          config.configurable as Record<string, unknown> | undefined
+            config.configurable as Record<string, unknown> | undefined
         ),
     };
     const runtime: ToolRuntime<T> = {
@@ -1953,13 +1947,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     batchContext: RunToolBatchContext<T> = {}
   ): Promise<BaseMessage | Command> {
     if (
-      this.preparedSubagents?.owns(this.executingAgentId ?? '', call) === true &&
+      this.preparedSubagents?.owns(this.executingAgentId ?? '', call) ===
+        true &&
       this.hookRegistry?.hasResultAlteringHooks(
         (config.configurable?.run_id as string | undefined) ?? ''
       ) === true
     ) {
       this.preparedSubagents.clear();
-      throw new PreparedSubagentError('Tool hooks changed after a subagent started.');
+      throw new PreparedSubagentError(
+        'Tool hooks changed after a subagent started.'
+      );
     }
     const replayController = (
       this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
@@ -2151,12 +2148,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       return args;
     };
-    /** Review evidence contains the exact resolved arguments shown to the
-     * user. Reuse those on resume so a rebuilt registry cannot turn an
-     * approved `{{tool…}}` value into an unresolved or different input. */
+    const originalResolvedArgs = resolveDirectArgs(
+      call.args as Record<string, unknown>
+    );
+    /** Reusable and pending hooks must replay from the original proposal so
+     * non-idempotent rewrites are applied exactly once. A rebuilt runtime
+     * without that policy instead falls back to the resolved arguments the
+     * user actually reviewed. */
     let resolvedArgs =
-      reviewedApproval?.request.arguments ??
-      resolveDirectArgs(call.args as Record<string, unknown>);
+      hasPreHook || pendingApproval != null
+        ? originalResolvedArgs
+        : (reviewedApproval?.request.arguments ?? originalResolvedArgs);
 
     let effectiveCall = call;
     if (
@@ -2210,6 +2212,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           resolvedArgs = resolveDirectArgs(
             preResult.updatedInput as Record<string, unknown>
           );
+          effectiveCall = {
+            ...call,
+            args: resolvedArgs,
+          };
+        } else if (reviewedApproval != null) {
+          resolvedArgs = reviewedApproval.request.arguments;
           effectiveCall = {
             ...call,
             args: resolvedArgs,
@@ -3001,7 +3009,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const signal = config.signal;
     if (
       signal?.aborted === true &&
-      (signal.reason instanceof StreamLimitExceededError || signal.reason instanceof PreparedSubagentError)
+      (signal.reason instanceof StreamLimitExceededError ||
+        signal.reason instanceof PreparedSubagentError)
     ) {
       throw signal.reason;
     }
@@ -3155,13 +3164,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             preToolCalls.map((entry) => {
               const toolUseId = entry.call.id;
               const approvalReplayKey =
-                toolUseId == null
-                  ? undefined
-                  : createToolApprovalReplayKey(
-                    config,
-                    this.executingAgentId ?? this.agentId ?? '',
-                    toolUseId
-                  );
+                  toolUseId == null
+                    ? undefined
+                    : createToolApprovalReplayKey(
+                      config,
+                      this.executingAgentId ?? this.agentId ?? '',
+                      toolUseId
+                    );
               return executeHooks({
                 registry: hookRegistry,
                 input: {
@@ -3263,9 +3272,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             item.contentString,
             config
           );
-          if (
-            hookRegistry?.hasHookFor('PermissionDenied', runId) === true
-          ) {
+          if (hookRegistry?.hasHookFor('PermissionDenied', runId) === true) {
             executeHooks({
               registry: hookRegistry,
               input: {
@@ -3839,9 +3846,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               // match it at the top level too.
               agentId: this.executingAgentId,
               callerCapabilityProjection:
-                this.getCallerCapabilityProjectionSnapshot(),
+                  this.getCallerCapabilityProjectionSnapshot(),
               configurable: stripHostExecutionConfig(
-                config.configurable as Record<string, unknown> | undefined
+                  config.configurable as Record<string, unknown> | undefined
               ),
               metadata: config.metadata as
                   | Record<string, unknown>
@@ -4499,7 +4506,26 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const settledBatchResults =
       baseContext.replayBatchKey == null
         ? undefined
-        : this.settledInterruptingResults.get(baseContext.replayBatchKey);
+        : (this.settledDirectResultsByBatch.get(baseContext.replayBatchKey) ??
+          new Map<string, SettledDirectToolResult>());
+    const cacheResult = (
+      call: ToolCall,
+      result: SettledDirectToolResult
+    ): void => {
+      if (
+        baseContext.replayBatchKey == null ||
+        call.id == null ||
+        call.id === '' ||
+        settledBatchResults == null
+      ) {
+        return;
+      }
+      settledBatchResults.set(call.id, result);
+      this.settledDirectResultsByBatch.set(
+        baseContext.replayBatchKey,
+        settledBatchResults
+      );
+    };
     const restoreResult = (
       call: ToolCall,
       result: SettledDirectToolResult
@@ -4535,11 +4561,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         call.id == null
           ? undefined
           : baseContext.resolvedArgsByCallId?.get(call.id);
-      return restoreResult(call, {
+      const result: SettledDirectToolResult = {
         output,
         additionalContexts,
         ...(resolvedArgs == null ? {} : { resolvedArgs }),
-      });
+      };
+      cacheResult(call, result);
+      return restoreResult(call, result);
     };
 
     const interrupting = this.interruptingToolNames;
@@ -4588,21 +4616,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       const position = interruptingPositions[i];
       outputs[position] = result.value.output;
-      const callId = directCalls[position].id;
-      if (
-        baseContext.replayBatchKey != null &&
-        typeof callId === 'string' &&
-        callId !== ''
-      ) {
-        const batchResults =
-          this.settledInterruptingResults.get(baseContext.replayBatchKey) ??
-          new Map<string, SettledDirectToolResult>();
-        batchResults.set(callId, result.value);
-        this.settledInterruptingResults.set(
-          baseContext.replayBatchKey,
-          batchResults
-        );
-      }
     }
     if (hasInterruptingError) {
       if (isGraphInterrupt(interruptingError)) {
@@ -4732,7 +4745,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * otherwise perform side effects on a failed run. */
     if (
       composedSignal?.aborted === true &&
-      (composedSignal.reason instanceof StreamLimitExceededError || composedSignal.reason instanceof PreparedSubagentError)
+      (composedSignal.reason instanceof StreamLimitExceededError ||
+        composedSignal.reason instanceof PreparedSubagentError)
     ) {
       throw composedSignal.reason;
     }
@@ -5093,14 +5107,38 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             )
             : [];
 
-        if (directCalls.length > 0 && directOutputs.length > 0) {
+        const settledDirectResults =
+          this.settledDirectResultsByBatch.get(replayBatchKey);
+        const unhandledDirectCalls: ToolCall[] = [];
+        const unhandledDirectOutputs: (BaseMessage | Command)[] = [];
+        for (let i = 0; i < directCalls.length; i++) {
+          const callId = directCalls[i].id;
+          const settled =
+            callId == null ? undefined : settledDirectResults?.get(callId);
+          if (settled?.completionHandled === true) {
+            continue;
+          }
+          unhandledDirectCalls.push(directCalls[i]);
+          unhandledDirectOutputs.push(directOutputs[i]);
+        }
+
+        if (unhandledDirectCalls.length > 0) {
           await this.handleRunToolCompletions(
-            directCalls,
-            directOutputs,
+            unhandledDirectCalls,
+            unhandledDirectOutputs,
             config,
             resolvedArgsByCallId,
             errorOwnership
           );
+          for (const call of unhandledDirectCalls) {
+            if (call.id == null) {
+              continue;
+            }
+            const settled = settledDirectResults?.get(call.id);
+            if (settled != null) {
+              settled.completionHandled = true;
+            }
+          }
         }
 
         const eventResult =
@@ -5222,7 +5260,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     if (!outputs.some(isCommand)) {
       if (replayBatchKey != null) {
-        this.settledInterruptingResults.delete(replayBatchKey);
+        this.settledDirectResultsByBatch.delete(replayBatchKey);
       }
       return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
     }
@@ -5365,7 +5403,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
 
     if (replayBatchKey != null) {
-      this.settledInterruptingResults.delete(replayBatchKey);
+      this.settledDirectResultsByBatch.delete(replayBatchKey);
     }
     return combinedOutputs as T;
   }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1964,6 +1964,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const replayController = (
       this.toolMap.get(call.name) as ReplayableSubagentTool | undefined
     )?.[SUBAGENT_REPLAY_CONTROLLER];
+    const isTrustedSubagentReviewHop =
+      call.name === Constants.SUBAGENT && replayController != null;
     const replayConfig =
       replayController == null
         ? config
@@ -2075,6 +2077,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       !hasPreHook &&
       pendingApproval == null &&
       reviewedApproval == null &&
+      approvalReviewEvidence == null &&
       !hasPostHook &&
       !hasFailureHook
     ) {
@@ -2129,27 +2132,39 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // value the PreToolUse hook observes matches the value the
     // (later-awaited) `runTool` will actually run with — both are
     // anchored to the pre-batch registry state.
-    let resolvedArgs = call.args as Record<string, unknown>;
     const hookResolveOptions = {
       substituteIntentKey: this.toolDeclaresBusinessIntent(call.name),
     };
-    if (batchContext.preBatchSnapshot != null) {
-      const { resolved } = batchContext.preBatchSnapshot.resolve(
-        call.args,
-        hookResolveOptions
-      );
-      resolvedArgs = resolved as Record<string, unknown>;
-    } else if (this.toolOutputRegistry != null) {
-      const { resolved } = this.toolOutputRegistry.resolve(
-        registryRunId,
-        call.args,
-        hookResolveOptions
-      );
-      resolvedArgs = resolved as Record<string, unknown>;
-    }
+    const resolveDirectArgs = (
+      args: Record<string, unknown>
+    ): Record<string, unknown> => {
+      if (batchContext.preBatchSnapshot != null) {
+        return batchContext.preBatchSnapshot.resolve(args, hookResolveOptions)
+          .resolved as Record<string, unknown>;
+      }
+      if (this.toolOutputRegistry != null) {
+        return this.toolOutputRegistry.resolve(
+          registryRunId,
+          args,
+          hookResolveOptions
+        ).resolved as Record<string, unknown>;
+      }
+      return args;
+    };
+    /** Review evidence contains the exact resolved arguments shown to the
+     * user. Reuse those on resume so a rebuilt registry cannot turn an
+     * approved `{{tool…}}` value into an unresolved or different input. */
+    let resolvedArgs =
+      reviewedApproval?.request.arguments ??
+      resolveDirectArgs(call.args as Record<string, unknown>);
 
     let effectiveCall = call;
-    if (hasPreHook || pendingApproval != null || reviewedApproval != null) {
+    if (
+      hasPreHook ||
+      pendingApproval != null ||
+      reviewedApproval != null ||
+      approvalReviewEvidence != null
+    ) {
       const preResult: AggregatedHookResult | undefined =
         hookRegistry == null
           ? {
@@ -2192,9 +2207,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // a valid combination (one matcher sanitises args, another asks
         // for approval); the reviewer should see the sanitised args.
         if (preResult.updatedInput != null) {
+          resolvedArgs = resolveDirectArgs(
+            preResult.updatedInput as Record<string, unknown>
+          );
           effectiveCall = {
             ...call,
-            args: preResult.updatedInput as Record<string, unknown>,
+            args: resolvedArgs,
           };
         }
 
@@ -2209,6 +2227,29 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               threadId,
             }),
             effectiveCall.args as Record<string, unknown>
+          );
+        }
+
+        /** A sibling absent from restored evidence may have raised a parallel
+         * approval that LangGraph did not preserve. A current hook can ask
+         * again; otherwise never let that unreviewed sibling execute. */
+        if (
+          approvalReviewEvidence != null &&
+          reviewedApproval == null &&
+          !isTrustedSubagentReviewHop &&
+          preResult.decision !== 'ask'
+        ) {
+          return persistOutput(
+            this.blockDirectCall({
+              call,
+              resolvedArgs,
+              reason:
+                'Tool call was not included in the restored approval batch — failing closed',
+              hookRegistry,
+              runId,
+              threadId,
+            }),
+            resolvedArgs
           );
         }
 
@@ -2271,6 +2312,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             preResult.decision === 'ask'
               ? preResult.reason
               : reviewedApproval?.request.description;
+          if (effectiveCall === call) {
+            effectiveCall = { ...call, args: resolvedArgs };
+          }
           const askEntry: AskEntry = {
             entry: {
               call: effectiveCall,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -1,4 +1,5 @@
 import { nanoid } from 'nanoid';
+import { createHash } from 'crypto';
 import { ToolCall } from '@langchain/core/messages/tool';
 import { RunnableLambda } from '@langchain/core/runnables';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
@@ -31,6 +32,7 @@ import type { LangGraphRunnableConfig } from '@langchain/langgraph';
 import type { BaseMessage } from '@langchain/core/messages';
 import type {
   ToolOutputResolveView,
+  ToolOutputReferenceState,
   PreResolvedArgsMap,
   ResolvedArgsByCallId,
   ResolveResult,
@@ -81,6 +83,7 @@ import {
   coerceRecordArgs,
   resolveRuntimeSessionHint,
   recordArgsEqual,
+  stableStringify,
 } from '@/tools/eagerEventExecution';
 import {
   attachSubagentResumeManifest,
@@ -439,8 +442,6 @@ function describeOfferedShape(value: unknown): string {
 
 type AssistantBatch = {
   message: AIMessage;
-  index: number;
-  messageCount: number;
 };
 
 function findAssistantBatch(
@@ -449,7 +450,7 @@ function findAssistantBatch(
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (isAIMessage(message)) {
-      return { message, index: i, messageCount: messages.length };
+      return { message };
     }
   }
   return undefined;
@@ -461,9 +462,8 @@ function getAssistantBatchReplayKey(
 ): string {
   return JSON.stringify([
     threadId ?? null,
-    batch.message.id ?? null,
-    batch.index,
-    batch.messageCount,
+    batch.message.id == null || batch.message.id === '' ? null : batch.message.id,
+    createHash('sha256').update(stableStringify(batch.message.tool_calls ?? [])).digest('hex'),
   ]);
 }
 
@@ -898,11 +898,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           config,
           this.executingAgentId ?? this.agentId ?? ''
         );
+        const reviewEvidence = getToolApprovalReviewEvidence(config);
+        if (reviewEvidence?.owner != null && reviewEvidence.owner !== replayOwner) {
+          const reviewedIds = new Set(reviewEvidence.payload.action_requests.map((request) => request.tool_call_id));
+          const calls = this.isSendInput(input) ? [input.lg_tool_call] : assistantBatch?.message.tool_calls ?? [];
+          const ownsReviewedCall = calls.some((call) => reviewedIds.has(call.id ?? ''));
+          if (ownsReviewedCall) {
+            throw new Error('Tool approval execution owner changed before resume — failing closed');
+          }
+        }
+        const referenceReplay: { state?: ToolOutputReferenceState } = {};
         const restoredBatches = await restoreToolBatchReplayState(config, replayOwner);
+        if (restoredBatches.length > 0 && !restoredBatches.some(({ batch }) => batch === activeReplayKey)) {
+          throw new Error('Tool batch proposal changed before approval replay — failing closed');
+        }
         if (activeReplayKey != null && getToolBatchReplayState(config.configurable) != null) {
           this.settledDirectResultsByBatch.delete(activeReplayKey);
         }
-        for (const { batch, results, turnState } of restoredBatches) {
+        for (const { batch, results, turnState, referenceState } of restoredBatches) {
           if (batch !== activeReplayKey) {
             continue;
           }
@@ -910,12 +923,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           if (turnState != null) {
             this.restoreSubagentResumeState(turnState);
           }
+          referenceReplay.state = referenceState;
         }
         const state = input as T & Pick<t.BaseGraphState, 'runStepState'>;
         restoreRunStepResumeState?.(state.runStepState, config);
         let result: T;
         try {
-          result = await this.run(input, config);
+          result = await this.run(input, config, referenceReplay);
         } catch (error) {
           if (!isGraphInterrupt(error)) {
             throw error;
@@ -934,7 +948,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 pendingInterrupt.value,
                 replayOwner,
                 activeBatches,
-                turnState
+                turnState,
+                referenceReplay.state
               );
               return {
                 ...pendingInterrupt,
@@ -4615,6 +4630,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const refMeta = isBaseMessage(result.output) ? result.output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
       if (refMeta?._refKey != null && result.referenceContent != null) {
         this.toolOutputRegistry?.set(baseContext.batchScopeId, refMeta._refKey, result.referenceContent);
+        if (isBaseMessage(result.output)) {
+          result = { ...result, output: new ToolMessage({
+            ...(result.output as ToolMessage),
+            additional_kwargs: { ...result.output.additional_kwargs, _refScope: baseContext.batchScopeId },
+          }) };
+        }
       }
       if (
         call.id != null &&
@@ -4819,7 +4840,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected async run(input: any, config: RunnableConfig): Promise<T> {
+  protected async run(input: any, config: RunnableConfig, referenceReplay: { state?: ToolOutputReferenceState } = {}): Promise<T> {
     /**
      * Breaker read once at batch entry: every downstream path (direct
      * `tool.invoke` runtimes and the ON_TOOL_EXECUTE dispatch) inherits this
@@ -4878,6 +4899,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      */
     const incomingRunId = config.configurable?.run_id as string | undefined;
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
+    if (referenceReplay.state != null) {
+      this.toolOutputRegistry?.restoreState(batchScopeId, referenceReplay.state);
+    }
+    referenceReplay.state = this.toolOutputRegistry?.snapshotState(batchScopeId);
     const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
     let replayBatchKey: string | undefined;

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -48,6 +48,7 @@ import type {
   ToolApprovalReplayKey,
 } from '@/hooks';
 import type { PreparedSubagents } from '@/tools/preparedSubagents';
+import type { SettledToolBatchResult } from '@/tools/toolBatchReplay';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
 import {
@@ -117,17 +118,29 @@ import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { attachRunStepResumeState } from '@/tools/runStepResume';
+import {
+  TOOL_BATCH_REPLAY_KEY,
+  getToolBatchReplayOwner,
+  getToolBatchReplayScope,
+  attachToolBatchReplayState,
+  restoreToolBatchReplayState,
+} from '@/tools/toolBatchReplay';
 
 function stripToolApprovalReviewConfig(
   configurable: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
   if (
     configurable == null ||
-    !(TOOL_APPROVAL_REVIEW_CONFIG_KEY in configurable)
+    !(TOOL_APPROVAL_REVIEW_CONFIG_KEY in configurable) &&
+    !(TOOL_BATCH_REPLAY_KEY in configurable)
   ) {
     return configurable;
   }
-  const { [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: _review, ...rest } = configurable;
+  const {
+    [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: _review,
+    [TOOL_BATCH_REPLAY_KEY]: _replay,
+    ...rest
+  } = configurable;
   return rest;
 }
 
@@ -233,6 +246,8 @@ type RunToolBatchContext<T = unknown> = {
   additionalContextsSink?: string[];
   /** Stable identity of the assistant tool-call batch across HITL replay. */
   replayBatchKey?: string;
+  /** Tool-call identities owned by this ToolNode invocation. */
+  approvalScopeCallIds?: ReadonlySet<string>;
   /**
    * Graph state the ToolNode was invoked with, threaded from `run()`
    * so `tool.invoke` can forward it as langgraph 1.4's `runtime.state`
@@ -260,12 +275,7 @@ function withSubagentReplayBatch(
   };
 }
 
-type SettledDirectToolResult = {
-  output: BaseMessage | Command;
-  additionalContexts: string[];
-  resolvedArgs?: Record<string, unknown>;
-  completionHandled?: boolean;
-};
+type SettledDirectToolResult = SettledToolBatchResult;
 
 /**
  * Batch-local record of who owns each failed call's completion event.
@@ -446,11 +456,9 @@ function findAssistantBatch(
 
 function getAssistantBatchReplayKey(
   batch: AssistantBatch,
-  runId: string | undefined,
   threadId: string | undefined
 ): string {
   return JSON.stringify([
-    runId ?? null,
     threadId ?? null,
     batch.message.id ?? null,
     batch.index,
@@ -879,23 +887,50 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       name: name ?? TOOL_NODE_RUN_NAME,
       tags,
       func: async (input, config) => {
+        const messages = Array.isArray(input) ? input as BaseMessage[] :
+          (input as { messages?: BaseMessage[] }).messages;
+        const assistantBatch = messages == null ? undefined : findAssistantBatch(messages);
+        const activeReplayKey = assistantBatch == null ? undefined : getAssistantBatchReplayKey(
+          assistantBatch, getToolBatchReplayScope(config)
+        );
+        const replayOwner = getToolBatchReplayOwner(
+          config,
+          this.executingAgentId ?? this.agentId ?? ''
+        );
+        const restoredBatches = await restoreToolBatchReplayState(config, replayOwner);
+        for (const { batch, results } of restoredBatches) {
+          if (batch !== activeReplayKey) {
+            continue;
+          }
+          if (!this.settledDirectResultsByBatch.has(batch)) {
+            this.settledDirectResultsByBatch.set(batch, new Map(results));
+          }
+        }
         const state = input as T & Pick<t.BaseGraphState, 'runStepState'>;
         restoreRunStepResumeState?.(state.runStepState, config);
         let result: T;
         try {
           result = await this.run(input, config);
         } catch (error) {
-          if (!isGraphInterrupt(error) || createRunStepResumeState == null) {
+          if (!isGraphInterrupt(error)) {
             throw error;
           }
-          const resumeState = createRunStepResumeState();
+          const resumeState = createRunStepResumeState?.();
+          const activeResults = activeReplayKey == null ? undefined : this.settledDirectResultsByBatch.get(activeReplayKey);
+          const activeBatches = activeReplayKey == null || activeResults == null
+            ? new Map<string, Map<string, SettledDirectToolResult>>()
+            : new Map([[activeReplayKey, activeResults]]);
           throw new GraphInterrupt(
-            error.interrupts.map((pendingInterrupt) => ({
-              ...pendingInterrupt,
-              value: attachRunStepResumeState(
+            await Promise.all(error.interrupts.map(async (pendingInterrupt) => {
+              const value = await attachToolBatchReplayState(
                 pendingInterrupt.value,
-                resumeState
-              ),
+                replayOwner,
+                activeBatches
+              );
+              return {
+                ...pendingInterrupt,
+                value: resumeState == null ? value : attachRunStepResumeState(value, resumeState),
+              };
             }))
           );
         }
@@ -2061,11 +2096,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           approvalReplaySessionId,
           approvalReplayKey
         );
-    const approvalReviewEvidence = getToolApprovalReviewEvidence(config);
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(config,
+      getToolBatchReplayOwner(config, this.executingAgentId ?? this.agentId ?? ''));
     const reviewedApproval = getReviewedToolApproval(
       approvalReviewEvidence?.payload,
       call.id
     );
+    const approvalEvidenceAppliesToBatch =
+      approvalReviewEvidence?.payload.action_requests.some((request) =>
+        batchContext.approvalScopeCallIds == null
+          ? request.tool_call_id === call.id
+          : batchContext.approvalScopeCallIds.has(request.tool_call_id)
+      ) === true;
     const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
@@ -2192,7 +2234,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             matchQuery: call.name,
             onceReplayKey: approvalReplayKey,
             onceReplaySessionId: approvalReplaySessionId,
-          }).catch(() => undefined);
+          }).catch((): AggregatedHookResult | undefined => approvalReviewEvidence == null ? undefined : {
+            decision: 'deny',
+            reason: 'Approval policy could not be evaluated on resume',
+            additionalContexts: [], injectedMessages: [], errors: [],
+          });
 
       if (preResult != null) {
         // Forward any additionalContext strings hooks returned into
@@ -2242,7 +2288,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
          * approval that LangGraph did not preserve. A current hook can ask
          * again; otherwise never let that unreviewed sibling execute. */
         if (
-          approvalReviewEvidence != null &&
+          approvalEvidenceAppliesToBatch &&
           reviewedApproval == null &&
           !isTrustedSubagentReviewHop &&
           preResult.decision !== 'ask'
@@ -3113,7 +3159,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       config,
       runId
     );
-    const approvalReviewEvidence = getToolApprovalReviewEvidence(config);
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(config,
+      getToolBatchReplayOwner(config, this.executingAgentId ?? this.agentId ?? ''));
     const hasPendingApproval = preToolCalls.some(
       (entry) =>
         entry.call.id != null &&
@@ -3386,6 +3433,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
            */
           if (hookResult.updatedInput != null) {
             applyInputOverride(entry, hookResult.updatedInput);
+          } else {
+            const reviewed = getReviewedToolApproval(approvalReviewEvidence?.payload, entry.call.id);
+            if (reviewed != null) {
+              entry.args = this.coerceEventToolArgs(entry.call.name, reviewed.request.arguments);
+              if (entry.call.id != null) {
+                unresolvedByCallId.delete(entry.call.id);
+              }
+            }
           }
           askEntries.push({
             entry,
@@ -3403,6 +3458,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           entry.call.id
         );
         if (reviewedApproval != null) {
+          if (hookResult.updatedInput == null) {
+            entry.args = this.coerceEventToolArgs(
+              entry.call.name,
+              reviewedApproval.request.arguments
+            );
+            if (entry.call.id != null) {
+              unresolvedByCallId.delete(entry.call.id);
+            }
+          }
           askEntries.push({
             entry,
             reason: reviewedApproval.request.description,
@@ -4531,6 +4595,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       result: SettledDirectToolResult
     ): SettledDirectToolResult => {
       baseContext.additionalContextsSink?.push(...result.additionalContexts);
+      const refMeta = isBaseMessage(result.output) ? result.output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
+      if (refMeta?._refKey != null && result.referenceContent != null) {
+        this.toolOutputRegistry?.set(baseContext.batchScopeId, refMeta._refKey, result.referenceContent);
+      }
       if (
         call.id != null &&
         result.resolvedArgs != null &&
@@ -4549,6 +4617,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? settledBatchResults?.get(call.id)
           : undefined;
       if (cachedResult != null) {
+        if (cachedResult.proposal != null && (cachedResult.proposal.name !== call.name ||
+          !recordArgsEqual(cachedResult.proposal.args, call.args as Record<string, unknown>))) {
+          throw new Error('Cannot change an already completed tool call during approval replay');
+        }
         return restoreResult(call, cachedResult);
       }
       const additionalContexts: string[] = [];
@@ -4562,10 +4634,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? undefined
           : baseContext.resolvedArgsByCallId?.get(call.id);
       const result: SettledDirectToolResult = {
+        proposal: structuredClone({ name: call.name, args: call.args as Record<string, unknown> }),
         output,
         additionalContexts,
         ...(resolvedArgs == null ? {} : { resolvedArgs }),
       };
+      const refMeta = isBaseMessage(output) ? output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
+      if (refMeta?._refKey != null) {
+        result.referenceContent = this.toolOutputRegistry?.get(refMeta._refScope, refMeta._refKey);
+      }
       cacheResult(call, result);
       return restoreResult(call, result);
     };
@@ -4576,10 +4653,21 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       directCalls.some((call) => interrupting.has(call.name));
 
     if (!hasInterrupting) {
-      const results = await Promise.all(
+      const results = await Promise.allSettled(
         directCalls.map((call, i) => runOne(call, i))
       );
-      return results.map((result) => result.output);
+      this.throwIfBreakerTripped(config);
+      const failed = results.find((result) => result.status === 'rejected' && !isGraphInterrupt(result.reason)) ??
+        results.find((result) => result.status === 'rejected');
+      if (failed?.status === 'rejected') {
+        throw failed.reason;
+      }
+      return results.map((result) => {
+        if (result.status === 'rejected') {
+          throw result.reason;
+        }
+        return result.value.output;
+      });
     }
 
     const outputs: (BaseMessage | Command)[] = new Array(directCalls.length);
@@ -4771,9 +4859,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
      * every subsequent registry call on this batch.
      */
     const incomingRunId = config.configurable?.run_id as string | undefined;
-    const incomingThreadId = config.configurable?.thread_id as
-      | string
-      | undefined;
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
     const turn = this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
     let outputs: (BaseMessage | Command)[];
@@ -4814,8 +4899,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? undefined
           : getAssistantBatchReplayKey(
             sendAssistantBatch,
-            incomingRunId,
-            incomingThreadId
+            getToolBatchReplayScope(config)
           );
       const sendOutput = await this.runDirectToolWithLifecycleHooks(
         input.lg_tool_call,
@@ -4880,8 +4964,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const aiMessage = assistantBatch.message;
       replayBatchKey = getAssistantBatchReplayKey(
         assistantBatch,
-        incomingRunId,
-        incomingThreadId
+        getToolBatchReplayScope(config)
       );
 
       if (this.loadRuntimeTools) {
@@ -5037,6 +5120,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const directIndices = directEntries.map((e) => e.batchIndex);
         const eventCalls = eventEntries.map((e) => e.call);
         const eventIndices = eventEntries.map((e) => e.batchIndex);
+        const approvalScopeCallIds = new Set(
+          filteredCalls.flatMap((call) => (call.id == null ? [] : [call.id]))
+        );
 
         /**
          * Snapshot the event calls' args against the *pre-batch*
@@ -5102,6 +5188,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 preBatchSnapshot,
                 additionalContextsSink: directAdditionalContexts,
                 replayBatchKey,
+                approvalScopeCallIds,
                 runInput: input as T,
               }
             )
@@ -5189,6 +5276,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const preBatchSnapshot =
           this.toolOutputRegistry?.snapshot(batchScopeId);
         const directAdditionalContexts: string[] = [];
+        const approvalScopeCallIds = new Set(
+          filteredCalls.flatMap((call) => (call.id == null ? [] : [call.id]))
+        );
         const toolOutputs = await this.runDirectBatchInterruptSafe(
           filteredCalls,
           filteredCalls.map((_call, i) => i),
@@ -5201,6 +5291,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             preBatchSnapshot,
             additionalContextsSink: directAdditionalContexts,
             replayBatchKey,
+            approvalScopeCallIds,
             runInput: input as T,
           }
         );

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -68,6 +68,13 @@ import {
   serializeToolContentBounded,
 } from '@/utils/toolContent';
 import {
+  getReviewedToolApproval,
+  getToolApprovalReviewEvidence,
+  toolApprovalPayloadMatches,
+  toolApprovalProposalMatches,
+  TOOL_APPROVAL_REVIEW_CONFIG_KEY,
+} from '@/hitl/approvalReview';
+import {
   buildToolExecutionRequestPlan,
   coerceArgsForSchema,
   coerceRecordArgs,
@@ -111,15 +118,35 @@ import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { attachRunStepResumeState } from '@/tools/runStepResume';
 
-/** Host-facing batch requests must not carry the batch's breaker scope —
- * hosts spread `configurable` into their own run configs. */
-function stripRunBreakerScope(
+function stripToolApprovalReviewConfig(
   configurable: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
-  if (configurable == null || !(RUN_BREAKER_SCOPE_CONFIG_KEY in configurable)) {
+  if (
+    configurable == null ||
+    !(TOOL_APPROVAL_REVIEW_CONFIG_KEY in configurable)
+  ) {
     return configurable;
   }
-  const { [RUN_BREAKER_SCOPE_CONFIG_KEY]: _scope, ...rest } = configurable;
+  const {
+    [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: _review,
+    ...rest
+  } = configurable;
+  return rest;
+}
+
+/** Host-facing requests must not carry SDK-private execution state — hosts
+ * spread `configurable` into their own run configs. */
+function stripHostExecutionConfig(
+  configurable: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  const withoutReview = stripToolApprovalReviewConfig(configurable);
+  if (
+    withoutReview == null ||
+    !(RUN_BREAKER_SCOPE_CONFIG_KEY in withoutReview)
+  ) {
+    return withoutReview;
+  }
+  const { [RUN_BREAKER_SCOPE_CONFIG_KEY]: _scope, ...rest } = withoutReview;
   return rest;
 }
 import { convertInjectedMessages } from '@/messages/injected';
@@ -1307,11 +1334,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     runInput?: RunToolBatchContext<T>['runInput']
   ): Promise<unknown> {
     const lgConfig = config as LangGraphRunnableConfig;
-    const runtime: ToolRuntime<T> = {
+    const toolConfig: RunnableConfig = {
       ...config,
+      configurable: stripToolApprovalReviewConfig(
+        config.configurable as Record<string, unknown> | undefined
+      ),
+    };
+    const runtime: ToolRuntime<T> = {
+      ...toolConfig,
       state: runInput as ToolRuntime<T>['state'],
       toolCallId: call.id ?? '',
-      config,
+      config: toolConfig,
       context: lgConfig.context as ToolRuntime<T>['context'],
       store: (lgConfig.store ?? null) as ToolRuntime<T>['store'],
       writer:
@@ -2024,6 +2057,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           approvalReplaySessionId,
           approvalReplayKey
         );
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(config);
+    const reviewedApproval = getReviewedToolApproval(
+      approvalReviewEvidence?.payload,
+      call.id
+    );
     const hasPostHook = hookRegistry?.hasHookFor('PostToolUse', runId) === true;
     const hasFailureHook =
       hookRegistry?.hasHookFor('PostToolUseFailure', runId) === true;
@@ -2032,6 +2070,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       hookRegistry == null ||
       (!hasPreHook &&
         pendingApproval == null &&
+        reviewedApproval == null &&
         !hasPostHook &&
         !hasFailureHook)
     ) {
@@ -2106,7 +2145,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
 
     let effectiveCall = call;
-    if (hasPreHook || pendingApproval != null) {
+    if (hasPreHook || pendingApproval != null || reviewedApproval != null) {
       const preResult = await executeHooks({
         registry: hookRegistry,
         input: {
@@ -2162,7 +2201,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           );
         }
 
-        if (preResult.decision === 'ask') {
+        if (preResult.decision === 'ask' || reviewedApproval != null) {
           if (this.humanInTheLoop?.enabled !== true) {
             // Fail-closed: no HITL UI configured, so we can't actually
             // ask. Logged once via the existing helper.
@@ -2213,14 +2252,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           // same ask entry without dispatching the consumed hook again.
           // ToolNode disables LangSmith tracing, so the AsyncLocalStorage
           // frame must be re-established here.
+          const allowedDecisions =
+            preResult.decision === 'ask'
+              ? preResult.allowedDecisions
+              : reviewedApproval?.reviewConfig.allowed_decisions;
+          const askReason =
+            preResult.decision === 'ask'
+              ? preResult.reason
+              : reviewedApproval?.request.description;
           const askEntry: AskEntry = {
             entry: {
               call: effectiveCall,
               args: effectiveCall.args as Record<string, unknown>,
               stepId,
             },
-            reason: preResult.reason,
-            allowedDecisions: preResult.allowedDecisions,
+            reason: askReason,
+            allowedDecisions,
           };
           const payload = buildToolApprovalInterruptPayload([askEntry], runId);
           const resumeValue = AsyncLocalStorageProviderSingleton.runWithConfig(
@@ -2235,6 +2282,25 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             approvalReplaySessionId,
             approvalReplayKey
           );
+          const currentApproval = getReviewedToolApproval(payload, toolCallId);
+          if (
+            reviewedApproval != null &&
+            (currentApproval == null ||
+              !toolApprovalProposalMatches(currentApproval, reviewedApproval))
+          ) {
+            return persistOutput(
+              this.blockDirectCall({
+                call,
+                resolvedArgs,
+                reason:
+                  'Reviewed tool proposal changed before resume; retry approval',
+                hookRegistry,
+                runId,
+                threadId,
+              }),
+              effectiveCall.args as Record<string, unknown>
+            );
+          }
           const decisionByCallId = normalizeApprovalDecisions(
             [toolCallId],
             resumeValue
@@ -2246,9 +2312,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           const declaredType = (decision as { type?: unknown }).type;
 
           if (
-            preResult.allowedDecisions != null &&
+            allowedDecisions != null &&
             (typeof declaredType !== 'string' ||
-              !preResult.allowedDecisions.includes(
+              !allowedDecisions.includes(
                 declaredType as t.ToolApprovalDecisionType
               ))
           ) {
@@ -2256,7 +2322,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               this.blockDirectCall({
                 call,
                 resolvedArgs,
-                reason: `Decision "${typeof declaredType === 'string' ? declaredType : '<missing>'}" not in allowedDecisions [${preResult.allowedDecisions.join(', ')}] — failing closed`,
+                reason: `Decision "${typeof declaredType === 'string' ? declaredType : '<missing>'}" not in allowedDecisions [${allowedDecisions.join(', ')}] — failing closed`,
                 hookRegistry,
                 runId,
                 threadId,
@@ -2270,8 +2336,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               this.blockDirectCall({
                 call,
                 resolvedArgs,
-                reason:
-                  decision.reason ?? preResult.reason ?? 'Rejected by user',
+                reason: decision.reason ?? askReason ?? 'Rejected by user',
                 hookRegistry,
                 runId,
                 threadId,
@@ -2984,6 +3049,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       config,
       runId
     );
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(config);
     const hasPendingApproval = preToolCalls.some(
       (entry) =>
         entry.call.id != null &&
@@ -2998,7 +3064,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     );
     if (
       hookRegistry != null &&
-      (hookRegistry.hasHookFor('PreToolUse', runId) || hasPendingApproval)
+      (hookRegistry.hasHookFor('PreToolUse', runId) ||
+        hasPendingApproval ||
+        approvalReviewEvidence != null)
     ) {
       /**
        * Pull each call's prestarted eager record BEFORE awaiting the hooks:
@@ -3264,6 +3332,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (hookResult.updatedInput != null) {
           applyInputOverride(entry, hookResult.updatedInput);
         }
+        const reviewedApproval = getReviewedToolApproval(
+          approvalReviewEvidence?.payload,
+          entry.call.id
+        );
+        if (reviewedApproval != null) {
+          askEntries.push({
+            entry,
+            reason: reviewedApproval.request.description,
+            allowedDecisions: reviewedApproval.reviewConfig.allowed_decisions,
+          });
+          continue;
+        }
         if (entry.call.id != null) {
           const preempted = preemptedEagerRecords.get(entry.call.id);
           if (preempted != null) {
@@ -3314,8 +3394,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           );
         }
 
+        const proposalMatches =
+          approvalReviewEvidence == null ||
+          toolApprovalPayloadMatches(payload, approvalReviewEvidence.payload);
+        if (!proposalMatches) {
+          for (const { entry } of askEntries) {
+            blockEntry(
+              entry,
+              'Reviewed tool proposal changed before resume; retry approval'
+            );
+          }
+        }
+        const decisionEntries = proposalMatches ? askEntries : [];
         const decisionByCallId = normalizeApprovalDecisions(
-          askEntries.map(({ entry }) => entry.call.id!),
+          decisionEntries.map(({ entry }) => entry.call.id!),
           resumeValue
         );
 
@@ -3323,7 +3415,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           entry,
           reason: askReason,
           allowedDecisions,
-        } of askEntries) {
+        } of decisionEntries) {
           const decision = decisionByCallId.get(entry.call.id!) ?? {
             type: 'reject' as const,
             reason: 'No decision provided for tool approval',
@@ -3689,8 +3781,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               agentId: this.executingAgentId,
               callerCapabilityProjection:
                 this.getCallerCapabilityProjectionSnapshot(),
-              configurable: stripRunBreakerScope(
-                  config.configurable as Record<string, unknown> | undefined
+              configurable: stripHostExecutionConfig(
+                config.configurable as Record<string, unknown> | undefined
               ),
               metadata: config.metadata as
                   | Record<string, unknown>

--- a/src/tools/__tests__/SubagentReplay.test.ts
+++ b/src/tools/__tests__/SubagentReplay.test.ts
@@ -10,6 +10,7 @@ import {
   stripRunStepResumeState,
 } from '@/tools/runStepResume';
 import type { RunStepResumeState } from '@/types';
+import { attachToolBatchReplayState, getPublicToolInterruptPayload, restoreToolReplayConfig, TOOL_BATCH_REPLAY_KEY } from '@/tools/toolBatchReplay';
 
 describe('SubagentReplay manifest', () => {
   const execution = {
@@ -75,6 +76,16 @@ describe('SubagentReplay manifest', () => {
       },
     ],
   };
+
+  it.each([null, 'confirm', ['a', 'b']])('preserves nested custom payload %j with parent replay state', async (payload) => {
+    const nested = attachSubagentResumeManifest(payload, { version: 1, executions: [execution] });
+    const wrapped = await attachToolBatchReplayState(nested, 'parent', new Map([['batch', new Map()]]));
+    const persisted = JSON.parse(JSON.stringify(wrapped));
+    expect(getPublicToolInterruptPayload(persisted)).toEqual(payload);
+    const config: Record<string, unknown> = {};
+    restoreToolReplayConfig(config, 'interrupt', persisted);
+    expect(config[TOOL_BATCH_REPLAY_KEY]).toMatchObject({ records: [{ owner: 'parent' }] });
+  });
 
   it('round-trips a private manifest without exposing it publicly', () => {
     const manifest = { version: 1 as const, executions: [execution] };

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -319,8 +319,9 @@ describe('ToolNode breaker signal composition', () => {
       ],
     };
 
-    await expect(node.invoke(input)).rejects.toBeInstanceOf(GraphInterrupt);
-    const replayResult = await node.invoke(input);
+    const config = { configurable: { thread_id: 'terminal-sibling-replay' } };
+    await expect(node.invoke(input, config)).rejects.toBeInstanceOf(GraphInterrupt);
+    const replayResult = await node.invoke(input, config);
     expect(terminalRuns).toBe(1);
     expect(terminalPreHooks).toBe(1);
     expect(JSON.stringify(replayResult)).toContain('cached terminal context');

--- a/src/tools/__tests__/ToolNode.breakerSignal.test.ts
+++ b/src/tools/__tests__/ToolNode.breakerSignal.test.ts
@@ -346,7 +346,7 @@ describe('ToolNode breaker signal composition', () => {
           ],
         }),
       ],
-    });
+    }, config);
     expect(terminalRuns).toBe(2);
     expect(terminalPreHooks).toBe(2);
   });

--- a/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
+++ b/src/tools/__tests__/ToolNode.onResultCompletion.test.ts
@@ -647,7 +647,8 @@ describe('ToolNode error-ownership scoping', () => {
    * instance-scoped markers, invocation 2's output loop consumes the
    * marker invocation 1 set and drops its only completion.
    */
-  it('does not let a pending invocation\'s marker suppress a concurrent call reusing the id', async () => {
+  it.each([undefined, ''])('isolates concurrent calls reusing an id with missing scope %j', async (threadId) => {
+    const config = { configurable: { thread_id: threadId } };
     const completions: string[] = [];
     jest
       .spyOn(events, 'safeDispatchCustomEvent')
@@ -712,7 +713,7 @@ describe('ToolNode error-ownership scoping', () => {
           { id: 'call_slow', name: 'slow', args: {} },
         ]),
       ],
-    }) as Promise<unknown>;
+    }, config) as Promise<unknown>;
     await flushAsync();
 
     // Invocation 2, while invocation 1 is still parked.
@@ -723,7 +724,7 @@ describe('ToolNode error-ownership scoping', () => {
           { id: shared, name: 'returner', args: {} },
         ]),
       ],
-    });
+    }, config);
     await flushAsync();
     const emittedBySecond = completions.slice(before);
 

--- a/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
+++ b/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
@@ -38,6 +38,65 @@ function replayConfig(payload: unknown): RunnableConfig {
 }
 
 describe('ToolNode checkpoint authority', () => {
+  it('keeps concurrently checkpointed references while replaying its frozen inputs', async () => {
+    let release: () => void = () => { throw new Error('not initialized'); };
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    let shouldPause = true;
+    const work = tool(async ({ value }) => {
+      if (shouldPause) {
+        await barrier;
+        throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+      }
+      return value;
+    }, { name: 'work', description: 'work', schema: z.object({ value: z.string() }) });
+    const sibling = tool(async () => 'sibling-result', { name: 'sibling', description: 'sibling', schema: z.object({}) });
+    const registry = new ToolOutputReferenceRegistry();
+    const config = { configurable: { thread_id: 'checkpoint-replay', run_id: 'shared' } };
+    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
+      { id: 'work', name: 'work', args: { value: '{{tool0turn1}}' } },
+    ] })] };
+    const paused = capturePause(new ToolNode({ tools: [work], toolOutputRegistry: registry }), input, config);
+    await new ToolNode({ tools: [sibling], toolOutputRegistry: registry }).invoke({ messages: [new AIMessage({ content: '', tool_calls: [
+      { id: 'sibling', name: 'sibling', args: {} },
+    ] })] }, config);
+    release();
+    const checkpoint = await paused;
+    const sharedState = registry.snapshotState('shared');
+    expect(sharedState.turnCounter).toBe(2);
+    const restoredRegistry = new ToolOutputReferenceRegistry();
+    restoredRegistry.restoreState('shared', sharedState);
+    const resume = replayConfig(checkpoint);
+    resume.configurable = { ...resume.configurable, run_id: 'shared' };
+    shouldPause = false;
+    const result = await new ToolNode({ tools: [work], toolOutputRegistry: restoredRegistry }).invoke(input, resume) as { messages: ToolMessage[] };
+    expect(result.messages[0].content).toBe('{{tool0turn1}}');
+    expect(restoredRegistry.get('shared', 'tool0turn1')).toBe('sibling-result');
+    expect(restoredRegistry.nextTurn('shared')).toBe(2);
+  });
+
+  it.each([undefined, ''])('restores an ID-less completed sibling (%j) without repeating it', async (id) => {
+    let executions = 0;
+    let shouldPause = true;
+    const work = tool(async () => { executions += 1; return `result-${executions}`; }, { name: 'work', description: 'work', schema: z.object({}) });
+    const pause = tool(async () => {
+      if (shouldPause) throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+      return 'resumed';
+    }, { name: 'pause', description: 'pause', schema: z.object({}) });
+    const alreadyDone = tool(async () => 'done', { name: 'done', description: 'done', schema: z.object({}) });
+    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
+      { id: 'done', name: 'done', args: {} }, { id, name: 'work', args: {} }, { id, name: 'work', args: {} }, { id: 'pause', name: 'pause', args: {} },
+    ] })] };
+    const checkpoint = await capturePause(new ToolNode({ tools: [work, pause, alreadyDone] }), input, { configurable: { thread_id: 'checkpoint-replay' } });
+    expect(executions).toBe(2);
+    shouldPause = false;
+    const result = await new ToolNode({ tools: [work, pause, alreadyDone] }).invoke({ messages: [
+      ...input.messages, new ToolMessage({ tool_call_id: 'done', content: 'done' }),
+    ] }, replayConfig(checkpoint));
+    expect(executions).toBe(2);
+    expect(JSON.stringify(result)).toContain('result-1');
+    expect(JSON.stringify(result)).toContain('result-2');
+  });
+
   it.each([false, true])(
     'restores an older checkpoint despite newer cached output (append=%s)',
     async (append) => {

--- a/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
+++ b/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { AIMessage } from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import { GraphInterrupt } from '@langchain/langgraph';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import { HookRegistry } from '@/hooks';
@@ -8,10 +8,18 @@ import { ToolNode } from '../ToolNode';
 import { restoreToolReplayConfig } from '../toolBatchReplay';
 import * as events from '@/utils/events';
 import { GraphEvents } from '@/common';
+import {
+  ToolOutputReferenceRegistry,
+  annotateMessagesForLLM,
+} from '../toolOutputReferences';
 
 afterEach(() => jest.restoreAllMocks());
 
-async function capturePause(node: ToolNode, input: object, config: RunnableConfig): Promise<unknown> {
+async function capturePause(
+  node: ToolNode,
+  input: object,
+  config: RunnableConfig
+): Promise<unknown> {
   try {
     await node.invoke(input, config);
   } catch (error) {
@@ -30,83 +38,267 @@ function replayConfig(payload: unknown): RunnableConfig {
 }
 
 describe('ToolNode checkpoint authority', () => {
-  it('replaces newer cached outputs when selecting an older checkpoint', async () => {
-    let generation = 'original';
-    let executions = 0;
-    let shouldPause = true;
-    const work = tool(async () => {
-      executions += 1;
-      return generation;
-    }, { name: 'work', description: 'work', schema: z.object({}) });
-    const pause = tool(async () => {
-      if (shouldPause) {
-        throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
-      }
-      return 'resumed';
-    }, { name: 'pause', description: 'pause', schema: z.object({}) });
-    const node = new ToolNode({ tools: [work, pause] });
-    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
-      { id: 'work', name: 'work', args: {} }, { id: 'pause', name: 'pause', args: {} },
-    ] })] };
-    const older = await capturePause(node, input, { configurable: { thread_id: 'checkpoint-replay' } });
-    const emptyCheckpoint = replayConfig(older);
-    const state = emptyCheckpoint.configurable?.__librechat_tool_batch_replay as { records: object[] };
-    state.records = [];
-    generation = 'newer';
-    await capturePause(node, input, emptyCheckpoint);
-    expect(executions).toBe(2);
-    shouldPause = false;
-    const result = await node.invoke(input, replayConfig(older));
-    expect(JSON.stringify(result)).toContain('original');
-    expect(JSON.stringify(result)).not.toContain('newer');
-    expect(executions).toBe(2);
-  });
-
-  it.each([false, true])('restores completed and pending turns in a fresh runtime (hooks=%s)', async (hooks) => {
-    const observed: Array<{ id: string; turn: number }> = [];
-    const completions: Array<{ index: number; tool_call: { id: string } }> = [];
-    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(async (event, data) => {
-      if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
-        completions.push((data as { result: (typeof completions)[number] }).result);
-      }
-      return true;
-    });
-    let shouldPause = true;
-    const work = tool(async ({ pause }, config) => {
-      const call = config.toolCall as { id: string; turn: number };
-      observed.push({ id: call.id, turn: call.turn });
-      if (pause && shouldPause) {
-        throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
-      }
-      return `turn-${call.turn}`;
-    }, { name: 'work', description: 'work', schema: z.object({ pause: z.boolean() }) });
-    const makeNode = () => {
-      const registry = new HookRegistry();
-      registry.register('PreToolUse', { hooks: [async () => ({ decision: 'allow' })] });
-      return new ToolNode({ tools: [work], hookRegistry: hooks ? registry : undefined,
-        toolCallStepIds: new Map(['earlier', 'completed', 'pending'].map((id) => [id, `step-${id}`])),
+  it.each([false, true])(
+    'restores an older checkpoint despite newer cached output (append=%s)',
+    async (append) => {
+      let generation = 'original';
+      let executions = 0;
+      let shouldPause = true;
+      const work = tool(
+        async () => {
+          executions += 1;
+          return generation;
+        },
+        { name: 'work', description: 'work', schema: z.object({}) }
+      );
+      const pause = tool(
+        async () => {
+          if (shouldPause) {
+            throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+          }
+          return 'resumed';
+        },
+        { name: 'pause', description: 'pause', schema: z.object({}) }
+      );
+      const node = new ToolNode({ tools: [work, pause] });
+      const input = {
+        messages: [
+          new AIMessage({
+            id: 'batch',
+            content: '',
+            tool_calls: [
+              { id: 'work', name: 'work', args: {} },
+              { id: 'pause', name: 'pause', args: {} },
+            ],
+          }),
+        ],
+      };
+      const older = await capturePause(node, input, {
+        configurable: { thread_id: 'checkpoint-replay' },
       });
-    };
-    const node = makeNode();
-    const config = { configurable: { thread_id: 'checkpoint-replay' } };
-    await node.invoke({ messages: [new AIMessage({ id: 'earlier', content: '', tool_calls: [
-      { id: 'earlier', name: 'work', args: { pause: false } },
-    ] })] }, config);
-    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
-      { id: 'completed', name: 'work', args: { pause: false } },
-      { id: 'pending', name: 'work', args: { pause: true } },
-    ] })] };
-    const checkpoint = await capturePause(node, input, config);
-    expect(observed).toEqual([{ id: 'earlier', turn: 0 }, { id: 'completed', turn: 1 }, { id: 'pending', turn: 2 }]);
-    shouldPause = false;
-    const fresh = makeNode();
-    const resumed = await fresh.invoke(input, replayConfig(checkpoint));
-    expect(observed).toEqual([{ id: 'earlier', turn: 0 }, { id: 'completed', turn: 1 }, { id: 'pending', turn: 2 }, { id: 'pending', turn: 2 }]);
-    expect(JSON.stringify(resumed)).toContain('turn-1');
-    expect(JSON.stringify(resumed)).toContain('turn-2');
-    expect(fresh.getToolUsageCounts().get('work')).toBe(3);
-    expect(completions.map(({ index, tool_call }) => ({ id: tool_call.id, index }))).toEqual([
-      { id: 'earlier', index: 0 }, { id: 'completed', index: 1 }, { id: 'pending', index: 2 },
-    ]);
-  });
+      const emptyCheckpoint = replayConfig(older);
+      const state = emptyCheckpoint.configurable
+        ?.__librechat_tool_batch_replay as { records: object[] };
+      state.records = [];
+      generation = 'newer';
+      await capturePause(node, input, emptyCheckpoint);
+      expect(executions).toBe(2);
+      shouldPause = false;
+      const result = await node.invoke(
+        append
+          ? {
+            messages: [
+              ...input.messages,
+              new HumanMessage('More instructions'),
+            ],
+          }
+          : input,
+        replayConfig(older)
+      );
+      expect(JSON.stringify(result)).toContain('original');
+      expect(JSON.stringify(result)).not.toContain('newer');
+      expect(executions).toBe(2);
+    }
+  );
+
+  it.each(['same-run', 'different-run', undefined])(
+    'restores reference content and counters under resumed scope %s',
+    async (resumedRunId) => {
+      let shouldPause = true;
+      const work = tool(
+        async ({ value, pause }) => {
+          if (pause && shouldPause) {
+            throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+          }
+          return value;
+        },
+        {
+          name: 'work',
+          description: 'work',
+          schema: z.object({ value: z.string(), pause: z.boolean() }),
+        }
+      );
+      const makeNode = (registry: ToolOutputReferenceRegistry) =>
+        new ToolNode({ tools: [work], toolOutputRegistry: registry });
+      const original = makeNode(new ToolOutputReferenceRegistry());
+      const config = {
+        configurable: { thread_id: 'checkpoint-replay', run_id: 'same-run' },
+      };
+      const earlier = (await original.invoke(
+        {
+          messages: [
+            new AIMessage({
+              id: 'earlier',
+              content: '',
+              tool_calls: [
+                {
+                  id: 'earlier',
+                  name: 'work',
+                  args: { value: 'old-value', pause: false },
+                },
+              ],
+            }),
+          ],
+        },
+        config
+      )) as { messages: ToolMessage[] };
+      const input = {
+        messages: [
+          new AIMessage({
+            id: 'batch',
+            content: '',
+            tool_calls: [
+              {
+                id: 'completed',
+                name: 'work',
+                args: { value: 'cached-value', pause: false },
+              },
+              {
+                id: 'pending',
+                name: 'work',
+                args: { value: '{{tool0turn1}}', pause: true },
+              },
+            ],
+          }),
+        ],
+      };
+      const checkpoint = await capturePause(original, input, config);
+      const registry = new ToolOutputReferenceRegistry();
+      const fresh = makeNode(registry);
+      shouldPause = false;
+      const resume = replayConfig(checkpoint);
+      resume.configurable = { ...resume.configurable, run_id: resumedRunId };
+      const result = (await fresh.invoke(input, resume)) as {
+        messages: ToolMessage[];
+      };
+      const completed = result.messages.find(
+        (message) => message.tool_call_id === 'completed'
+      )!;
+      const pending = result.messages.find(
+        (message) => message.tool_call_id === 'pending'
+      )!;
+      const scope = pending.additional_kwargs._refScope as string;
+      expect(registry.get(scope, 'tool0turn0')).toBe('old-value');
+      expect(pending.additional_kwargs._refKey).not.toBe('tool0turn0');
+      expect(pending.additional_kwargs._refKey).toBe('tool1turn1');
+      expect(pending.content).toBe('{{tool0turn1}}');
+      expect(completed.additional_kwargs._refScope).toBe(scope);
+      expect(
+        annotateMessagesForLLM([completed], registry, resumedRunId)[0].content
+      ).toContain('[ref: tool0turn1]');
+      expect(registry.resolve(scope, '{{tool0turn1}}').resolved).toBe(
+        'cached-value'
+      );
+      if (resumedRunId === 'same-run') {
+        expect(
+          annotateMessagesForLLM(earlier.messages, registry, resumedRunId)[0]
+            .content
+        ).toContain('old-value');
+        expect(registry.resolve(scope, '{{tool0turn0}}').resolved).toBe(
+          'old-value'
+        );
+      }
+    }
+  );
+
+  it.each([false, true])(
+    'restores completed and pending turns in a fresh runtime (hooks=%s)',
+    async (hooks) => {
+      const observed: Array<{ id: string; turn: number }> = [];
+      const completions: Array<{ index: number; tool_call: { id: string } }> =
+        [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+            completions.push(
+              (data as { result: (typeof completions)[number] }).result
+            );
+          }
+          return true;
+        });
+      let shouldPause = true;
+      const work = tool(
+        async ({ pause }, config) => {
+          const call = config.toolCall as { id: string; turn: number };
+          observed.push({ id: call.id, turn: call.turn });
+          if (pause && shouldPause) {
+            throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+          }
+          return `turn-${call.turn}`;
+        },
+        {
+          name: 'work',
+          description: 'work',
+          schema: z.object({ pause: z.boolean() }),
+        }
+      );
+      const makeNode = () => {
+        const registry = new HookRegistry();
+        registry.register('PreToolUse', {
+          hooks: [async () => ({ decision: 'allow' })],
+        });
+        return new ToolNode({
+          tools: [work],
+          hookRegistry: hooks ? registry : undefined,
+          toolCallStepIds: new Map(
+            ['earlier', 'completed', 'pending'].map((id) => [id, `step-${id}`])
+          ),
+        });
+      };
+      const node = makeNode();
+      const config = { configurable: { thread_id: 'checkpoint-replay' } };
+      await node.invoke(
+        {
+          messages: [
+            new AIMessage({
+              id: 'earlier',
+              content: '',
+              tool_calls: [
+                { id: 'earlier', name: 'work', args: { pause: false } },
+              ],
+            }),
+          ],
+        },
+        config
+      );
+      const input = {
+        messages: [
+          new AIMessage({
+            id: 'batch',
+            content: '',
+            tool_calls: [
+              { id: 'completed', name: 'work', args: { pause: false } },
+              { id: 'pending', name: 'work', args: { pause: true } },
+            ],
+          }),
+        ],
+      };
+      const checkpoint = await capturePause(node, input, config);
+      expect(observed).toEqual([
+        { id: 'earlier', turn: 0 },
+        { id: 'completed', turn: 1 },
+        { id: 'pending', turn: 2 },
+      ]);
+      shouldPause = false;
+      const fresh = makeNode();
+      const resumed = await fresh.invoke(input, replayConfig(checkpoint));
+      expect(observed).toEqual([
+        { id: 'earlier', turn: 0 },
+        { id: 'completed', turn: 1 },
+        { id: 'pending', turn: 2 },
+        { id: 'pending', turn: 2 },
+      ]);
+      expect(JSON.stringify(resumed)).toContain('turn-1');
+      expect(JSON.stringify(resumed)).toContain('turn-2');
+      expect(fresh.getToolUsageCounts().get('work')).toBe(3);
+      expect(
+        completions.map(({ index, tool_call }) => ({ id: tool_call.id, index }))
+      ).toEqual([
+        { id: 'earlier', index: 0 },
+        { id: 'completed', index: 1 },
+        { id: 'pending', index: 2 },
+      ]);
+    }
+  );
 });

--- a/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
+++ b/src/tools/__tests__/ToolNode.replayCheckpoint.test.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage } from '@langchain/core/messages';
+import { GraphInterrupt } from '@langchain/langgraph';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import { HookRegistry } from '@/hooks';
+import { ToolNode } from '../ToolNode';
+import { restoreToolReplayConfig } from '../toolBatchReplay';
+import * as events from '@/utils/events';
+import { GraphEvents } from '@/common';
+
+afterEach(() => jest.restoreAllMocks());
+
+async function capturePause(node: ToolNode, input: object, config: RunnableConfig): Promise<unknown> {
+  try {
+    await node.invoke(input, config);
+  } catch (error) {
+    if (error instanceof GraphInterrupt) {
+      return JSON.parse(JSON.stringify(error.interrupts[0].value));
+    }
+    throw error;
+  }
+  throw new Error('Expected an interrupt');
+}
+
+function replayConfig(payload: unknown): RunnableConfig {
+  const configurable = { thread_id: 'checkpoint-replay' };
+  restoreToolReplayConfig(configurable, 'pause', payload);
+  return { configurable };
+}
+
+describe('ToolNode checkpoint authority', () => {
+  it('replaces newer cached outputs when selecting an older checkpoint', async () => {
+    let generation = 'original';
+    let executions = 0;
+    let shouldPause = true;
+    const work = tool(async () => {
+      executions += 1;
+      return generation;
+    }, { name: 'work', description: 'work', schema: z.object({}) });
+    const pause = tool(async () => {
+      if (shouldPause) {
+        throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+      }
+      return 'resumed';
+    }, { name: 'pause', description: 'pause', schema: z.object({}) });
+    const node = new ToolNode({ tools: [work, pause] });
+    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
+      { id: 'work', name: 'work', args: {} }, { id: 'pause', name: 'pause', args: {} },
+    ] })] };
+    const older = await capturePause(node, input, { configurable: { thread_id: 'checkpoint-replay' } });
+    const emptyCheckpoint = replayConfig(older);
+    const state = emptyCheckpoint.configurable?.__librechat_tool_batch_replay as { records: object[] };
+    state.records = [];
+    generation = 'newer';
+    await capturePause(node, input, emptyCheckpoint);
+    expect(executions).toBe(2);
+    shouldPause = false;
+    const result = await node.invoke(input, replayConfig(older));
+    expect(JSON.stringify(result)).toContain('original');
+    expect(JSON.stringify(result)).not.toContain('newer');
+    expect(executions).toBe(2);
+  });
+
+  it.each([false, true])('restores completed and pending turns in a fresh runtime (hooks=%s)', async (hooks) => {
+    const observed: Array<{ id: string; turn: number }> = [];
+    const completions: Array<{ index: number; tool_call: { id: string } }> = [];
+    jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(async (event, data) => {
+      if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+        completions.push((data as { result: (typeof completions)[number] }).result);
+      }
+      return true;
+    });
+    let shouldPause = true;
+    const work = tool(async ({ pause }, config) => {
+      const call = config.toolCall as { id: string; turn: number };
+      observed.push({ id: call.id, turn: call.turn });
+      if (pause && shouldPause) {
+        throw new GraphInterrupt([{ id: 'pause', value: 'confirm' }]);
+      }
+      return `turn-${call.turn}`;
+    }, { name: 'work', description: 'work', schema: z.object({ pause: z.boolean() }) });
+    const makeNode = () => {
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', { hooks: [async () => ({ decision: 'allow' })] });
+      return new ToolNode({ tools: [work], hookRegistry: hooks ? registry : undefined,
+        toolCallStepIds: new Map(['earlier', 'completed', 'pending'].map((id) => [id, `step-${id}`])),
+      });
+    };
+    const node = makeNode();
+    const config = { configurable: { thread_id: 'checkpoint-replay' } };
+    await node.invoke({ messages: [new AIMessage({ id: 'earlier', content: '', tool_calls: [
+      { id: 'earlier', name: 'work', args: { pause: false } },
+    ] })] }, config);
+    const input = { messages: [new AIMessage({ id: 'batch', content: '', tool_calls: [
+      { id: 'completed', name: 'work', args: { pause: false } },
+      { id: 'pending', name: 'work', args: { pause: true } },
+    ] })] };
+    const checkpoint = await capturePause(node, input, config);
+    expect(observed).toEqual([{ id: 'earlier', turn: 0 }, { id: 'completed', turn: 1 }, { id: 'pending', turn: 2 }]);
+    shouldPause = false;
+    const fresh = makeNode();
+    const resumed = await fresh.invoke(input, replayConfig(checkpoint));
+    expect(observed).toEqual([{ id: 'earlier', turn: 0 }, { id: 'completed', turn: 1 }, { id: 'pending', turn: 2 }, { id: 'pending', turn: 2 }]);
+    expect(JSON.stringify(resumed)).toContain('turn-1');
+    expect(JSON.stringify(resumed)).toContain('turn-2');
+    expect(fresh.getToolUsageCounts().get('work')).toBe(3);
+    expect(completions.map(({ index, tool_call }) => ({ id: tool_call.id, index }))).toEqual([
+      { id: 'earlier', index: 0 }, { id: 'completed', index: 1 }, { id: 'pending', index: 2 },
+    ]);
+  });
+});

--- a/src/tools/__tests__/directToolHITLResumeScope.test.ts
+++ b/src/tools/__tests__/directToolHITLResumeScope.test.ts
@@ -24,12 +24,12 @@ import type { PreToolUseHookOutput } from '@/hooks';
 import type * as t from '@/types';
 import {
   getSubagentResumeManifest,
-  stripSubagentResumeManifest,
   SUBAGENT_PARENT_BATCH_CONFIG_KEY,
   SUBAGENT_REPLAY_CONTROLLER,
 } from '@/tools/subagent/SubagentReplay';
 import { HookRegistry } from '@/hooks';
 import { ToolNode } from '../ToolNode';
+import { getPublicToolInterruptPayload } from '../toolBatchReplay';
 
 /**
  * Pins the resume-scope behaviour for direct-path interrupts. The
@@ -193,7 +193,7 @@ describe('direct-path HITL: resume scope', () => {
       })
     );
     expect(getSubagentResumeManifest(internalPayload)).toEqual(manifest);
-    expect(stripSubagentResumeManifest(internalPayload)).toBe('confirm child');
+    expect(getPublicToolInterruptPayload(internalPayload)).toBe('confirm child');
   });
 
   it('preserves a one-shot approval until a reject decision is applied', async () => {

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -34,13 +34,13 @@ import type {
   UserPromptSubmitHookOutput,
 } from '@/hooks';
 import type * as t from '@/types';
+import type { ReplayableSubagentTool } from '@/tools/subagent/SubagentReplay';
 import {
   TOOL_APPROVAL_REVIEW_CONFIG_KEY,
   createToolApprovalReviewEvidence,
 } from '@/hitl/approvalReview';
 import {
   SUBAGENT_REPLAY_CONTROLLER,
-  type ReplayableSubagentTool,
 } from '@/tools/subagent/SubagentReplay';
 import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
 import { Constants, Providers as providers, GraphEvents } from '@/common';
@@ -3502,8 +3502,9 @@ describe('Codex review fixes', () => {
   });
 
   it.each([
-    { fresh: false, mutate: false }, { fresh: true, mutate: false }, { fresh: true, mutate: true },
-  ])('reuses a settled direct sibling when a later event tool interrupts (fresh=$fresh, mutate=$mutate)', async ({ fresh, mutate }) => {
+    { fresh: false, mutate: false, append: false }, { fresh: true, mutate: false, append: false }, { fresh: true, mutate: true, append: false },
+    { fresh: true, mutate: false, append: true },
+  ])('reuses a settled direct sibling when a later event tool interrupts (fresh=$fresh, mutate=$mutate, append=$append)', async ({ fresh, mutate, append }) => {
     let directExecutions = 0;
     const completedCallIds: string[] = [];
     const dispatchedEventNames: string[] = [];
@@ -3623,12 +3624,13 @@ describe('Codex review fixes', () => {
             id: original?.id, content: '', tool_calls: calls.map((call) => call.id === 'call_direct' ?
               { ...call, args: { command: 'different operation' } } : call),
           })] },
-        })).rejects.toThrow('Cannot change an already completed tool call');
+        })).rejects.toThrow('Tool batch proposal changed before approval replay');
         expect(directExecutions).toBe(1);
         expect(dispatchedEventNames).toEqual([]);
         return;
       }
-      await restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' });
+      await restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' }, undefined,
+        append ? { update: { messages: [new HumanMessage('Additional instructions during approval')] } } : undefined);
       await restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' });
       const state = await restoredGraph.getState?.(config);
       resumed = (state as { values: { messages: BaseMessage[] } }).values;
@@ -4149,9 +4151,12 @@ describe('Codex review fixes', () => {
     }
   );
 
-  it.each([true, false])(
-    'restores a rewritten approval with fresh Run and ToolNode instances (direct=%s)',
-    async (direct) => {
+  it.each([
+    { direct: true, changedOwner: false }, { direct: false, changedOwner: false },
+    { direct: true, changedOwner: true }, { direct: false, changedOwner: true },
+  ])(
+    'restores a rewritten approval with fresh instances (direct=$direct, changedOwner=$changedOwner)',
+    async ({ direct, changedOwner }) => {
       const checkpointer = new MemorySaver();
       const executed: string[] = [];
       const echo = tool(async ({ command }) => {
@@ -4183,12 +4188,12 @@ describe('Codex review fixes', () => {
         hooks: [async () => ({ decision: 'ask', updatedInput: { command: 'reviewed' } })],
       });
       const { Run } = await import('@/run');
-      const create = async (hooks?: HookRegistry) => {
+      const create = async (hooks?: HookRegistry, agentId = 'a') => {
         const node = new ToolNode({
           tools: [echo],
           eventDrivenMode: true,
           ...(direct ? { directToolNames: new Set(['echo']) } : {}),
-          agentId: 'a',
+          agentId,
           toolCallStepIds: new Map([['call_1', 'step_1']]),
           hookRegistry: hooks,
           humanInTheLoop: { enabled: true },
@@ -4219,7 +4224,12 @@ describe('Codex review fixes', () => {
         action_requests: [{ arguments: { command: 'reviewed' } }],
       });
       expect(executed).toEqual([]);
-      const restored = await create();
+      const restored = await create(undefined, changedOwner ? 'different-agent' : 'a');
+      if (changedOwner) {
+        await expect(restored.resume([{ type: 'reject' }], config)).rejects.toThrow('Tool approval execution owner changed');
+        expect(executed).toEqual([]);
+        return;
+      }
       await restored.resume([{ type: 'approve' }], config);
       expect(executed).toEqual(['reviewed']);
     }

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -158,7 +158,7 @@ type CompiledMessagesGraph = Runnable<unknown, { messages: BaseMessage[] }> & {
 /** Factory for a minimal `agent → tools → END` graph wrapping the ToolNode. */
 function buildHITLGraph(
   toolNode: ToolNode,
-  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>,
+  toolCalls: Array<{ id?: string; name: string; args: Record<string, unknown> }>,
   checkpointer = new MemorySaver()
 ): CompiledMessagesGraph {
   const toolCallIds = new Set(toolCalls.map((call) => call.id));
@@ -4152,11 +4152,12 @@ describe('Codex review fixes', () => {
   );
 
   it.each([
-    { direct: true, changedOwner: false }, { direct: false, changedOwner: false },
-    { direct: true, changedOwner: true }, { direct: false, changedOwner: true },
+    { direct: true, changedOwner: false, replaceIds: false }, { direct: false, changedOwner: false, replaceIds: false },
+    { direct: true, changedOwner: true, replaceIds: false }, { direct: false, changedOwner: true, replaceIds: false },
+    { direct: true, changedOwner: true, replaceIds: true }, { direct: false, changedOwner: true, replaceIds: true },
   ])(
-    'restores a rewritten approval with fresh instances (direct=$direct, changedOwner=$changedOwner)',
-    async ({ direct, changedOwner }) => {
+    'restores a rewritten approval with fresh instances (direct=$direct, changedOwner=$changedOwner, replaceIds=$replaceIds)',
+    async ({ direct, changedOwner, replaceIds }) => {
       const checkpointer = new MemorySaver();
       const executed: string[] = [];
       const echo = tool(async ({ command }) => {
@@ -4226,7 +4227,14 @@ describe('Codex review fixes', () => {
       expect(executed).toEqual([]);
       const restored = await create(undefined, changedOwner ? 'different-agent' : 'a');
       if (changedOwner) {
-        await expect(restored.resume([{ type: 'reject' }], config)).rejects.toThrow('Tool approval execution owner changed');
+        const tuple = await checkpointer.getTuple(config);
+        const messages = tuple?.checkpoint.channel_values.messages as BaseMessage[];
+        const assistant = messages.find((message) => message.getType() === 'ai');
+        await expect(restored.resume([{ type: 'reject' }], config, undefined, replaceIds ? {
+          update: { messages: [new AIMessage({ id: assistant?.id, content: '', tool_calls: [
+            { id: 'replacement', name: 'echo', args: { command: 'unreviewed' } },
+          ] })] },
+        } : undefined)).rejects.toThrow('Tool approval execution owner changed');
         expect(executed).toEqual([]);
         return;
       }
@@ -4234,6 +4242,48 @@ describe('Codex review fixes', () => {
       expect(executed).toEqual(['reviewed']);
     }
   );
+
+  it.each([false, true])('preserves ID-less successes beside a rejected approval (mixed=%s)', async (mixed) => {
+    let executions = 0;
+    const work = tool(async () => { executions += 1; return `completed-${executions}`; }, {
+      name: 'work', description: 'work', schema: z.object({}),
+    });
+    const ask = tool(async () => 'approved', { name: 'ask', description: 'ask', schema: z.object({}) });
+    const checkpointer = new MemorySaver();
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', { hooks: [async (input) => ({ decision: input.toolName === 'ask' ? 'ask' : 'allow' })] });
+    const { Run } = await import('@/run');
+    const makeRun = async (hooks?: HookRegistry) => {
+      const run = await Run.create<t.IState>({
+        runId: `idless-${mixed}`,
+        graphConfig: { type: 'standard', agents: [{
+          agentId: 'a', provider: providers.OPENAI,
+          clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+          instructions: 'noop', maxContextTokens: 8000,
+        }], compileOptions: { checkpointer } },
+        humanInTheLoop: { enabled: true }, hooks,
+      });
+      const graph = buildHITLGraph(new ToolNode({
+        tools: [work, ask], agentId: 'a', eventDrivenMode: mixed,
+        directToolNames: new Set(['work']), hookRegistry: hooks,
+        toolCallStepIds: new Map([['ask', 'ask-step']]),
+        humanInTheLoop: { enabled: true },
+      }), [{ name: 'work', args: {} }, { name: 'work', args: {} }, { id: 'ask', name: 'ask', args: {} }], checkpointer);
+      run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+      return { run, graph };
+    };
+    const config = { configurable: { thread_id: `idless-${mixed}` }, version: 'v2' as const };
+    const original = await makeRun(registry);
+    await original.run.processStream({ messages: [] }, config);
+    expect(original.run.getInterrupt()?.payload).toMatchObject({ type: 'tool_approval' });
+    expect(executions).toBe(2);
+    const fresh = await makeRun();
+    await fresh.run.resume([{ type: 'reject' }], config);
+    const result = await fresh.graph.getState?.(config);
+    expect(executions).toBe(2);
+    expect(JSON.stringify(result)).toContain('completed-1');
+    expect(JSON.stringify(result)).toContain('completed-2');
+  });
 
   it('forwards child review evidence without blocking an unrelated parent sibling', async () => {
     const receivedConfigurables: Array<Record<string, unknown> | undefined> =

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -50,6 +50,7 @@ import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
 import { ToolNode } from '../ToolNode';
+import { TOOL_BATCH_REPLAY_KEY, getToolBatchReplayState } from '../toolBatchReplay';
 
 async function flushAsyncWork(): Promise<void> {
   await Promise.resolve();
@@ -157,7 +158,8 @@ type CompiledMessagesGraph = Runnable<unknown, { messages: BaseMessage[] }> & {
 /** Factory for a minimal `agent → tools → END` graph wrapping the ToolNode. */
 function buildHITLGraph(
   toolNode: ToolNode,
-  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>
+  toolCalls: Array<{ id: string; name: string; args: Record<string, unknown> }>,
+  checkpointer = new MemorySaver()
 ): CompiledMessagesGraph {
   const toolCallIds = new Set(toolCalls.map((call) => call.id));
   const builder = new StateGraph(MessagesAnnotation)
@@ -190,7 +192,7 @@ function buildHITLGraph(
     .addEdge('agent', 'tools')
     .addEdge('tools', END);
   return builder.compile({
-    checkpointer: new MemorySaver(),
+    checkpointer,
   }) as unknown as CompiledMessagesGraph;
 }
 
@@ -252,7 +254,15 @@ async function resumeGraph<TResume>(
   }
   return graph.invoke(
     resumeFromInterrupt(interrupted, resume),
-    checkpointConfig
+    {
+      ...checkpointConfig,
+      configurable: {
+        ...checkpointConfig.configurable,
+        [TOOL_BATCH_REPLAY_KEY]: isInterrupted<unknown>(interrupted)
+          ? getToolBatchReplayState(interrupted.__interrupt__[0]?.value)
+          : undefined,
+      },
+    }
   );
 }
 
@@ -1192,6 +1202,8 @@ describe('Run integration — HITL fallback checkpointer + resume', () => {
               value: {
                 type: 'tool_approval',
                 hook_session_id: 'persisted-hook-session',
+                action_requests: [],
+                review_configs: [],
               },
             },
           ],
@@ -3455,7 +3467,43 @@ describe('Codex review fixes', () => {
     expect(executed).toEqual([reviewedName]);
   });
 
-  it('reuses a settled direct sibling when a later event tool interrupts', async () => {
+  it('waits for a started sibling before checkpointing an approval pause', async () => {
+    let release: () => void = () => { throw new Error('not initialized'); };
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    let executions = 0;
+    const slow = tool(async () => {
+      await barrier;
+      executions += 1;
+      return 'completed';
+    }, { name: 'slow', description: 'controlled side effect', schema: z.object({}) });
+    const ask = tool(async () => 'approved', { name: 'ask', description: 'approval', schema: z.object({}) });
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', { hooks: [async (input) => ({ decision: input.toolName === 'ask' ? 'ask' : 'allow' })] });
+    const node = new ToolNode({ tools: [ask, slow], directToolNames: new Set(['ask', 'slow']),
+      hookRegistry: registry, humanInTheLoop: { enabled: true } });
+    const graph = buildHITLGraph(node, [
+      { id: 'ask_call', name: 'ask', args: {} }, { id: 'slow_call', name: 'slow', args: {} },
+    ]);
+    let paused = false;
+    const pending = graph.invoke({ messages: [] }, { configurable: { thread_id: 'settle-before-pause' } })
+      .then((result) => { paused = true; return result; });
+    await flushAsyncWork();
+    expect(paused).toBe(false);
+    expect(executions).toBe(0);
+    release();
+    const interrupted = await pending;
+    expect(executions).toBe(1);
+    expect(isInterrupted(interrupted)).toBe(true);
+    if (!isInterrupted<unknown>(interrupted)) {
+      throw new Error('Expected approval pause');
+    }
+    const state = getToolBatchReplayState(interrupted.__interrupt__[0].value);
+    expect(state?.records).toHaveLength(1);
+  });
+
+  it.each([
+    { fresh: false, mutate: false }, { fresh: true, mutate: false }, { fresh: true, mutate: true },
+  ])('reuses a settled direct sibling when a later event tool interrupts (fresh=$fresh, mutate=$mutate)', async ({ fresh, mutate }) => {
     let directExecutions = 0;
     const completedCallIds: string[] = [];
     const dispatchedEventNames: string[] = [];
@@ -3510,7 +3558,7 @@ describe('Codex review fixes', () => {
             : { decision: 'allow' },
       ],
     });
-    const node = new ToolNode({
+    const createNode = () => new ToolNode({
       tools: [directTool, createSchemaStub('remote_event')],
       toolMap: new Map([
         ['local_direct', directTool],
@@ -3526,7 +3574,8 @@ describe('Codex review fixes', () => {
       hookRegistry: registry,
       humanInTheLoop: { enabled: true },
     });
-    const graph = buildHITLGraph(node, [
+    const checkpointer = new MemorySaver();
+    const calls = [
       {
         id: 'call_direct',
         name: 'local_direct',
@@ -3537,7 +3586,8 @@ describe('Codex review fixes', () => {
         name: 'remote_event',
         args: { command: 'remote' },
       },
-    ]);
+    ];
+    const graph = buildHITLGraph(createNode(), calls, checkpointer);
     const config = { configurable: { thread_id: 'mixed-direct-event-replay' } };
 
     const interrupted = await graph.invoke({ messages: [] }, config);
@@ -3546,12 +3596,45 @@ describe('Codex review fixes', () => {
       1
     );
 
-    const resumed = (await resumeGraph(
-      graph,
-      interrupted,
-      [{ type: 'approve' }],
-      config
-    )) as { messages: BaseMessage[] };
+    let resumed: { messages: BaseMessage[] };
+    if (fresh) {
+      const restoredGraph = buildHITLGraph(createNode(), calls, checkpointer);
+      const { Run } = await import('@/run');
+      const restoredRun = await Run.create<t.IState>({
+        runId: 'a-different-process-run-id',
+        graphConfig: {
+          type: 'standard',
+          agents: [{
+            agentId: 'a', provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop', maxContextTokens: 8000,
+          }],
+          compileOptions: { checkpointer },
+        },
+        humanInTheLoop: { enabled: true },
+      });
+      restoredRun.graphRunnable = restoredGraph as unknown as t.CompiledStateWorkflow;
+      if (mutate) {
+        const checkpoint = await checkpointer.getTuple(config);
+        const messages = checkpoint?.checkpoint.channel_values.messages as BaseMessage[];
+        const original = messages.find((message) => message.getType() === 'ai');
+        await expect(restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' }, undefined, {
+          update: { messages: [new AIMessage({
+            id: original?.id, content: '', tool_calls: calls.map((call) => call.id === 'call_direct' ?
+              { ...call, args: { command: 'different operation' } } : call),
+          })] },
+        })).rejects.toThrow('Cannot change an already completed tool call');
+        expect(directExecutions).toBe(1);
+        expect(dispatchedEventNames).toEqual([]);
+        return;
+      }
+      await restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' });
+      await restoredRun.resume([{ type: 'approve' }], { ...config, version: 'v2' });
+      const state = await restoredGraph.getState?.(config);
+      resumed = (state as { values: { messages: BaseMessage[] } }).values;
+    } else {
+      resumed = await resumeGraph(graph, interrupted, [{ type: 'approve' }], config) as { messages: BaseMessage[] };
+    }
 
     expect(directExecutions).toBe(1);
     expect(completedCallIds.filter((id) => id === 'call_direct')).toHaveLength(
@@ -4066,7 +4149,83 @@ describe('Codex review fixes', () => {
     }
   );
 
-  it('forwards review evidence only through the trusted built-in subagent hop', async () => {
+  it.each([true, false])(
+    'restores a rewritten approval with fresh Run and ToolNode instances (direct=%s)',
+    async (direct) => {
+      const checkpointer = new MemorySaver();
+      const executed: string[] = [];
+      const echo = tool(async ({ command }) => {
+        executed.push(command);
+        return command;
+      }, {
+        name: 'echo',
+        description: 'echo a reviewed command',
+        schema: z.object({ command: z.string() }),
+      });
+      if (!direct) {
+        jest.spyOn(events, 'safeDispatchCustomEvent').mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          const request = data as {
+            toolCalls: t.ToolCallRequest[];
+            resolve: (results: t.ToolExecuteResult[]) => void;
+          };
+          request.resolve(request.toolCalls.map((call) => {
+            const command = String(call.args.command);
+            executed.push(command);
+            return { toolCallId: call.id, content: command, status: 'success' };
+          }));
+        });
+      }
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [async () => ({ decision: 'ask', updatedInput: { command: 'reviewed' } })],
+      });
+      const { Run } = await import('@/run');
+      const create = async (hooks?: HookRegistry) => {
+        const node = new ToolNode({
+          tools: [echo],
+          eventDrivenMode: true,
+          ...(direct ? { directToolNames: new Set(['echo']) } : {}),
+          agentId: 'a',
+          toolCallStepIds: new Map([['call_1', 'step_1']]),
+          hookRegistry: hooks,
+          humanInTheLoop: { enabled: true },
+        });
+        const run = await Run.create<t.IState>({
+          runId: `fresh-approval-${direct}`,
+          graphConfig: {
+            type: 'standard',
+            agents: [{
+              agentId: 'a', provider: providers.OPENAI,
+              clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+              instructions: 'noop', maxContextTokens: 8000,
+            }],
+            compileOptions: { checkpointer },
+          },
+          hooks,
+          humanInTheLoop: { enabled: true },
+        });
+        run.graphRunnable = buildHITLGraph(node, [
+          { id: 'call_1', name: 'echo', args: { command: 'original' } },
+        ], checkpointer) as unknown as t.CompiledStateWorkflow;
+        return run;
+      };
+      const config = { configurable: { thread_id: `fresh-approval-${direct}` }, version: 'v2' as const };
+      const original = await create(registry);
+      await original.processStream({ messages: [] }, config);
+      expect(original.getInterrupt()?.payload).toMatchObject({
+        action_requests: [{ arguments: { command: 'reviewed' } }],
+      });
+      expect(executed).toEqual([]);
+      const restored = await create();
+      await restored.resume([{ type: 'approve' }], config);
+      expect(executed).toEqual(['reviewed']);
+    }
+  );
+
+  it('forwards child review evidence without blocking an unrelated parent sibling', async () => {
     const receivedConfigurables: Array<Record<string, unknown> | undefined> =
       [];
     const subagentTool = tool(
@@ -4087,9 +4246,15 @@ describe('Codex review fixes', () => {
       getSettledOutput: async () => undefined,
       persistSettledOutput: async () => undefined,
     };
+    let siblingExecutions = 0;
+    const sibling = tool(async () => {
+      siblingExecutions += 1;
+      return 'parent result';
+    }, { name: 'parent_sibling', description: 'parent sibling', schema: z.object({}) });
     const node = new ToolNode({
-      tools: [subagentTool],
-      directToolNames: new Set([Constants.SUBAGENT]),
+      tools: [subagentTool, sibling],
+      directToolNames: new Set([Constants.SUBAGENT, 'parent_sibling']),
+      interruptingToolNames: new Set([Constants.SUBAGENT]),
     });
     const graph = buildHITLGraph(node, [
       {
@@ -4097,6 +4262,7 @@ describe('Codex review fixes', () => {
         name: Constants.SUBAGENT,
         args: { description: 'inspect logs', subagent_type: 'researcher' },
       },
+      { id: 'parent_sibling_call', name: 'parent_sibling', args: {} },
     ]);
     const reviewEvidence = createToolApprovalReviewEvidence('interrupt_1', {
       type: 'tool_approval',
@@ -4128,6 +4294,7 @@ describe('Codex review fixes', () => {
     );
 
     expect(receivedConfigurables).toHaveLength(1);
+    expect(siblingExecutions).toBe(1);
     expect(receivedConfigurables[0]?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY]).toBe(
       reviewEvidence
     );

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -38,9 +38,6 @@ import type {
   UserPromptSubmitHookOutput,
 } from '@/hooks';
 import type * as t from '@/types';
-import { Constants, Providers as providers, GraphEvents } from '@/common';
-import { getProviderMessageProvenance } from '@/messages/provenance';
-import { getRunStepResumeState } from '@/tools/runStepResume';
 import {
   TOOL_APPROVAL_REVIEW_CONFIG_KEY,
   createToolApprovalReviewEvidence,
@@ -49,6 +46,10 @@ import {
   SUBAGENT_REPLAY_CONTROLLER,
   type ReplayableSubagentTool,
 } from '@/tools/subagent/SubagentReplay';
+import { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import { Constants, Providers as providers, GraphEvents } from '@/common';
+import { getProviderMessageProvenance } from '@/messages/provenance';
+import { getRunStepResumeState } from '@/tools/runStepResume';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
@@ -3380,6 +3381,175 @@ describe('Codex review fixes', () => {
       ).toBe(true);
     }
   );
+
+  it('fails closed for a direct sibling missing from restored review evidence', async () => {
+    const executed: string[] = [];
+    const tools = ['first_direct', 'second_direct'].map(
+      (name) =>
+        tool(
+          async (): Promise<string> => {
+            executed.push(name);
+            return 'ran';
+          },
+          {
+            name,
+            description: `${name} test tool`,
+            schema: z.object({ command: z.string() }),
+          }
+        ) as unknown as StructuredToolInterface
+    );
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => ({
+          decision: 'ask',
+          reason: 'review direct command',
+        }),
+      ],
+    });
+    const node = new ToolNode({
+      tools,
+      eventDrivenMode: true,
+      directToolNames: new Set(tools.map((entry) => entry.name)),
+      agentId: 'a',
+      toolCallStepIds: new Map([
+        ['call_1', 'step_1'],
+        ['call_2', 'step_2'],
+      ]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'first_direct', args: { command: 'first' } },
+      { id: 'call_2', name: 'second_direct', args: { command: 'second' } },
+    ]);
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'parallel-reviewed-directs',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: { thread_id: 'parallel-reviewed-directs' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    const interrupt = run.getInterrupt();
+    const reviewedName =
+      interrupt?.payload.type === 'tool_approval'
+        ? interrupt.payload.action_requests[0]?.name
+        : undefined;
+    expect(reviewedName).toBeDefined();
+    (node as unknown as { hookRegistry?: HookRegistry }).hookRegistry =
+      undefined;
+
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(executed).toEqual([reviewedName]);
+  });
+
+  it('executes the exact resolved direct arguments that were reviewed', async () => {
+    const executedCommands: string[] = [];
+    const directTool = tool(
+      async ({ command }): Promise<string> => {
+        executedCommands.push(command);
+        return 'ran';
+      },
+      {
+        name: 'reference_direct',
+        description: 'reference test tool',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const registry = makeHookRegistry('ask', 'review resolved command');
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      directToolNames: new Set(['reference_direct']),
+      agentId: 'a',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+      toolOutputReferences: { enabled: true },
+    });
+    const referenceRegistry = (
+      node as unknown as {
+        toolOutputRegistry?: ToolOutputReferenceRegistry;
+      }
+    ).toolOutputRegistry;
+    referenceRegistry?.set(
+      'reviewed-reference-direct',
+      'tool0turn0',
+      'resolved-value'
+    );
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_1',
+        name: 'reference_direct',
+        args: { command: 'echo {{tool0turn0}}' },
+      },
+    ]);
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'reviewed-reference-direct',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+      toolOutputReferences: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: {
+        thread_id: 'reviewed-reference-direct',
+        run_id: 'reviewed-reference-direct',
+      },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    const interrupt = run.getInterrupt();
+    const reviewedArguments =
+      interrupt?.payload.type === 'tool_approval'
+        ? interrupt.payload.action_requests[0]?.arguments
+        : undefined;
+    expect(reviewedArguments).toEqual({
+      command: 'echo resolved-value',
+    });
+    (
+      node as unknown as {
+        toolOutputRegistry?: ToolOutputReferenceRegistry;
+      }
+    ).toolOutputRegistry = new ToolOutputReferenceRegistry();
+
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(executedCommands).toEqual(['echo resolved-value']);
+  });
 
   it('Run.resume fails closed when a reusable hook changes the reviewed arguments', async () => {
     let dispatchCalls = 0;

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import {
-  AIMessage,
-  HumanMessage,
-  ToolMessage,
-} from '@langchain/core/messages';
+import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages';
 import {
   describe,
   it,
@@ -110,10 +106,7 @@ async function stripStopContinuationExecutionIds(
     checkpointer.storage[threadId] ?? {}
   )) {
     for (const stored of Object.values(checkpoints)) {
-      const checkpoint = await checkpointer.serde.loadsTyped(
-        'json',
-        stored[0]
-      );
+      const checkpoint = await checkpointer.serde.loadsTyped('json', stored[0]);
       const runStepState = (
         checkpoint as {
           channel_values?: { runStepState?: t.RunStepResumeState };
@@ -3462,6 +3455,118 @@ describe('Codex review fixes', () => {
     expect(executed).toEqual([reviewedName]);
   });
 
+  it('reuses a settled direct sibling when a later event tool interrupts', async () => {
+    let directExecutions = 0;
+    const completedCallIds: string[] = [];
+    const dispatchedEventNames: string[] = [];
+    const directTool = tool(
+      async (): Promise<string> => {
+        directExecutions += 1;
+        return 'direct-result';
+      },
+      {
+        name: 'local_direct',
+        description: 'local direct test tool',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event === GraphEvents.ON_RUN_STEP_COMPLETED) {
+          const completed = data as {
+            result?: { tool_call?: { id?: string } };
+          };
+          const id = completed.result?.tool_call?.id;
+          if (id != null) {
+            completedCallIds.push(id);
+          }
+          return;
+        }
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        const request = data as {
+          toolCalls: t.ToolCallRequest[];
+          resolve: (results: t.ToolExecuteResult[]) => void;
+        };
+        dispatchedEventNames.push(
+          ...request.toolCalls.map((call) => call.name)
+        );
+        request.resolve(
+          request.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            content: 'event-result',
+            status: 'success' as const,
+          }))
+        );
+      });
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> =>
+          input.toolName === 'remote_event'
+            ? { decision: 'ask', reason: 'review event tool' }
+            : { decision: 'allow' },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [directTool, createSchemaStub('remote_event')],
+      toolMap: new Map([
+        ['local_direct', directTool],
+        ['remote_event', createSchemaStub('remote_event')],
+      ]),
+      eventDrivenMode: true,
+      directToolNames: new Set(['local_direct']),
+      agentId: 'a',
+      toolCallStepIds: new Map([
+        ['call_direct', 'step_direct'],
+        ['call_event', 'step_event'],
+      ]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_direct',
+        name: 'local_direct',
+        args: { command: 'local' },
+      },
+      {
+        id: 'call_event',
+        name: 'remote_event',
+        args: { command: 'remote' },
+      },
+    ]);
+    const config = { configurable: { thread_id: 'mixed-direct-event-replay' } };
+
+    const interrupted = await graph.invoke({ messages: [] }, config);
+    expect(directExecutions).toBe(1);
+    expect(completedCallIds.filter((id) => id === 'call_direct')).toHaveLength(
+      1
+    );
+
+    const resumed = (await resumeGraph(
+      graph,
+      interrupted,
+      [{ type: 'approve' }],
+      config
+    )) as { messages: BaseMessage[] };
+
+    expect(directExecutions).toBe(1);
+    expect(completedCallIds.filter((id) => id === 'call_direct')).toHaveLength(
+      1
+    );
+    expect(dispatchedEventNames).toEqual(['remote_event']);
+    const directResult = resumed.messages.find(
+      (message): message is ToolMessage =>
+        message._getType() === 'tool' &&
+        (message as ToolMessage).tool_call_id === 'call_direct'
+    );
+    expect(directResult?.status).not.toBe('error');
+    expect(directResult?.content).toBe('direct-result');
+  });
+
   it('executes the exact resolved direct arguments that were reviewed', async () => {
     const executedCommands: string[] = [];
     const directTool = tool(
@@ -3549,6 +3654,152 @@ describe('Codex review fixes', () => {
     await run.resume([{ type: 'approve' }], config);
 
     expect(executedCommands).toEqual(['echo resolved-value']);
+  });
+
+  it('replays a direct hook rewrite from the original arguments', async () => {
+    const hookInputs: string[] = [];
+    const executedCommands: string[] = [];
+    const directTool = tool(
+      async ({ command }): Promise<string> => {
+        executedCommands.push(command);
+        return 'ran';
+      },
+      {
+        name: 'rewritten_direct',
+        description: 'rewrite replay test tool',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (input): Promise<PreToolUseHookOutput> => {
+          const command = String(input.toolInput.command);
+          hookInputs.push(command);
+          return {
+            decision: 'ask',
+            reason: 'review rewritten command',
+            updatedInput: { command: `safe:${command}` },
+          };
+        },
+      ],
+    });
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      directToolNames: new Set(['rewritten_direct']),
+      agentId: 'a',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_1',
+        name: 'rewritten_direct',
+        args: { command: 'original' },
+      },
+    ]);
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'direct-rewrite-replay',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: {
+              modelName: 'gpt-4o-mini',
+              apiKey: 'test-key',
+            },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: { thread_id: 'direct-rewrite-replay' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(hookInputs).toEqual(['original', 'original']);
+    expect(executedCommands).toEqual(['safe:original']);
+  });
+
+  it('does not let a host mutation change the reviewed direct proposal', async () => {
+    const executedCommands: string[] = [];
+    const directTool = tool(
+      async ({ command }): Promise<string> => {
+        executedCommands.push(command);
+        return 'ran';
+      },
+      {
+        name: 'immutable_direct',
+        description: 'immutable proposal test tool',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+    const registry = makeHookRegistry('ask', 'review immutable command');
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      directToolNames: new Set(['immutable_direct']),
+      agentId: 'a',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'call_1',
+        name: 'immutable_direct',
+        args: { command: 'reviewed' },
+      },
+    ]);
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'immutable-direct-proposal',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: {
+              modelName: 'gpt-4o-mini',
+              apiKey: 'test-key',
+            },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: { thread_id: 'immutable-direct-proposal' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    const exposed = run.getInterrupt();
+    if (exposed?.payload.type !== 'tool_approval') {
+      throw new Error('expected tool approval');
+    }
+    exposed.payload.action_requests[0].arguments.command = 'mutated';
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(executedCommands).toEqual(['reviewed']);
   });
 
   it('Run.resume fails closed when a reusable hook changes the reviewed arguments', async () => {
@@ -3816,7 +4067,8 @@ describe('Codex review fixes', () => {
   );
 
   it('forwards review evidence only through the trusted built-in subagent hop', async () => {
-    const receivedConfigurables: Array<Record<string, unknown> | undefined> = [];
+    const receivedConfigurables: Array<Record<string, unknown> | undefined> =
+      [];
     const subagentTool = tool(
       async (_input, config): Promise<string> => {
         receivedConfigurables.push(config.configurable);

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -3258,6 +3258,280 @@ describe('Codex review fixes', () => {
     expect(dispatchedArgs).toEqual([{ command: 'redacted-command' }]);
   });
 
+  it.each([
+    {
+      label: 'rejection',
+      decision: { type: 'reject', reason: 'not approved' } as const,
+      expectedDispatches: 0,
+    },
+    {
+      label: 'approval',
+      decision: { type: 'approve' } as const,
+      expectedDispatches: 1,
+    },
+  ])(
+    'Run.resume preserves a reviewed $label when a reusable hook later loosens ask to allow',
+    async ({ label, decision, expectedDispatches }) => {
+      let dispatchCalls = 0;
+      const hostConfigurables: Array<Record<string, unknown> | undefined> = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== 'on_tool_execute') {
+            return;
+          }
+          dispatchCalls += 1;
+          const request = data as {
+            toolCalls: t.ToolCallRequest[];
+            configurable?: Record<string, unknown>;
+            resolve: (results: t.ToolExecuteResult[]) => void;
+          };
+          hostConfigurables.push(request.configurable);
+          request.resolve(
+            request.toolCalls.map((call) => ({
+              toolCallId: call.id,
+              content: 'ran',
+              status: 'success' as const,
+            }))
+          );
+        });
+
+      let hookCalls = 0;
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            hookCalls += 1;
+            return hookCalls === 1
+              ? { decision: 'ask', reason: 'review this command' }
+              : { decision: 'allow' };
+          },
+        ],
+      });
+
+      const node = new ToolNode({
+        tools: [createSchemaStub('echo')],
+        eventDrivenMode: true,
+        agentId: 'a',
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+        hookRegistry: registry,
+        humanInTheLoop: { enabled: true },
+      });
+      const graph = buildHITLGraph(node, [
+        { id: 'call_1', name: 'echo', args: { command: 'reviewed' } },
+      ]);
+
+      const { Run } = await import('@/run');
+      const run = await Run.create<t.IState>({
+        runId: `reviewed-decision-survives-policy-replay-${label}`,
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            {
+              agentId: 'a',
+              provider: providers.OPENAI,
+              clientOptions: {
+                modelName: 'gpt-4o-mini',
+                apiKey: 'test-key',
+              },
+              instructions: 'noop',
+              maxContextTokens: 8000,
+            },
+          ],
+        },
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+      run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+      const config = {
+        configurable: { thread_id: `reviewed-decision-thread-${label}` },
+        version: 'v2' as const,
+      };
+
+      await run.processStream({ messages: [] }, config);
+      expect(run.getInterrupt()?.payload).toMatchObject({
+        type: 'tool_approval',
+        action_requests: [
+          {
+            tool_call_id: 'call_1',
+            name: 'echo',
+            arguments: { command: 'reviewed' },
+          },
+        ],
+      });
+
+      await run.resume([decision], config);
+
+      expect(hookCalls).toBe(2);
+      expect(dispatchCalls).toBe(expectedDispatches);
+      expect(
+        hostConfigurables.every(
+          (configurable) =>
+            configurable?.__librechat_tool_approval_review == null
+        )
+      ).toBe(true);
+    }
+  );
+
+  it('Run.resume fails closed when a reusable hook changes the reviewed arguments', async () => {
+    let dispatchCalls = 0;
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data) => {
+        if (event !== 'on_tool_execute') {
+          return;
+        }
+        dispatchCalls += 1;
+        const request = data as {
+          toolCalls: t.ToolCallRequest[];
+          resolve: (results: t.ToolExecuteResult[]) => void;
+        };
+        request.resolve(
+          request.toolCalls.map((call) => ({
+            toolCallId: call.id,
+            content: 'ran',
+            status: 'success' as const,
+          }))
+        );
+      });
+
+    let hookCalls = 0;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          hookCalls += 1;
+          return {
+            decision: 'ask',
+            reason: 'review this command',
+            updatedInput: {
+              command: hookCalls === 1 ? 'reviewed' : 'changed-after-review',
+            },
+          };
+        },
+      ],
+    });
+
+    const node = new ToolNode({
+      tools: [createSchemaStub('echo')],
+      eventDrivenMode: true,
+      agentId: 'a',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'echo', args: { command: 'original' } },
+    ]);
+
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'reviewed-argument-integrity',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: {
+              modelName: 'gpt-4o-mini',
+              apiKey: 'test-key',
+            },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: { thread_id: 'reviewed-argument-thread' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    await run.resume([{ type: 'approve' }], config);
+
+    expect(hookCalls).toBe(2);
+    expect(dispatchCalls).toBe(0);
+  });
+
+  it('Run.resume preserves the reviewed decision for a direct tool when policy replay loosens', async () => {
+    const executedCommands: string[] = [];
+    const directTool = tool(
+      async ({ command }): Promise<string> => {
+        executedCommands.push(command);
+        return 'ran';
+      },
+      {
+        name: 'direct_echo',
+        description: 'direct test tool',
+        schema: z.object({ command: z.string() }),
+      }
+    ) as unknown as StructuredToolInterface;
+
+    let hookCalls = 0;
+    const registry = new HookRegistry();
+    registry.register('PreToolUse', {
+      hooks: [
+        async (): Promise<PreToolUseHookOutput> => {
+          hookCalls += 1;
+          return hookCalls === 1
+            ? { decision: 'ask', reason: 'review direct command' }
+            : { decision: 'allow' };
+        },
+      ],
+    });
+
+    const node = new ToolNode({
+      tools: [directTool],
+      eventDrivenMode: true,
+      directToolNames: new Set(['direct_echo']),
+      agentId: 'a',
+      toolCallStepIds: new Map([['call_1', 'step_1']]),
+      hookRegistry: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    const graph = buildHITLGraph(node, [
+      { id: 'call_1', name: 'direct_echo', args: { command: 'reviewed' } },
+    ]);
+
+    const { Run } = await import('@/run');
+    const run = await Run.create<t.IState>({
+      runId: 'reviewed-direct-rejection',
+      graphConfig: {
+        type: 'standard',
+        agents: [
+          {
+            agentId: 'a',
+            provider: providers.OPENAI,
+            clientOptions: {
+              modelName: 'gpt-4o-mini',
+              apiKey: 'test-key',
+            },
+            instructions: 'noop',
+            maxContextTokens: 8000,
+          },
+        ],
+      },
+      hooks: registry,
+      humanInTheLoop: { enabled: true },
+    });
+    run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+    const config = {
+      configurable: { thread_id: 'reviewed-direct-thread' },
+      version: 'v2' as const,
+    };
+
+    await run.processStream({ messages: [] }, config);
+    await run.resume([{ type: 'reject', reason: 'not approved' }], config);
+
+    expect(hookCalls).toBe(2);
+    expect(executedCommands).toEqual([]);
+  });
+
   it('captures interrupt even when payload is null (custom node calling interrupt(null))', async () => {
     const langgraph = await import('@langchain/langgraph');
 

--- a/src/tools/__tests__/hitl.test.ts
+++ b/src/tools/__tests__/hitl.test.ts
@@ -41,6 +41,14 @@ import type * as t from '@/types';
 import { Constants, Providers as providers, GraphEvents } from '@/common';
 import { getProviderMessageProvenance } from '@/messages/provenance';
 import { getRunStepResumeState } from '@/tools/runStepResume';
+import {
+  TOOL_APPROVAL_REVIEW_CONFIG_KEY,
+  createToolApprovalReviewEvidence,
+} from '@/hitl/approvalReview';
+import {
+  SUBAGENT_REPLAY_CONTROLLER,
+  type ReplayableSubagentTool,
+} from '@/tools/subagent/SubagentReplay';
 import { HookRegistry, createToolPolicyHook } from '@/hooks';
 import * as events from '@/utils/events';
 import { askUserQuestion } from '@/hitl';
@@ -3530,6 +3538,177 @@ describe('Codex review fixes', () => {
 
     expect(hookCalls).toBe(2);
     expect(executedCommands).toEqual([]);
+  });
+
+  it.each([
+    { label: 'event-dispatched', direct: false },
+    { label: 'direct', direct: true },
+  ])(
+    'Run.resume honors a reviewed rejection for a $label tool after its hook registry is removed',
+    async ({ direct }) => {
+      let executions = 0;
+      const echoTool = tool(
+        async (): Promise<string> => {
+          executions += 1;
+          return 'ran';
+        },
+        {
+          name: 'echo',
+          description: 'test tool',
+          schema: z.object({ command: z.string() }),
+        }
+      ) as unknown as StructuredToolInterface;
+      if (!direct) {
+        jest
+          .spyOn(events, 'safeDispatchCustomEvent')
+          .mockImplementation(async (event, data) => {
+            if (event !== 'on_tool_execute') {
+              return;
+            }
+            executions += 1;
+            const request = data as {
+              toolCalls: t.ToolCallRequest[];
+              resolve: (results: t.ToolExecuteResult[]) => void;
+            };
+            request.resolve(
+              request.toolCalls.map((call) => ({
+                toolCallId: call.id,
+                content: 'ran',
+                status: 'success' as const,
+              }))
+            );
+          });
+      }
+
+      let hookCalls = 0;
+      const registry = new HookRegistry();
+      registry.register('PreToolUse', {
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => {
+            hookCalls += 1;
+            return { decision: 'ask', reason: 'review this command' };
+          },
+        ],
+      });
+      const node = new ToolNode({
+        tools: [echoTool],
+        eventDrivenMode: true,
+        ...(direct ? { directToolNames: new Set(['echo']) } : {}),
+        agentId: 'a',
+        toolCallStepIds: new Map([['call_1', 'step_1']]),
+        hookRegistry: registry,
+        humanInTheLoop: { enabled: true },
+      });
+      const graph = buildHITLGraph(node, [
+        { id: 'call_1', name: 'echo', args: { command: 'reviewed' } },
+      ]);
+      const { Run } = await import('@/run');
+      const run = await Run.create<t.IState>({
+        runId: `removed-hook-registry-${direct ? 'direct' : 'event'}`,
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            {
+              agentId: 'a',
+              provider: providers.OPENAI,
+              clientOptions: {
+                modelName: 'gpt-4o-mini',
+                apiKey: 'test-key',
+              },
+              instructions: 'noop',
+              maxContextTokens: 8000,
+            },
+          ],
+        },
+        hooks: registry,
+        humanInTheLoop: { enabled: true },
+      });
+      run.graphRunnable = graph as unknown as t.CompiledStateWorkflow;
+      const config = {
+        configurable: {
+          thread_id: `removed-hook-registry-${direct ? 'direct' : 'event'}`,
+        },
+        version: 'v2' as const,
+      };
+
+      await run.processStream({ messages: [] }, config);
+      expect(run.getInterrupt()?.payload).toMatchObject({
+        type: 'tool_approval',
+      });
+      (node as unknown as { hookRegistry?: HookRegistry }).hookRegistry =
+        undefined;
+
+      await run.resume([{ type: 'reject', reason: 'not approved' }], config);
+
+      expect(hookCalls).toBe(1);
+      expect(executions).toBe(0);
+    }
+  );
+
+  it('forwards review evidence only through the trusted built-in subagent hop', async () => {
+    const receivedConfigurables: Array<Record<string, unknown> | undefined> = [];
+    const subagentTool = tool(
+      async (_input, config): Promise<string> => {
+        receivedConfigurables.push(config.configurable);
+        return 'child result';
+      },
+      {
+        name: Constants.SUBAGENT,
+        description: 'execute a child agent',
+        schema: z.object({
+          description: z.string(),
+          subagent_type: z.string(),
+        }),
+      }
+    ) as unknown as StructuredToolInterface & ReplayableSubagentTool;
+    subagentTool[SUBAGENT_REPLAY_CONTROLLER] = {
+      getSettledOutput: async () => undefined,
+      persistSettledOutput: async () => undefined,
+    };
+    const node = new ToolNode({
+      tools: [subagentTool],
+      directToolNames: new Set([Constants.SUBAGENT]),
+    });
+    const graph = buildHITLGraph(node, [
+      {
+        id: 'parent_call',
+        name: Constants.SUBAGENT,
+        args: { description: 'inspect logs', subagent_type: 'researcher' },
+      },
+    ]);
+    const reviewEvidence = createToolApprovalReviewEvidence('interrupt_1', {
+      type: 'tool_approval',
+      action_requests: [
+        {
+          tool_call_id: 'child_call',
+          name: 'bash',
+          arguments: { command: 'git status' },
+        },
+      ],
+      review_configs: [
+        {
+          tool_call_id: 'child_call',
+          action_name: 'bash',
+          allowed_decisions: ['approve', 'reject'],
+        },
+      ],
+    });
+    expect(reviewEvidence).toBeDefined();
+
+    await graph.invoke(
+      { messages: [] },
+      {
+        configurable: {
+          thread_id: 'nested-review-evidence',
+          [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: reviewEvidence,
+        },
+      }
+    );
+
+    expect(receivedConfigurables).toHaveLength(1);
+    expect(receivedConfigurables[0]?.[TOOL_APPROVAL_REVIEW_CONFIG_KEY]).toBe(
+      reviewEvidence
+    );
   });
 
   it('captures interrupt even when payload is null (custom node calling interrupt(null))', async () => {

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1450,7 +1450,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     ).toBe(true);
   });
 
-  it('forks nested resumes from each checkpoint in the manifest chain', async () => {
+  it.each([true, false])('forks nested resumes from each checkpoint in the manifest chain (restore hooks=%s)', async (restoreHooks) => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {
       if (provider === Providers.OPENAI) {
         return NestedHitlFakeChatModel;
@@ -1500,7 +1500,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
         returnContent: true,
         skipCleanup: true,
         customHandlers,
-        hooks: registry,
+        hooks: restoreHooks || runId.endsWith('-initial') ? registry : undefined,
         humanInTheLoop: { enabled: true },
       });
     const parentCall = makeSubagentToolCall(

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1096,6 +1096,7 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     );
 
     expect(rebuiltRun.getInterrupt()).toBeUndefined();
+    expect(updates.filter((event) => event.phase === 'error')).toEqual([]);
     expect(executedToolIds).toHaveLength(1);
     expect(deniedToolIds).toHaveLength(1);
     expect(completedSubagentCalls).toEqual([first.id, second.id]);

--- a/src/tools/__tests__/toolOutputReferences.test.ts
+++ b/src/tools/__tests__/toolOutputReferences.test.ts
@@ -9,6 +9,24 @@ import {
 } from '../toolOutputReferences';
 
 describe('ToolOutputReferenceRegistry', () => {
+  describe('resumeBatch', () => {
+    it.each([0, 5])('keeps shared state and applies current limits to frozen inputs (turns=%s)', (turns) => {
+      const registry = new ToolOutputReferenceRegistry({ maxOutputSize: 4, maxTotalSize: 8 });
+      registry.set('r', 'tool0turn4', 'live');
+      for (let i = 0; i < turns; i++) registry.nextTurn('r');
+      const snapshot = registry.resumeBatch('r', {
+        entries: [{ key: 'tool0turn0', value: 'historical-long-value' }],
+        turnCounter: 1, warnedNonStringTools: [],
+      });
+      const value = snapshot.resolve('{{tool0turn0}}').resolved;
+      expect(value.length).toBeLessThanOrEqual(4);
+      expect(snapshot.resolve('{{tool0turn4}}').unresolved).toEqual(['tool0turn4']);
+      expect(registry.get('r', 'tool0turn4')).toBe('live');
+      expect(registry.get('r', 'tool0turn0')).toBeUndefined();
+      expect(registry.nextTurn('r')).toBe(Math.max(turns, 2));
+    });
+  });
+
   describe('buildReferenceKey', () => {
     it('formats keys as tool<idx>turn<turn>', () => {
       expect(buildReferenceKey(0, 0)).toBe('tool0turn0');

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2,7 +2,6 @@ import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
-import { rebindToolBatchReplayScope } from '@/tools/toolBatchReplay';
 import {
   AIMessage,
   BaseMessage,
@@ -89,6 +88,11 @@ import type {
   ToolApprovalReplaySnapshot,
 } from '@/hooks';
 import type { GraphFactory } from '@/graphs/graphFactory';
+import {
+  rebindToolBatchReplayScope,
+  rebindToolBatchReplayPayload,
+  restoreToolReplayConfig,
+} from '@/tools/toolBatchReplay';
 import type { StandardGraph } from '@/graphs/Graph';
 import {
   getSubagentApprovalExecutionScope,
@@ -1449,7 +1453,8 @@ export class SubagentExecutor {
       await this.prepareCheckpointFork(
         resumeExecution.checkpoints,
         branchChildThreadId,
-        lease
+        lease,
+        { source: resumeExecution.approvalExecutionScope, target: approvalExecutionScope }
       );
       let previousApprovals: ToolApprovalReplaySnapshot[] = [];
       let approvalsMutated = false;
@@ -1590,7 +1595,8 @@ export class SubagentExecutor {
   private async prepareCheckpointFork(
     sources: ReadonlyArray<SubagentCheckpointReference>,
     targetThreadId: string,
-    lease: SubagentExecutionPreparationLease
+    lease: SubagentExecutionPreparationLease,
+    approvalScope?: { source: string; target: string }
   ): Promise<void> {
     const checkpointer = this.checkpointer;
     try {
@@ -1609,7 +1615,7 @@ export class SubagentExecutor {
           checkpointer.deleteThread(targetThreadId)
         );
       }
-      await this.forkCheckpointSnapshot(sources, targetThreadId);
+      await this.forkCheckpointSnapshot(sources, targetThreadId, approvalScope);
       lease.assertOwned();
     } catch (error) {
       return lease.rollback(error);
@@ -1664,7 +1670,8 @@ export class SubagentExecutor {
   /** Copies exact checkpoint lineages, including pending task writes. */
   private async forkCheckpointSnapshot(
     sources: ReadonlyArray<SubagentCheckpointReference>,
-    targetThreadId: string
+    targetThreadId: string,
+    approvalScope?: { source: string; target: string }
   ): Promise<void> {
     if (
       this.checkpointer == null ||
@@ -1756,7 +1763,15 @@ export class SubagentExecutor {
             writes = [];
             writesByTask.set(taskId, writes);
           }
-          writes.push([channel, value]);
+          /** Repeated unconsumed forks must persist their current owner. */
+          const reboundValue =
+            channel === INTERRUPT && approvalScope != null &&
+            value != null && typeof value === 'object' && 'value' in value
+              ? { ...value, value: rebindToolBatchReplayPayload(
+                value.value, approvalScope.source, approvalScope.target
+              ) }
+              : value;
+          writes.push([channel, reboundValue]);
         }
         for (const [taskId, writes] of writesByTask) {
           await this.checkpointer.putWrites(storedConfig, writes, taskId);
@@ -2612,13 +2627,6 @@ export class SubagentExecutor {
       if (this.humanInTheLoop?.enabled === true) {
         childConfigurable[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] =
           approvalExecutionScope;
-        if (resumeExecution != null) {
-          rebindToolBatchReplayScope(
-            childConfigurable,
-            resumeExecution.approvalExecutionScope,
-            approvalExecutionScope
-          );
-        }
       }
       if (resumeExecution?.descendant != null) {
         childConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] =
@@ -2655,7 +2663,11 @@ export class SubagentExecutor {
         }
         const persistedInterrupts = getPersistedInterrupts(persistedState);
         if (persistedInterrupts.length > 0) {
-          activeChildRun.pendingInterrupts = persistedInterrupts;
+          activeChildRun.pendingInterrupts = resumeExecution == null ? persistedInterrupts :
+            persistedInterrupts.map((pending) => ({
+              ...pending,
+              value: rebindToolBatchReplayPayload(pending.value, resumeExecution.approvalExecutionScope, approvalExecutionScope),
+            }));
           execution.markStarted();
           childAlreadyStarted = true;
         } else if (persistedState.next.length > 0) {
@@ -2690,6 +2702,15 @@ export class SubagentExecutor {
         }
         let childInput: BaseGraphState | Command | null;
         if (childResumeMap != null) {
+          const pending = activeChildRun.pendingInterrupts.find((entry) =>
+            entry.id != null && Object.prototype.hasOwnProperty.call(childResumeMap, entry.id)
+          ) ?? activeChildRun.pendingInterrupts[0];
+          restoreToolReplayConfig(childConfigurable, pending.id, pending.value);
+          rebindToolBatchReplayScope(
+            childConfigurable,
+            resumeExecution?.approvalExecutionScope ?? approvalExecutionScope,
+            approvalExecutionScope
+          );
           childInput = new Command({ resume: childResumeMap });
         } else if (recoveredInProgress) {
           childInput = null;

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2,6 +2,7 @@ import { nanoid } from 'nanoid';
 import { createHash } from 'crypto';
 import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
 import { AsyncLocalStorageProviderSingleton } from '@langchain/core/singletons';
+import { rebindToolBatchReplayScope } from '@/tools/toolBatchReplay';
 import {
   AIMessage,
   BaseMessage,
@@ -2611,6 +2612,13 @@ export class SubagentExecutor {
       if (this.humanInTheLoop?.enabled === true) {
         childConfigurable[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] =
           approvalExecutionScope;
+        if (resumeExecution != null) {
+          rebindToolBatchReplayScope(
+            childConfigurable,
+            resumeExecution.approvalExecutionScope,
+            approvalExecutionScope
+          );
+        }
       }
       if (resumeExecution?.descendant != null) {
         childConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] =

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -201,7 +201,7 @@ function isDirectPathTurnReference(
   return isString(entry.toolCallId) && isNonnegativeInteger(entry.turn);
 }
 
-function isToolNodeResumeState(
+export function isToolNodeResumeState(
   value: unknown
 ): value is SubagentToolNodeResumeState {
   if (value == null || typeof value !== 'object') {

--- a/src/tools/subagent/SubagentReplay.ts
+++ b/src/tools/subagent/SubagentReplay.ts
@@ -266,7 +266,7 @@ function isToolOutputReferenceEntry(
   return isString(entry.key) && typeof entry.value === 'string';
 }
 
-function isToolOutputReferenceState(
+export function isToolOutputReferenceState(
   value: unknown
 ): value is ToolOutputReferenceState {
   if (value == null || typeof value !== 'object') {

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -1,0 +1,156 @@
+import { ToolMessage } from '@langchain/core/messages';
+import { Command } from '@langchain/langgraph';
+import {
+  TOOL_BATCH_REPLAY_KEY,
+  attachToolBatchReplayState,
+  getToolBatchReplayOwner,
+  getToolBatchReplayState,
+  restoreToolBatchReplayState,
+  stripToolBatchReplayState,
+  restoreToolReplayConfig,
+} from './toolBatchReplay';
+
+const approval = {
+  type: 'tool_approval',
+  action_requests: [{ tool_call_id: 'call', name: 'echo', arguments: {} }],
+  review_configs: [
+    {
+      tool_call_id: 'call',
+      action_name: 'echo',
+      allowed_decisions: ['approve'],
+    },
+  ],
+};
+
+describe('checkpoint-owned tool batch replay', () => {
+  it('does not reinterpret corrupt approval evidence as permission to execute', () => {
+    const configurable = {
+      forged: 'retained',
+      [TOOL_BATCH_REPLAY_KEY]: { version: 1, records: [] },
+    };
+    expect(() =>
+      restoreToolReplayConfig(configurable, 'interrupt', {
+        ...approval,
+        action_requests: [null],
+      })
+    ).toThrow('Invalid tool approval checkpoint');
+    expect(configurable).toEqual({ forged: 'retained' });
+  });
+  it.each([undefined, 'child:task'])(
+    'round-trips complete results through the checkpoint codec (%s)',
+    async (namespace) => {
+      const config = {
+        configurable: { thread_id: 'thread', checkpoint_ns: namespace },
+      };
+      const owner = getToolBatchReplayOwner(config, 'agent');
+      const results = new Map([
+        [
+          'message',
+          {
+            output: new ToolMessage({ content: 'saved', tool_call_id: 'call' }),
+            additionalContexts: ['context'],
+            completionHandled: true,
+          },
+        ],
+        [
+          'command',
+          {
+            output: new Command({
+              update: {
+                messages: [
+                  new ToolMessage({
+                    content: 'handoff',
+                    tool_call_id: 'handoff',
+                  }),
+                ],
+              },
+            }),
+            additionalContexts: [],
+          },
+        ],
+      ]);
+      const payload = await attachToolBatchReplayState(
+        approval,
+        owner,
+        new Map([['batch', results]])
+      );
+      const state = getToolBatchReplayState(
+        JSON.parse(JSON.stringify(payload))
+      );
+      const restored = await restoreToolBatchReplayState(
+        { configurable: { [TOOL_BATCH_REPLAY_KEY]: state } },
+        owner
+      );
+      expect(restored[0].batch).toBe('batch');
+      expect(restored[0].results[0]).toEqual([
+        'message',
+        results.get('message'),
+      ]);
+      const command = restored[0].results[1][1].output;
+      expect(command).toBeInstanceOf(Command);
+      expect(command).toMatchObject({
+        update: { messages: [expect.any(ToolMessage)] },
+      });
+      expect(JSON.stringify(command)).toEqual(
+        JSON.stringify(results.get('command')?.output)
+      );
+      expect(stripToolBatchReplayState(payload)).toEqual(approval);
+    }
+  );
+
+  it('keeps the child approval owner while accumulating distinct parent results', async () => {
+    const child = await attachToolBatchReplayState(
+      approval,
+      'child',
+      new Map()
+    );
+    const parent = await attachToolBatchReplayState(
+      child,
+      'parent',
+      new Map([
+        [
+          'batch',
+          new Map([
+            [
+              'call',
+              {
+                output: new ToolMessage({
+                  content: 'result',
+                  tool_call_id: 'call',
+                }),
+                additionalContexts: [],
+              },
+            ],
+          ]),
+        ],
+      ])
+    );
+    const state = getToolBatchReplayState(parent);
+    expect(state?.approvalOwner).toBe('child');
+    expect(
+      await restoreToolBatchReplayState(
+        { configurable: { [TOOL_BATCH_REPLAY_KEY]: state } },
+        'unrelated'
+      )
+    ).toEqual([]);
+    expect(state?.records.map((record) => record.owner)).toEqual(['parent']);
+  });
+
+  it.each([
+    null,
+    {},
+    { version: 2, records: [] },
+    { version: 1, records: [null] },
+  ])('fails closed for malformed checkpoint state %j', (state) => {
+    expect(() =>
+      getToolBatchReplayState({ [TOOL_BATCH_REPLAY_KEY]: state })
+    ).toThrow('Invalid tool batch replay checkpoint');
+  });
+
+  it('does not require private state in legacy checkpoints', () => {
+    expect(getToolBatchReplayState(approval)).toBeUndefined();
+    expect(
+      getToolBatchReplayState({ [TOOL_BATCH_REPLAY_KEY]: undefined })
+    ).toBeUndefined();
+  });
+});

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -26,6 +26,12 @@ const approval = {
 };
 
 describe('checkpoint-owned tool batch replay', () => {
+  it('does not downgrade a versioned approval with a missing owner to legacy evidence', () => {
+    expect(() => restoreToolReplayConfig({}, 'interrupt', {
+      ...approval, [TOOL_BATCH_REPLAY_KEY]: { version: 1, records: [] },
+    })).toThrow('Invalid tool approval checkpoint');
+    expect(() => restoreToolReplayConfig({}, 'interrupt', approval)).not.toThrow();
+  });
   it('durably rebinds only the proven owner across consecutive unconsumed forks', async () => {
     const owner = JSON.stringify(['source', '', 'agent']);
     const batch = JSON.stringify(['source', 'assistant', 'proposal']);

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -23,6 +23,13 @@ const approval = {
 };
 
 describe('checkpoint-owned tool batch replay', () => {
+  it.each([null, 'confirm', ['one', 'two']])('preserves custom interrupt payload %j with settled results', async (payload) => {
+    const wrapped = await attachToolBatchReplayState(payload, 'owner', new Map([['batch', new Map([['call', {
+      output: new ToolMessage({ content: 'done', tool_call_id: 'call' }), additionalContexts: [],
+    }]])]]));
+    expect(getToolBatchReplayState(wrapped)?.records).toHaveLength(1);
+    expect(stripToolBatchReplayState(wrapped)).toEqual(payload);
+  });
   it('does not reinterpret corrupt approval evidence as permission to execute', () => {
     const configurable = {
       forged: 'retained',

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -10,6 +10,7 @@ import {
   restoreToolReplayConfig,
   getToolBatchReplayScope,
   getPublicToolInterruptPayload,
+  rebindToolBatchReplayPayload,
 } from './toolBatchReplay';
 
 const approval = {
@@ -25,28 +26,140 @@ const approval = {
 };
 
 describe('checkpoint-owned tool batch replay', () => {
+  it('durably rebinds only the proven owner across consecutive unconsumed forks', async () => {
+    const owner = JSON.stringify(['source', '', 'agent']);
+    const batch = JSON.stringify(['source', 'assistant', 'proposal']);
+    const unrelated = JSON.stringify(['other-child', '', 'agent']);
+    const original = await attachToolBatchReplayState(
+      approval,
+      owner,
+      new Map([[batch, new Map()]])
+    );
+    const wrapped = await attachToolBatchReplayState(
+      original,
+      unrelated,
+      new Map([[JSON.stringify(['other-child', 'assistant']), new Map()]])
+    );
+    const first = rebindToolBatchReplayPayload(wrapped, 'source', 'fork-1');
+    const second = rebindToolBatchReplayPayload(
+      JSON.parse(JSON.stringify(first)),
+      'fork-1',
+      'fork-2'
+    );
+    const state = getToolBatchReplayState(second);
+    expect(state?.approvalOwner).toBe(JSON.stringify(['fork-2', '', 'agent']));
+    expect(state?.records.map(({ owner, batch }) => [owner, batch])).toEqual([
+      [
+        JSON.stringify(['fork-2', '', 'agent']),
+        JSON.stringify(['fork-2', 'assistant', 'proposal']),
+      ],
+      [unrelated, JSON.stringify(['other-child', 'assistant'])],
+    ]);
+    expect(getToolBatchReplayState(wrapped)?.approvalOwner).toBe(owner);
+    expect(getPublicToolInterruptPayload(second)).toEqual(approval);
+  });
+
+  it('rejects corrupt reference counters instead of restarting numbering', async () => {
+    const wrapped = await attachToolBatchReplayState(
+      approval,
+      'owner',
+      new Map([['batch', new Map()]])
+    );
+    const state = getToolBatchReplayState(wrapped)!;
+    state.records[0].referenceState = {
+      entries: [],
+      turnCounter: -1,
+      warnedNonStringTools: [],
+    };
+    expect(() =>
+      getToolBatchReplayState({ [TOOL_BATCH_REPLAY_KEY]: state })
+    ).toThrow('Invalid tool batch replay checkpoint');
+  });
+
   it.each([undefined, '', 0])('does not cache a missing scope %j', (scope) => {
-    expect(getToolBatchReplayScope({ configurable: { thread_id: scope } })).toBeUndefined();
+    expect(
+      getToolBatchReplayScope({ configurable: { thread_id: scope } })
+    ).toBeUndefined();
   });
   it('preserves objects resembling the primitive wrapper', async () => {
-    const payload = { __librechat_tool_batch_wrapper: 1, __librechat_tool_batch_payload: 'user data' };
-    const wrapped = await attachToolBatchReplayState(payload, 'owner', new Map([['batch', new Map()]]));
-    expect(getPublicToolInterruptPayload(JSON.parse(JSON.stringify(wrapped)))).toEqual(payload);
+    const payload = {
+      __librechat_tool_batch_wrapper: 1,
+      __librechat_tool_batch_payload: 'user data',
+    };
+    const wrapped = await attachToolBatchReplayState(
+      payload,
+      'owner',
+      new Map([['batch', new Map()]])
+    );
+    expect(
+      getPublicToolInterruptPayload(JSON.parse(JSON.stringify(wrapped)))
+    ).toEqual(payload);
   });
-  it.each([undefined, {}, { name: 'echo' }])('rejects a missing or incomplete proposal %j', async (proposal) => {
-    const wrapped = await attachToolBatchReplayState(approval, 'owner', new Map([['batch', new Map([['call', {
-      proposal, output: new ToolMessage({ content: 'done', tool_call_id: 'call' }), additionalContexts: [],
-    }]])]]));
-    await expect(restoreToolBatchReplayState({ configurable: { [TOOL_BATCH_REPLAY_KEY]: getToolBatchReplayState(wrapped) } }, 'owner'))
-      .rejects.toThrow('Invalid settled tool batch results');
-  });
-  it.each([null, 'confirm', ['one', 'two']])('preserves custom interrupt payload %j with settled results', async (payload) => {
-    const wrapped = await attachToolBatchReplayState(payload, 'owner', new Map([['batch', new Map([['call', {
-      output: new ToolMessage({ content: 'done', tool_call_id: 'call' }), additionalContexts: [],
-    }]])]]));
-    expect(getToolBatchReplayState(wrapped)?.records).toHaveLength(1);
-    expect(stripToolBatchReplayState(wrapped)).toEqual(payload);
-  });
+  it.each([undefined, {}, { name: 'echo' }])(
+    'rejects a missing or incomplete proposal %j',
+    async (proposal) => {
+      const wrapped = await attachToolBatchReplayState(
+        approval,
+        'owner',
+        new Map([
+          [
+            'batch',
+            new Map([
+              [
+                'call',
+                {
+                  proposal,
+                  output: new ToolMessage({
+                    content: 'done',
+                    tool_call_id: 'call',
+                  }),
+                  additionalContexts: [],
+                },
+              ],
+            ]),
+          ],
+        ])
+      );
+      await expect(
+        restoreToolBatchReplayState(
+          {
+            configurable: {
+              [TOOL_BATCH_REPLAY_KEY]: getToolBatchReplayState(wrapped),
+            },
+          },
+          'owner'
+        )
+      ).rejects.toThrow('Invalid settled tool batch results');
+    }
+  );
+  it.each([null, 'confirm', ['one', 'two']])(
+    'preserves custom interrupt payload %j with settled results',
+    async (payload) => {
+      const wrapped = await attachToolBatchReplayState(
+        payload,
+        'owner',
+        new Map([
+          [
+            'batch',
+            new Map([
+              [
+                'call',
+                {
+                  output: new ToolMessage({
+                    content: 'done',
+                    tool_call_id: 'call',
+                  }),
+                  additionalContexts: [],
+                },
+              ],
+            ]),
+          ],
+        ])
+      );
+      expect(getToolBatchReplayState(wrapped)?.records).toHaveLength(1);
+      expect(stripToolBatchReplayState(wrapped)).toEqual(payload);
+    }
+  );
   it('does not reinterpret corrupt approval evidence as permission to execute', () => {
     const configurable = {
       forged: 'retained',

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -8,6 +8,8 @@ import {
   restoreToolBatchReplayState,
   stripToolBatchReplayState,
   restoreToolReplayConfig,
+  getToolBatchReplayScope,
+  getPublicToolInterruptPayload,
 } from './toolBatchReplay';
 
 const approval = {
@@ -23,6 +25,21 @@ const approval = {
 };
 
 describe('checkpoint-owned tool batch replay', () => {
+  it.each([undefined, '', 0])('does not cache a missing scope %j', (scope) => {
+    expect(getToolBatchReplayScope({ configurable: { thread_id: scope } })).toBeUndefined();
+  });
+  it('preserves objects resembling the primitive wrapper', async () => {
+    const payload = { __librechat_tool_batch_wrapper: 1, __librechat_tool_batch_payload: 'user data' };
+    const wrapped = await attachToolBatchReplayState(payload, 'owner', new Map([['batch', new Map()]]));
+    expect(getPublicToolInterruptPayload(JSON.parse(JSON.stringify(wrapped)))).toEqual(payload);
+  });
+  it.each([undefined, {}, { name: 'echo' }])('rejects a missing or incomplete proposal %j', async (proposal) => {
+    const wrapped = await attachToolBatchReplayState(approval, 'owner', new Map([['batch', new Map([['call', {
+      proposal, output: new ToolMessage({ content: 'done', tool_call_id: 'call' }), additionalContexts: [],
+    }]])]]));
+    await expect(restoreToolBatchReplayState({ configurable: { [TOOL_BATCH_REPLAY_KEY]: getToolBatchReplayState(wrapped) } }, 'owner'))
+      .rejects.toThrow('Invalid settled tool batch results');
+  });
   it.each([null, 'confirm', ['one', 'two']])('preserves custom interrupt payload %j with settled results', async (payload) => {
     const wrapped = await attachToolBatchReplayState(payload, 'owner', new Map([['batch', new Map([['call', {
       output: new ToolMessage({ content: 'done', tool_call_id: 'call' }), additionalContexts: [],
@@ -54,6 +71,7 @@ describe('checkpoint-owned tool batch replay', () => {
         [
           'message',
           {
+            proposal: { name: 'echo', args: {} },
             output: new ToolMessage({ content: 'saved', tool_call_id: 'call' }),
             additionalContexts: ['context'],
             completionHandled: true,
@@ -62,6 +80,7 @@ describe('checkpoint-owned tool batch replay', () => {
         [
           'command',
           {
+            proposal: { name: 'handoff', args: {} },
             output: new Command({
               update: {
                 messages: [

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -3,7 +3,12 @@ import { isBaseMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { SubagentToolNodeResumeState } from '@/tools/subagent/SubagentReplay';
-import { isToolNodeResumeState, stripSubagentResumeManifest } from '@/tools/subagent/SubagentReplay';
+import type { ToolOutputReferenceState } from '@/tools/toolOutputReferences';
+import {
+  isToolNodeResumeState,
+  isToolOutputReferenceState,
+  stripSubagentResumeManifest,
+} from '@/tools/subagent/SubagentReplay';
 import { isToolApprovalInterrupt } from '@/types/hitl';
 import { TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY } from '@/hooks/types';
 import {
@@ -37,6 +42,7 @@ export interface ToolBatchReplayRecord {
   encoding: string;
   data: string;
   turnState?: SubagentToolNodeResumeState;
+  referenceState?: ToolOutputReferenceState;
 }
 
 interface ToolBatchReplayState {
@@ -137,6 +143,29 @@ export function rebindToolBatchReplayScope(
   }
 }
 
+/** A fork may be paused again before it consumes its pending interrupt. */
+export function rebindToolBatchReplayPayload(
+  payload: unknown,
+  sourceScope: string,
+  destinationScope: string
+): unknown {
+  const state = getToolBatchReplayState(payload);
+  const value = stripRunStepResumeState(payload);
+  if (state == null || !isRecord(value)) {
+    return payload;
+  }
+  const configurable = { [TOOL_BATCH_REPLAY_KEY]: state };
+  rebindToolBatchReplayScope(configurable, sourceScope, destinationScope);
+  const rebound = {
+    ...value,
+    [TOOL_BATCH_REPLAY_KEY]: configurable[TOOL_BATCH_REPLAY_KEY],
+  };
+  const runStepState = getRunStepResumeState(payload);
+  return runStepState == null
+    ? rebound
+    : attachRunStepResumeState(rebound, runStepState);
+}
+
 export function getToolBatchReplayState(
   payload: unknown
 ): ToolBatchReplayState | undefined {
@@ -155,7 +184,8 @@ export function getToolBatchReplayState(
   const state = candidate as Partial<ToolBatchReplayState> | null;
   if (
     state?.version !== 1 ||
-    (state.wrappedPayload != null && typeof state.wrappedPayload !== 'boolean') ||
+    (state.wrappedPayload != null &&
+      typeof state.wrappedPayload !== 'boolean') ||
     (state.approvalOwner != null && typeof state.approvalOwner !== 'string') ||
     !Array.isArray(state.records) ||
     state.records.some((value: unknown) => {
@@ -168,7 +198,10 @@ export function getToolBatchReplayState(
         typeof record.batch !== 'string' ||
         typeof record.encoding !== 'string' ||
         typeof record.data !== 'string' ||
-        (record.turnState != null && !isToolNodeResumeState(record.turnState))
+        (record.turnState != null &&
+          !isToolNodeResumeState(record.turnState)) ||
+        (record.referenceState != null &&
+          !isToolOutputReferenceState(record.referenceState))
       );
     })
   ) {
@@ -187,7 +220,10 @@ export function stripToolBatchReplayState(payload: unknown): unknown {
   }
   const state = getToolBatchReplayState(payload);
   const { [TOOL_BATCH_REPLAY_KEY]: _state, ...publicPayload } = payload;
-  if (state?.wrappedPayload === true && TOOL_BATCH_PAYLOAD_KEY in publicPayload) {
+  if (
+    state?.wrappedPayload === true &&
+    TOOL_BATCH_PAYLOAD_KEY in publicPayload
+  ) {
     return publicPayload[TOOL_BATCH_PAYLOAD_KEY];
   }
   return publicPayload;
@@ -204,7 +240,8 @@ export async function attachToolBatchReplayState(
   payload: unknown,
   owner: string,
   batches: ReadonlyMap<string, ReadonlyMap<string, object>>,
-  turnState?: SubagentToolNodeResumeState
+  turnState?: SubagentToolNodeResumeState,
+  referenceState?: ToolOutputReferenceState
 ): Promise<unknown> {
   const publicPayload = stripRunStepResumeState(payload);
   const previous = getToolBatchReplayState(publicPayload);
@@ -218,6 +255,7 @@ export async function attachToolBatchReplayState(
       encoding,
       data: Buffer.from(bytes).toString('base64'),
       ...(turnState == null ? {} : { turnState }),
+      ...(referenceState == null ? {} : { referenceState }),
     });
   }
   const approvalOwner =
@@ -227,10 +265,12 @@ export async function attachToolBatchReplayState(
     return payload;
   }
   const result = {
-    ...(isRecord(publicPayload) ? publicPayload : {
-      [TOOL_BATCH_WRAPPER_KEY]: 1,
-      [TOOL_BATCH_PAYLOAD_KEY]: publicPayload,
-    }),
+    ...(isRecord(publicPayload)
+      ? publicPayload
+      : {
+        [TOOL_BATCH_WRAPPER_KEY]: 1,
+        [TOOL_BATCH_PAYLOAD_KEY]: publicPayload,
+      }),
     [TOOL_BATCH_REPLAY_KEY]: {
       version: 1,
       approvalOwner,
@@ -248,7 +288,12 @@ export async function restoreToolBatchReplayState(
   config: RunnableConfig,
   owner: string
 ): Promise<
-  Array<{ batch: string; results: Array<[string, SettledToolBatchResult]>; turnState?: SubagentToolNodeResumeState }>
+  Array<{
+    batch: string;
+    results: Array<[string, SettledToolBatchResult]>;
+    turnState?: SubagentToolNodeResumeState;
+    referenceState?: ToolOutputReferenceState;
+  }>
 > {
   const state = getToolBatchReplayState(config.configurable);
   if (state == null) {
@@ -288,7 +333,8 @@ export async function restoreToolBatchReplayState(
                 typeof result.completionHandled !== 'boolean') ||
               (result.referenceContent != null &&
                 typeof result.referenceContent !== 'string') ||
-              (result.turn != null && (!Number.isSafeInteger(result.turn) || result.turn < 0)) ||
+              (result.turn != null &&
+                (!Number.isSafeInteger(result.turn) || result.turn < 0)) ||
               !isRecord(result.proposal) ||
               typeof result.proposal.name !== 'string' ||
               result.proposal.name.length === 0 ||
@@ -317,7 +363,12 @@ export async function restoreToolBatchReplayState(
             ];
           }
         );
-        return { batch: record.batch, results, turnState: record.turnState };
+        return {
+          batch: record.batch,
+          results,
+          turnState: record.turnState,
+          referenceState: record.referenceState,
+        };
       })
   );
 }

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -2,6 +2,8 @@ import { Command, MemorySaver, isCommand } from '@langchain/langgraph';
 import { isBaseMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
+import type { SubagentToolNodeResumeState } from '@/tools/subagent/SubagentReplay';
+import { isToolNodeResumeState, stripSubagentResumeManifest } from '@/tools/subagent/SubagentReplay';
 import { isToolApprovalInterrupt } from '@/types/hitl';
 import { TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY } from '@/hooks/types';
 import {
@@ -20,12 +22,13 @@ const TOOL_BATCH_PAYLOAD_KEY = '__librechat_tool_batch_payload';
 const TOOL_BATCH_WRAPPER_KEY = '__librechat_tool_batch_wrapper';
 
 export interface SettledToolBatchResult {
-  proposal?: { name: string; args: Record<string, unknown> };
+  proposal: { name: string; args: Record<string, unknown> };
   output: BaseMessage | Command;
   additionalContexts: string[];
   resolvedArgs?: Record<string, unknown>;
   completionHandled?: boolean;
   referenceContent?: string;
+  turn?: number;
 }
 
 export interface ToolBatchReplayRecord {
@@ -33,12 +36,14 @@ export interface ToolBatchReplayRecord {
   batch: string;
   encoding: string;
   data: string;
+  turnState?: SubagentToolNodeResumeState;
 }
 
 interface ToolBatchReplayState {
   version: 1;
   approvalOwner?: string;
   records: ToolBatchReplayRecord[];
+  wrappedPayload?: boolean;
 }
 
 /** Use the same message/Command codec as LangGraph checkpoints. */
@@ -57,7 +62,7 @@ export function restoreToolReplayConfig(
   delete configurable[TOOL_BATCH_REPLAY_KEY];
   delete configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
   const state = getToolBatchReplayState(payload);
-  const publicPayload = stripToolBatchReplayState(payload);
+  const publicPayload = getPublicToolInterruptPayload(payload);
   const review = createToolApprovalReviewEvidence(
     interruptId,
     publicPayload,
@@ -93,7 +98,7 @@ export function getToolBatchReplayScope(
   const scope =
     config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] ??
     config.configurable?.thread_id;
-  return typeof scope === 'string' ? scope : undefined;
+  return typeof scope === 'string' && scope.length > 0 ? scope : undefined;
 }
 
 /** Rebind only the checkpoint-proven source execution when a child fork is created. */
@@ -150,6 +155,7 @@ export function getToolBatchReplayState(
   const state = candidate as Partial<ToolBatchReplayState> | null;
   if (
     state?.version !== 1 ||
+    (state.wrappedPayload != null && typeof state.wrappedPayload !== 'boolean') ||
     (state.approvalOwner != null && typeof state.approvalOwner !== 'string') ||
     !Array.isArray(state.records) ||
     state.records.some((value: unknown) => {
@@ -161,7 +167,8 @@ export function getToolBatchReplayState(
         typeof record.owner !== 'string' ||
         typeof record.batch !== 'string' ||
         typeof record.encoding !== 'string' ||
-        typeof record.data !== 'string'
+        typeof record.data !== 'string' ||
+        (record.turnState != null && !isToolNodeResumeState(record.turnState))
       );
     })
   ) {
@@ -178,17 +185,26 @@ export function stripToolBatchReplayState(payload: unknown): unknown {
   ) {
     return payload;
   }
+  const state = getToolBatchReplayState(payload);
   const { [TOOL_BATCH_REPLAY_KEY]: _state, ...publicPayload } = payload;
-  if (TOOL_BATCH_WRAPPER_KEY in publicPayload && publicPayload[TOOL_BATCH_WRAPPER_KEY] === 1 && TOOL_BATCH_PAYLOAD_KEY in publicPayload) {
+  if (state?.wrappedPayload === true && TOOL_BATCH_PAYLOAD_KEY in publicPayload) {
     return publicPayload[TOOL_BATCH_PAYLOAD_KEY];
   }
   return publicPayload;
 }
 
+/** Decode outer execution metadata before shape-sensitive child wrappers. */
+export function getPublicToolInterruptPayload(payload: unknown): unknown {
+  return stripSubagentResumeManifest(
+    stripToolBatchReplayState(stripRunStepResumeState(payload))
+  );
+}
+
 export async function attachToolBatchReplayState(
   payload: unknown,
   owner: string,
-  batches: ReadonlyMap<string, ReadonlyMap<string, object>>
+  batches: ReadonlyMap<string, ReadonlyMap<string, object>>,
+  turnState?: SubagentToolNodeResumeState
 ): Promise<unknown> {
   const publicPayload = stripRunStepResumeState(payload);
   const previous = getToolBatchReplayState(publicPayload);
@@ -201,6 +217,7 @@ export async function attachToolBatchReplayState(
       batch,
       encoding,
       data: Buffer.from(bytes).toString('base64'),
+      ...(turnState == null ? {} : { turnState }),
     });
   }
   const approvalOwner =
@@ -218,6 +235,7 @@ export async function attachToolBatchReplayState(
       version: 1,
       approvalOwner,
       records,
+      wrappedPayload: previous?.wrappedPayload ?? !isRecord(publicPayload),
     } satisfies ToolBatchReplayState,
   };
   const runStepState = getRunStepResumeState(payload);
@@ -230,7 +248,7 @@ export async function restoreToolBatchReplayState(
   config: RunnableConfig,
   owner: string
 ): Promise<
-  Array<{ batch: string; results: Array<[string, SettledToolBatchResult]> }>
+  Array<{ batch: string; results: Array<[string, SettledToolBatchResult]>; turnState?: SubagentToolNodeResumeState }>
 > {
   const state = getToolBatchReplayState(config.configurable);
   if (state == null) {
@@ -270,9 +288,11 @@ export async function restoreToolBatchReplayState(
                 typeof result.completionHandled !== 'boolean') ||
               (result.referenceContent != null &&
                 typeof result.referenceContent !== 'string') ||
-              (result.proposal != null &&
-                (typeof result.proposal.name !== 'string' ||
-                  !isRecord(result.proposal.args))) ||
+              (result.turn != null && (!Number.isSafeInteger(result.turn) || result.turn < 0)) ||
+              !isRecord(result.proposal) ||
+              typeof result.proposal.name !== 'string' ||
+              result.proposal.name.length === 0 ||
+              !isRecord(result.proposal.args) ||
               (result.resolvedArgs != null && !isRecord(result.resolvedArgs))
             ) {
               throw new Error('Invalid settled tool batch results');
@@ -290,13 +310,14 @@ export async function restoreToolBatchReplayState(
               entry[0],
               {
                 ...result,
+                proposal: result.proposal,
                 output,
                 additionalContexts: result.additionalContexts,
               },
             ];
           }
         );
-        return { batch: record.batch, results };
+        return { batch: record.batch, results, turnState: record.turnState };
       })
   );
 }

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -8,6 +8,7 @@ import {
   isToolNodeResumeState,
   isToolOutputReferenceState,
   stripSubagentResumeManifest,
+  requireValidSubagentResumeManifest,
 } from '@/tools/subagent/SubagentReplay';
 import { isToolApprovalInterrupt } from '@/types/hitl';
 import { TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY } from '@/hooks/types';
@@ -74,7 +75,8 @@ export function restoreToolReplayConfig(
     publicPayload,
     state?.approvalOwner
   );
-  if (isToolApprovalInterrupt(publicPayload) && review == null) {
+  if (isToolApprovalInterrupt(publicPayload) &&
+    (review == null || (state != null && state.approvalOwner == null))) {
     throw new Error('Invalid tool approval checkpoint');
   }
   if (state != null) {
@@ -105,6 +107,25 @@ export function getToolBatchReplayScope(
     config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] ??
     config.configurable?.thread_id;
   return typeof scope === 'string' && scope.length > 0 ? scope : undefined;
+}
+
+/** Foreign approval evidence may only transit a checkpoint-proven child path. */
+export function isChildToolApprovalOwner(
+  config: RunnableConfig,
+  owner: string,
+  trustedParentCallIds: ReadonlySet<string>
+): boolean {
+  const manifest = requireValidSubagentResumeManifest(config.configurable);
+  if (manifest == null || trustedParentCallIds.size === 0) return false;
+  const identity: unknown = JSON.parse(owner);
+  if (!Array.isArray(identity) || identity.length !== 3 || identity[1] !== '') return false;
+  const pending = manifest.executions.filter((execution) => trustedParentCallIds.has(execution.parentToolCallId));
+  while (pending.length > 0) {
+    const execution = pending.pop()!;
+    if (execution.approvalExecutionScope === identity[0]) return true;
+    pending.push(...(execution.descendant?.executions ?? []));
+  }
+  return false;
 }
 
 /** Rebind only the checkpoint-proven source execution when a child fork is created. */

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -16,6 +16,8 @@ import {
 } from '@/tools/runStepResume';
 
 export const TOOL_BATCH_REPLAY_KEY = '__librechat_tool_batch_replay';
+const TOOL_BATCH_PAYLOAD_KEY = '__librechat_tool_batch_payload';
+const TOOL_BATCH_WRAPPER_KEY = '__librechat_tool_batch_wrapper';
 
 export interface SettledToolBatchResult {
   proposal?: { name: string; args: Record<string, unknown> };
@@ -177,6 +179,9 @@ export function stripToolBatchReplayState(payload: unknown): unknown {
     return payload;
   }
   const { [TOOL_BATCH_REPLAY_KEY]: _state, ...publicPayload } = payload;
+  if (TOOL_BATCH_WRAPPER_KEY in publicPayload && publicPayload[TOOL_BATCH_WRAPPER_KEY] === 1 && TOOL_BATCH_PAYLOAD_KEY in publicPayload) {
+    return publicPayload[TOOL_BATCH_PAYLOAD_KEY];
+  }
   return publicPayload;
 }
 
@@ -186,13 +191,6 @@ export async function attachToolBatchReplayState(
   batches: ReadonlyMap<string, ReadonlyMap<string, object>>
 ): Promise<unknown> {
   const publicPayload = stripRunStepResumeState(payload);
-  if (
-    publicPayload == null ||
-    typeof publicPayload !== 'object' ||
-    Array.isArray(publicPayload)
-  ) {
-    return payload;
-  }
   const previous = getToolBatchReplayState(publicPayload);
   const records =
     previous?.records.filter((record) => record.owner !== owner) ?? [];
@@ -212,7 +210,10 @@ export async function attachToolBatchReplayState(
     return payload;
   }
   const result = {
-    ...publicPayload,
+    ...(isRecord(publicPayload) ? publicPayload : {
+      [TOOL_BATCH_WRAPPER_KEY]: 1,
+      [TOOL_BATCH_PAYLOAD_KEY]: publicPayload,
+    }),
     [TOOL_BATCH_REPLAY_KEY]: {
       version: 1,
       approvalOwner,

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -1,0 +1,301 @@
+import { Command, MemorySaver, isCommand } from '@langchain/langgraph';
+import { isBaseMessage } from '@langchain/core/messages';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import { isToolApprovalInterrupt } from '@/types/hitl';
+import { TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY } from '@/hooks/types';
+import {
+  TOOL_APPROVAL_REVIEW_CONFIG_KEY,
+  getToolApprovalReviewEvidence,
+  createToolApprovalReviewEvidence,
+} from '@/hitl/approvalReview';
+import {
+  attachRunStepResumeState,
+  getRunStepResumeState,
+  stripRunStepResumeState,
+} from '@/tools/runStepResume';
+
+export const TOOL_BATCH_REPLAY_KEY = '__librechat_tool_batch_replay';
+
+export interface SettledToolBatchResult {
+  proposal?: { name: string; args: Record<string, unknown> };
+  output: BaseMessage | Command;
+  additionalContexts: string[];
+  resolvedArgs?: Record<string, unknown>;
+  completionHandled?: boolean;
+  referenceContent?: string;
+}
+
+export interface ToolBatchReplayRecord {
+  owner: string;
+  batch: string;
+  encoding: string;
+  data: string;
+}
+
+interface ToolBatchReplayState {
+  version: 1;
+  approvalOwner?: string;
+  records: ToolBatchReplayRecord[];
+}
+
+/** Use the same message/Command codec as LangGraph checkpoints. */
+const serializer = new MemorySaver().serde;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/** The only host-to-runtime entry point for checkpoint-owned tool replay state. */
+export function restoreToolReplayConfig(
+  configurable: Record<string, unknown>,
+  interruptId: string | undefined,
+  payload: unknown
+): void {
+  delete configurable[TOOL_BATCH_REPLAY_KEY];
+  delete configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
+  const state = getToolBatchReplayState(payload);
+  const publicPayload = stripToolBatchReplayState(payload);
+  const review = createToolApprovalReviewEvidence(
+    interruptId,
+    publicPayload,
+    state?.approvalOwner
+  );
+  if (isToolApprovalInterrupt(publicPayload) && review == null) {
+    throw new Error('Invalid tool approval checkpoint');
+  }
+  if (state != null) {
+    configurable[TOOL_BATCH_REPLAY_KEY] = state;
+  }
+  if (review != null) {
+    configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = review;
+  }
+}
+
+export function getToolBatchReplayOwner(
+  config: RunnableConfig,
+  agentId: string
+): string {
+  return JSON.stringify([
+    getToolBatchReplayScope(config),
+    config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] == null
+      ? (config.configurable?.checkpoint_ns ?? '')
+      : '',
+    agentId,
+  ]);
+}
+
+export function getToolBatchReplayScope(
+  config: RunnableConfig
+): string | undefined {
+  const scope =
+    config.configurable?.[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] ??
+    config.configurable?.thread_id;
+  return typeof scope === 'string' ? scope : undefined;
+}
+
+/** Rebind only the checkpoint-proven source execution when a child fork is created. */
+export function rebindToolBatchReplayScope(
+  configurable: Record<string, unknown>,
+  sourceScope: string,
+  destinationScope: string
+): void {
+  const rebind = (key: string): string => {
+    const parts: unknown = JSON.parse(key);
+    if (!Array.isArray(parts) || parts[0] !== sourceScope) {
+      return key;
+    }
+    return JSON.stringify([destinationScope, ...parts.slice(1)]);
+  };
+  const config = { configurable };
+  const review = getToolApprovalReviewEvidence(config);
+  if (review?.owner != null) {
+    configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] = {
+      ...review,
+      owner: rebind(review.owner),
+    };
+  }
+  const state = getToolBatchReplayState(configurable);
+  if (state != null) {
+    configurable[TOOL_BATCH_REPLAY_KEY] = {
+      ...state,
+      approvalOwner:
+        state.approvalOwner == null ? undefined : rebind(state.approvalOwner),
+      records: state.records.map((record) => ({
+        ...record,
+        owner: rebind(record.owner),
+        batch: rebind(record.batch),
+      })),
+    };
+  }
+}
+
+export function getToolBatchReplayState(
+  payload: unknown
+): ToolBatchReplayState | undefined {
+  const value = stripRunStepResumeState(payload);
+  if (
+    value == null ||
+    typeof value !== 'object' ||
+    !(TOOL_BATCH_REPLAY_KEY in value)
+  ) {
+    return undefined;
+  }
+  const candidate: unknown = value[TOOL_BATCH_REPLAY_KEY];
+  if (candidate === undefined) {
+    return undefined;
+  }
+  const state = candidate as Partial<ToolBatchReplayState> | null;
+  if (
+    state?.version !== 1 ||
+    (state.approvalOwner != null && typeof state.approvalOwner !== 'string') ||
+    !Array.isArray(state.records) ||
+    state.records.some((value: unknown) => {
+      if (value == null || typeof value !== 'object') {
+        return true;
+      }
+      const record = value as Partial<ToolBatchReplayRecord>;
+      return (
+        typeof record.owner !== 'string' ||
+        typeof record.batch !== 'string' ||
+        typeof record.encoding !== 'string' ||
+        typeof record.data !== 'string'
+      );
+    })
+  ) {
+    throw new Error('Invalid tool batch replay checkpoint');
+  }
+  return structuredClone(state as ToolBatchReplayState);
+}
+
+export function stripToolBatchReplayState(payload: unknown): unknown {
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    !(TOOL_BATCH_REPLAY_KEY in payload)
+  ) {
+    return payload;
+  }
+  const { [TOOL_BATCH_REPLAY_KEY]: _state, ...publicPayload } = payload;
+  return publicPayload;
+}
+
+export async function attachToolBatchReplayState(
+  payload: unknown,
+  owner: string,
+  batches: ReadonlyMap<string, ReadonlyMap<string, object>>
+): Promise<unknown> {
+  const publicPayload = stripRunStepResumeState(payload);
+  if (
+    publicPayload == null ||
+    typeof publicPayload !== 'object' ||
+    Array.isArray(publicPayload)
+  ) {
+    return payload;
+  }
+  const previous = getToolBatchReplayState(publicPayload);
+  const records =
+    previous?.records.filter((record) => record.owner !== owner) ?? [];
+  for (const [batch, results] of batches) {
+    const [encoding, bytes] = await serializer.dumpsTyped([...results]);
+    records.push({
+      owner,
+      batch,
+      encoding,
+      data: Buffer.from(bytes).toString('base64'),
+    });
+  }
+  const approvalOwner =
+    previous?.approvalOwner ??
+    (isToolApprovalInterrupt(publicPayload) ? owner : undefined);
+  if (records.length === 0 && approvalOwner == null) {
+    return payload;
+  }
+  const result = {
+    ...publicPayload,
+    [TOOL_BATCH_REPLAY_KEY]: {
+      version: 1,
+      approvalOwner,
+      records,
+    } satisfies ToolBatchReplayState,
+  };
+  const runStepState = getRunStepResumeState(payload);
+  return runStepState == null
+    ? result
+    : attachRunStepResumeState(result, runStepState);
+}
+
+export async function restoreToolBatchReplayState(
+  config: RunnableConfig,
+  owner: string
+): Promise<
+  Array<{ batch: string; results: Array<[string, SettledToolBatchResult]> }>
+> {
+  const state = getToolBatchReplayState(config.configurable);
+  if (state == null) {
+    return [];
+  }
+  return Promise.all(
+    state.records
+      .filter((record) => record.owner === owner)
+      .map(async (record) => {
+        const values: unknown = await serializer.loadsTyped(
+          record.encoding,
+          Buffer.from(record.data, 'base64')
+        );
+        if (!Array.isArray(values)) {
+          throw new Error('Invalid settled tool batch results');
+        }
+        const seen = new Set<string>();
+        const results = values.map(
+          (entry: unknown): [string, SettledToolBatchResult] => {
+            if (
+              !Array.isArray(entry) ||
+              entry.length !== 2 ||
+              typeof entry[0] !== 'string' ||
+              seen.has(entry[0])
+            ) {
+              throw new Error('Invalid settled tool batch results');
+            }
+            const result = entry[1] as Partial<SettledToolBatchResult> | null;
+            if (
+              result == null ||
+              (!isBaseMessage(result.output) && !isCommand(result.output)) ||
+              !Array.isArray(result.additionalContexts) ||
+              result.additionalContexts.some(
+                (context) => typeof context !== 'string'
+              ) ||
+              (result.completionHandled != null &&
+                typeof result.completionHandled !== 'boolean') ||
+              (result.referenceContent != null &&
+                typeof result.referenceContent !== 'string') ||
+              (result.proposal != null &&
+                (typeof result.proposal.name !== 'string' ||
+                  !isRecord(result.proposal.args))) ||
+              (result.resolvedArgs != null && !isRecord(result.resolvedArgs))
+            ) {
+              throw new Error('Invalid settled tool batch results');
+            }
+            seen.add(entry[0]);
+            const output = isCommand(result.output)
+              ? new Command({
+                update: result.output.update,
+                goto: result.output.goto,
+                graph: result.output.graph,
+                resume: result.output.resume,
+              })
+              : result.output;
+            return [
+              entry[0],
+              {
+                ...result,
+                output,
+                additionalContexts: result.additionalContexts,
+              },
+            ];
+          }
+        );
+        return { batch: record.batch, results };
+      })
+  );
+}

--- a/src/tools/toolOutputReferences.ts
+++ b/src/tools/toolOutputReferences.ts
@@ -420,6 +420,22 @@ export class ToolOutputReferenceRegistry {
     };
   }
 
+  /** Restore batch inputs without rolling back graph-owned concurrent outputs. */
+  resumeBatch(runId: string, state: ToolOutputReferenceState): ToolOutputResolveView {
+    if (!this.runStates.has(runId)) {
+      this.restoreState(runId, state);
+    }
+    const bucket = this.getOrCreate(runId);
+    bucket.turnCounter = Math.max(bucket.turnCounter, state.turnCounter + 1);
+    const inputs = new ToolOutputReferenceRegistry({
+      maxOutputSize: this.maxOutputSize,
+      maxTotalSize: this.maxTotalSize,
+      maxActiveRuns: 1,
+    });
+    inputs.restoreState(runId, state);
+    return inputs.snapshot(runId);
+  }
+
   /** Restores a checkpointed run bucket under the current resume scope. */
   restoreState(
     runId: string | undefined,


### PR DESCRIPTION
## Summary

I bound human approval decisions to the exact tool proposal restored from the durable interrupt checkpoint, preventing hook replay, runtime rebuilding, and direct sibling execution from changing or bypassing what the user reviewed.

- Restore private approval evidence for both `Run.resume()` and direct `Command` resume entry points.
- Preserve the original approval gate when reusable policy hooks loosen from ask to allow.
- Fail closed when the tool call ID, tool name, resolved arguments, batch membership, batch order, or allowed decisions differ at resume time.
- Treat restored evidence as the authoritative direct-execution lifecycle, including empty allowed-decision lists and absent parallel siblings.
- Resolve dynamic arguments before presenting them for approval and reuse those exact effective arguments for hooks and execution.
- Preserve stricter deny decisions made during hook replay.
- Permit only an exact trusted subagent replay when a restored direct sibling is absent from the approval evidence.
- Apply the same integrity checks to event-dispatched and direct tools.
- Strip private review evidence before host dispatch or direct tool invocation.
- Add regression coverage for approval, rejection, argument drift, batch drift, direct-tool replay, parallel siblings, empty allowlists, and resolved placeholders.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran the two focused approval suites selected from the changed HITL and tool-node boundaries: 93 tests passed.
- Ran ESLint and import-order checks on the affected TypeScript files.
- Ran the TypeScript no-emit typecheck.
- Rebased onto current `main`, including the streamed-argument parsing change in #530, and reran the focused suites successfully.
- Relied on CI for the broad repository matrix.

### **Test Configuration**:

- Node.js with the repository dependency tree
- LangGraph `MemorySaver` checkpoints
- Event-driven and direct-tool execution modes

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in complex areas of my code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective
- [x] Local focused unit tests pass with my changes
