### PR TITLE
🧯 fix: Stop Retrying Unsupported Code Environments

### DIFF
--- a/src/tools/BashExecutor.ts
+++ b/src/tools/BashExecutor.ts
@@ -279,7 +279,7 @@ function createBashExecutionTool(
         };
 
         const proxyAgent = resolveFetchProxyAgent(execEndpoint);
-        if (proxyAgent) {
+        if (proxyAgent != null) {
           fetchOptions.agent = proxyAgent;
         }
         const response = await fetch(execEndpoint, fetchOptions);
@@ -343,7 +343,7 @@ function createBashExecutionTool(
           normalizeCodeApiRequestError(error).message,
           command
         );
-        throw new Error(`Execution error:\n\n${messageWithReminder}`);
+        throw new CodeApiRequestError(`Execution error:\n\n${messageWithReminder}`);
       }
     },
     {

--- a/src/tools/BashProgrammaticToolCalling.ts
+++ b/src/tools/BashProgrammaticToolCalling.ts
@@ -542,9 +542,11 @@ export function createBashProgrammaticToolCallingTool(
           (error as Error).message,
           code
         );
-        throw new Error(
-          `Bash programmatic execution failed: ${messageWithReminder}`
-        );
+        const message = `Bash programmatic execution failed: ${messageWithReminder}`;
+        if (error instanceof CodeApiRequestError) {
+          throw new CodeApiRequestError(message);
+        }
+        throw new Error(message, { cause: error });
       }
     },
     {

--- a/src/tools/CodeExecutor.ts
+++ b/src/tools/CodeExecutor.ts
@@ -70,6 +70,7 @@ export function appendFailedExecutionFileReminder(
   code: string
 ): string {
   if (
+    output.includes(CODE_API_CAPABILITY_ERROR_MESSAGE) ||
     !MNT_DATA_PATH_PATTERN.test(code) ||
     output.includes(FAILED_EXECUTION_FILE_REMINDER)
   ) {
@@ -157,10 +158,67 @@ const SAFE_CODE_API_EXECUTION_ERROR_DETAILS: Readonly<
   'stdout length exceeded': 'Execution output exceeded the size limit.',
 };
 
+export const CODE_API_CAPABILITY_ERROR_MESSAGE =
+  'Code execution is not supported by the selected environment.';
+const CODE_API_CAPABILITY_ERROR_GUIDANCE =
+  'This is a permanent capability mismatch. Do not retry this tool in this environment; select a compatible environment or use an available workspace tool.';
+
+const CODE_API_CAPABILITY_LIMITATIONS: Readonly<
+  Partial<Record<string, string>>
+> = {
+  bridge_worker_mismatch:
+    'The selected worker does not support the requested execution capabilities (such as the stateful workspace required by programmatic tool calling).',
+  execution_profile_mismatch:
+    'The selected environment does not provide the requested execution profile.',
+  capability_mismatch:
+    'The selected environment lacks a required execution capability.',
+  unsupported_capability:
+    'The selected environment lacks a required execution capability.',
+  stateful_workspace_unsupported:
+    'The selected worker does not provide a stateful workspace.',
+};
+
+function getCodeApiCapabilityErrorMessage(
+  responseBody: string
+): string | undefined {
+  try {
+    const parsed = JSON.parse(responseBody) as {
+      error?: string;
+      code?: string;
+      message?: string;
+    } | null;
+    const code = parsed?.code ?? parsed?.error;
+    if (typeof code !== 'string') return undefined;
+    const normalizedCode = code.toLowerCase();
+    if (!Object.hasOwn(CODE_API_CAPABILITY_LIMITATIONS, normalizedCode))
+      return undefined;
+    let limitation = CODE_API_CAPABILITY_LIMITATIONS[normalizedCode];
+    if (limitation == null) return undefined;
+    if (
+      normalizedCode === 'bridge_worker_mismatch' &&
+      typeof parsed?.message === 'string' &&
+      /^Bridge worker [A-Za-z0-9._:-]+ does not provide a stateful workspace$/.test(
+        parsed.message
+      )
+    ) {
+      limitation =
+        CODE_API_CAPABILITY_LIMITATIONS.stateful_workspace_unsupported;
+    }
+    return `${CODE_API_CAPABILITY_ERROR_MESSAGE} ${limitation} ${CODE_API_CAPABILITY_ERROR_GUIDANCE}`;
+  } catch {
+    return undefined;
+  }
+}
+
 export class CodeApiRequestError extends Error {
+  readonly retryable: boolean;
+
   constructor(message = CODE_API_UNAVAILABLE_ERROR_MESSAGE) {
     super(message);
     this.name = 'CodeApiRequestError';
+    this.retryable =
+      message.includes(CODE_API_UNAVAILABLE_ERROR_MESSAGE) ||
+      message.includes('Code execution is temporarily rate-limited.');
   }
 }
 
@@ -277,11 +335,7 @@ type CodeApiErrorResponse = {
   body?: NodeJS.ReadableStream | null;
 };
 
-/**
- * Only the 429 branch reads the body, and node-fetch keeps the stream and its
- * socket alive until something does. Repeated backend failures would otherwise
- * accumulate connections holding payloads this module deliberately discards.
- */
+/** Releases unread or incomplete error responses after bounded classification. */
 function discardResponseBody(response: CodeApiErrorResponse): void {
   const body = response.body;
   if (body == null || !('destroy' in body)) {
@@ -298,6 +352,48 @@ function discardResponseBody(response: CodeApiErrorResponse): void {
   }
 }
 
+const MAX_CODE_API_ERROR_BODY_BYTES = 64 * 1024;
+const CODE_API_ERROR_BODY_TIMEOUT_MS = 1_000;
+
+/** Reads only small error envelopes, with a deadline for stalled upstreams. */
+async function readCodeApiErrorBody(
+  response: CodeApiErrorResponse
+): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const read = async (): Promise<string> => {
+      if (response.body != null && Symbol.asyncIterator in response.body) {
+        let bytes = 0;
+        const chunks: Buffer[] = [];
+        for await (const chunk of response.body as AsyncIterable<
+          Buffer | string
+        >) {
+          const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          bytes += buffer.length;
+          if (bytes > MAX_CODE_API_ERROR_BODY_BYTES) return '';
+          chunks.push(buffer);
+        }
+        return Buffer.concat(chunks).toString('utf8');
+      }
+      const body = await response.text();
+      return Buffer.byteLength(body) <= MAX_CODE_API_ERROR_BODY_BYTES
+        ? body
+        : '';
+    };
+    return await Promise.race([
+      read(),
+      new Promise<string>((resolve) => {
+        timer = setTimeout(() => resolve(''), CODE_API_ERROR_BODY_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timer);
+    discardResponseBody(response);
+  }
+}
+
 export async function buildCodeApiHttpErrorMessage(
   method: CodeApiMethod,
   _endpoint: string,
@@ -305,8 +401,8 @@ export async function buildCodeApiHttpErrorMessage(
   options?: { recoverable?: boolean; profile?: t.CodeApiExecutionProfile }
 ): Promise<string> {
   /* Logged before the body is touched. A non-OK response can leave a chunked
-     body open, and there is no read timeout here, so draining first would
-     withhold the diagnostic indefinitely for exactly the backend it identifies.
+     body open, so logging first preserves the diagnostic even if the bounded
+     classification read times out.
      The body itself is never logged — it is upstream free text that can echo
      the header that was sent — and the endpoint is host-configured, so the
      backend is named by the profile this module chose rather than by its
@@ -325,16 +421,12 @@ export async function buildCodeApiHttpErrorMessage(
       }
     );
   }
-  if (response.status !== 429) {
-    discardResponseBody(response);
+  const responseBody = await readCodeApiErrorBody(response);
+  const capabilityError = getCodeApiCapabilityErrorMessage(responseBody);
+  if (capabilityError != null) {
+    return capabilityError;
   }
   if (response.status === 429) {
-    let responseBody = '';
-    try {
-      responseBody = await response.text();
-    } catch {
-      responseBody = '';
-    }
     const retryAfterSeconds = getRetryAfterSeconds(responseBody);
     return retryAfterSeconds != null
       ? `Code execution is temporarily rate-limited. Retry after ${retryAfterSeconds} seconds.`
@@ -543,7 +635,7 @@ function createCodeExecutionTool(
         };
 
         const proxyAgent = resolveFetchProxyAgent(execEndpoint);
-        if (proxyAgent) {
+        if (proxyAgent != null) {
           fetchOptions.agent = proxyAgent;
         }
         const response = await fetch(execEndpoint, fetchOptions);
@@ -610,7 +702,9 @@ function createCodeExecutionTool(
           normalizeCodeApiRequestError(error).message,
           code
         );
-        throw new Error(`Execution error:\n\n${messageWithReminder}`);
+        throw new CodeApiRequestError(
+          `Execution error:\n\n${messageWithReminder}`
+        );
       }
     },
     {

--- a/src/tools/ProgrammaticToolCalling.ts
+++ b/src/tools/ProgrammaticToolCalling.ts
@@ -469,7 +469,7 @@ export async function fetchSessionFiles(
     };
 
     const proxyAgent = resolveFetchProxyAgent(filesEndpoint, proxy);
-    if (proxyAgent) {
+    if (proxyAgent != null) {
       fetchOptions.agent = proxyAgent;
     }
 
@@ -531,7 +531,7 @@ export async function makeRequest(
     };
 
     const proxyAgent = resolveFetchProxyAgent(endpoint, proxy);
-    if (proxyAgent) {
+    if (proxyAgent != null) {
       fetchOptions.agent = proxyAgent;
     }
 
@@ -689,7 +689,7 @@ type ToolInputSchemaKind = {
 function detectSchemaKind(schema: unknown): ToolInputSchemaKind {
   const kind: ToolInputSchemaKind = { object: false, string: false };
 
-  if (!schema || typeof schema !== 'object') {
+  if (schema == null || typeof schema !== 'object') {
     return kind;
   }
 
@@ -704,7 +704,7 @@ function detectSchemaKind(schema: unknown): ToolInputSchemaKind {
   }
 
   const zodDef = (schema as { _def?: unknown })._def;
-  if (!zodDef || typeof zodDef !== 'object') {
+  if (zodDef == null || typeof zodDef !== 'object') {
     return kind;
   }
 
@@ -726,7 +726,7 @@ function detectSchemaKind(schema: unknown): ToolInputSchemaKind {
         type?: unknown;
       }
     ).innerType ?? (zodDef as { schema?: unknown }).schema;
-  if (innerSchema) {
+  if (innerSchema != null) {
     const innerKind = detectSchemaKind(innerSchema);
     kind.object ||= innerKind.object;
     kind.string ||= innerKind.string;
@@ -1221,9 +1221,11 @@ export function createProgrammaticToolCallingTool(
           (error as Error).message,
           code
         );
-        throw new Error(
-          `Programmatic execution failed: ${messageWithReminder}`
-        );
+        const message = `Programmatic execution failed: ${messageWithReminder}`;
+        if (error instanceof CodeApiRequestError) {
+          throw new CodeApiRequestError(message);
+        }
+        throw new Error(message, { cause: error });
       }
     },
     {

--- a/src/tools/__tests__/CodeApiAuthHeaders.test.ts
+++ b/src/tools/__tests__/CodeApiAuthHeaders.test.ts
@@ -1,4 +1,5 @@
 import fetch from 'node-fetch';
+import { Readable } from 'node:stream';
 import {
   afterEach,
   beforeEach,
@@ -26,6 +27,8 @@ import {
 } from '../ProgrammaticToolCalling';
 import { createBashProgrammaticToolCallingTool } from '../BashProgrammaticToolCalling';
 import {
+  CodeApiRequestError,
+  buildCodeApiHttpErrorMessage,
   createCodeExecutionTool,
   resolveCodeApiAuthHeaders,
 } from '../CodeExecutor';
@@ -474,6 +477,108 @@ describe('CodeAPI auth header injection', () => {
     expect((error as Error).message).not.toContain('Cannot POST');
   });
 
+  it.each([400, 409, 422, 500, 503])(
+    'classifies worker capability mismatches independently of HTTP %s',
+    async (status) => {
+      fetchMock.mockResolvedValueOnce(
+        errorResponse(
+          status,
+          JSON.stringify({
+            error: 'bridge_worker_mismatch',
+            message:
+              'Code environment does not support this execution; select a compatible worker',
+          })
+        )
+      );
+      const error = await makeRequest('https://code.example/exec', {}).catch(
+        (caught: unknown) => caught
+      );
+      expect(error).toBeInstanceOf(CodeApiRequestError);
+      expect(error).toHaveProperty('retryable', false);
+      expect((error as Error).message).toContain('stateful workspace');
+      expect((error as Error).message).toContain('Do not retry');
+      expect((error as Error).message).not.toContain('temporarily');
+    }
+  );
+
+  it.each([
+    'BRIDGE_WORKER_MISMATCH',
+    'execution_profile_mismatch',
+    'capability_mismatch',
+    'unsupported_capability',
+  ])(
+    'recognizes structured capability code %s without exposing upstream text',
+    async (code) => {
+      fetchMock.mockResolvedValueOnce(
+        errorResponse(
+          503,
+          JSON.stringify({
+            code,
+            message: 'Bearer secret-token from private.internal',
+          })
+        )
+      );
+      const error = await makeRequest('https://code.example/exec', {}).catch(
+        (caught: unknown) => caught
+      );
+      expect(error).toHaveProperty('retryable', false);
+      expect((error as Error).message).not.toContain('secret-token');
+      expect((error as Error).message).not.toContain('private.internal');
+    }
+  );
+
+  it.each([
+    ['Bash', () => createBashExecutionTool().invoke({ command: 'echo 1' })],
+    ['Code', () => createCodeExecutionTool().invoke({ lang: 'py', code: 'print(1)' })],
+    ['Python PTC', () => createProgrammaticToolCallingTool().invoke({ code: 'print(1)' }, {
+      toolCall: { toolMap: toolMap(), toolDefs },
+    } as RunnableConfig)],
+  ] as const)('preserves non-retryable errors through the %s wrapper', async (_name, invoke) => {
+    fetchMock.mockResolvedValueOnce(errorResponse(409, JSON.stringify({ error: 'bridge_worker_mismatch' })));
+    const error = await invoke().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(CodeApiRequestError);
+    expect(error).toHaveProperty('retryable', false);
+  });
+
+  it('does not tell programmatic Bash to rerun files after a permanent mismatch', async () => {
+    fetchMock.mockResolvedValueOnce(
+      errorResponse(
+        409,
+        JSON.stringify({
+          error: 'BRIDGE_WORKER_MISMATCH',
+          message:
+            'Bridge worker personal-vm does not provide a stateful workspace',
+        })
+      )
+    );
+    const error = await createBashProgrammaticToolCallingTool()
+      .invoke({ code: 'echo result > /mnt/data/result.txt' }, {
+        toolCall: { toolMap: toolMap(), toolDefs },
+      } as RunnableConfig)
+      .catch((caught: unknown) => caught);
+    expect(error).toHaveProperty('retryable', false);
+    expect((error as Error).message).toContain(
+      'does not provide a stateful workspace'
+    );
+    expect((error as Error).message).not.toContain('personal-vm');
+    expect((error as Error).message).not.toContain('fix the error and rerun');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'not JSON',
+    'null',
+    '{"error":"bridge_worker_offline"}',
+    '{"error":"bridge_worker_busy"}',
+  ])('keeps unavailable failures retryable for %s', async (body) => {
+    fetchMock.mockResolvedValueOnce(errorResponse(503, body));
+    const error = await makeRequest('https://code.example/exec', {}).catch(
+      (caught: unknown) => caught
+    );
+    expect(error).toHaveProperty('retryable', true);
+    expect((error as Error).message).toContain('temporarily unavailable');
+  });
+
   it.each([401, 403])(
     'reports CodeAPI HTTP %s authorization failures as non-retryable',
     async (status) => {
@@ -636,7 +741,7 @@ describe('CodeAPI auth header injection', () => {
     debugSpy.mockRestore();
   });
 
-  it('discards a body it will never read, and keeps the one it will', async () => {
+  it('releases error response bodies after bounded classification', async () => {
     const destroy = jest.fn();
     fetchMock.mockResolvedValueOnce({
       ok: false,
@@ -663,8 +768,53 @@ describe('CodeAPI auth header injection', () => {
       .invoke({ command: 'echo 1' })
       .catch((caught: unknown) => caught);
 
-    expect(rateLimitedDestroy).not.toHaveBeenCalled();
+    expect(rateLimitedDestroy).toHaveBeenCalledTimes(1);
     expect((error as Error).message).toContain('Retry after 3 seconds');
+  });
+
+  it('classifies a real streamed error envelope', async () => {
+    const body = Readable.from([
+      Buffer.from('{"error":"bridge_'),
+      Buffer.from('worker_mismatch"}'),
+    ]);
+    const message = await buildCodeApiHttpErrorMessage('POST', '', {
+      status: 409,
+      body,
+      text: async () => '',
+    });
+    expect(message).toContain('permanent capability mismatch');
+    expect(body.destroyed).toBe(true);
+  });
+
+  it('stops reading oversized error bodies', async () => {
+    const body = Readable.from([
+      Buffer.alloc(64 * 1024 + 1),
+      Buffer.from('{"error":"bridge_worker_mismatch"}'),
+    ]);
+    const message = await buildCodeApiHttpErrorMessage('POST', '', {
+      status: 503,
+      body,
+      text: async () => '',
+    });
+    expect(message).toContain('temporarily unavailable');
+    expect(body.destroyed).toBe(true);
+  });
+
+  it('bounds stalled error reads and releases the stream', async () => {
+    jest.useFakeTimers();
+    const body = new Readable({ read() {} });
+    try {
+      const pending = buildCodeApiHttpErrorMessage('POST', '', {
+        status: 503,
+        body,
+        text: async () => '',
+      });
+      await jest.advanceTimersByTimeAsync(1_000);
+      expect(await pending).toContain('temporarily unavailable');
+      expect(body.destroyed).toBe(true);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('logs the rejection before the response body is drained', async () => {


### PR DESCRIPTION
## Summary

I classify unsupported Code API execution capabilities as permanent failures so agents stop retrying attached workers that cannot provide a stateful workspace.

- Recognize `bridge_worker_mismatch` / `BRIDGE_WORKER_MISMATCH`, execution-profile mismatches, and structured capability errors regardless of HTTP status.
- Return a safe explanation of the missing capability and explicit instructions to select a compatible environment or available workspace tool.
- Preserve `CodeApiRequestError.retryable = false` through direct code/Bash and Python/Bash programmatic wrappers, and suppress contradictory file-rerun reminders.
- Bound error-envelope reads to 64 KiB and one second, release streams, and preserve response-body redaction and transient/rate-limit guidance.

The companion LibreChat change, https://github.com/danny-avila/LibreChat/pull/15726, gates programmatic Bash before advertisement. This PR requires an agents package release and downstream adoption to make the improved classification available in deployed LibreChat; it does not publish an npm version.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Run `npx jest CodeApiAuthHeaders CodeExecutor.stateful langfuse deterministic-trace-id --runInBand --silent`: 288 tests passed.
- Run `npx jest CodeApiAuthHeaders ProgrammaticToolCalling --runInBand --silent`: 172 passed; 9 existing tests skipped.
- Run `npx tsc --noEmit` and `npm run build`: passed.
- Run ESLint on all five changed source/test files and `git diff --check`: passed.
- Cover actual streamed responses, oversized/stalled bodies, uppercase/lowercase codes, multiple HTTP statuses, auth redaction, and non-retryable metadata through each execution wrapper.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented in any complex areas of my code
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes
