### PR TITLE
⏱️ test: Extend Azure Streaming Test Timeout

### DIFF
--- a/src/specs/azure.simple.test.ts
+++ b/src/specs/azure.simple.test.ts
@@ -212,7 +212,7 @@ describeIfAzure(`${capitalizeFirstLetter(provider)} Streaming Tests`, () => {
       }
       throw error;
     }
-  });
+  }, 60000);
 
   test(`${capitalizeFirstLetter(provider)}: should generate title using completion method`, async () => {
     if (contentFilterTriggered) {


### PR DESCRIPTION
## Summary

I extended the timeout for the live Azure streaming test that exceeded Jest’s 30-second default in the v3.8.2 publish workflow.

- Set a scoped 60-second timeout on the Azure streaming and structured-title test.
- Kept the suite-level 30-second timeout unchanged for all remaining tests.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Ran `npx jest src/specs/azure.simple.test.ts --runInBand` (blocked before execution because this worktree does not have `ts-jest` installed).
- Verified the patch with `git diff --check`.

### **Test Configuration**:

- Local dependency installation is absent in this worktree.
- CI has the Azure credentials required to exercise this live integration test.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
