### PR TITLE
🧶 chore: Restore LangSmith Streaming in Nested Graphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@langchain/google-gauth": "2.2.0",
         "@langchain/google-genai": "2.2.0",
         "@langchain/google-vertexai": "2.2.0",
-        "@langchain/langgraph": "1.4.8",
+        "@langchain/langgraph": "1.4.11",
         "@langchain/mistralai": "^1.2.0",
         "@langchain/openai": "1.5.8",
         "@langchain/textsplitters": "^1.0.1",
@@ -2660,13 +2660,13 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
-      "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.11.tgz",
+      "integrity": "sha512-M1GLcxgY9Rrk8OCnQTEAK2bAF7WD76XCVc9w3oDGj3D24qcV7bU4i1Ggsqn8Sjls/0BSObuX8WelGtIQioS2Qw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "^1.1.3",
-        "@langchain/langgraph-sdk": "~1.9.26",
+        "@langchain/langgraph-sdk": "~1.9.30",
         "@langchain/protocol": "^0.0.18",
         "@standard-schema/spec": "1.1.0"
       },
@@ -2708,9 +2708,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "1.9.28",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
-      "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
+      "version": "1.9.31",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.31.tgz",
+      "integrity": "sha512-y1sSdq39IPb6mOX43+JiSezVbUdA8EBEJ1gvn91GP0jrLG0EcSApeRDCjRouyDpPXZ51bQXEQhA8CiHM0mzcAw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/protocol": "^0.0.18",

--- a/package.json
+++ b/package.json
@@ -302,7 +302,7 @@
     "@langchain/google-gauth": "2.2.0",
     "@langchain/google-genai": "2.2.0",
     "@langchain/google-vertexai": "2.2.0",
-    "@langchain/langgraph": "1.4.8",
+    "@langchain/langgraph": "1.4.11",
     "@langchain/mistralai": "^1.2.0",
     "@langchain/openai": "1.5.8",
     "@langchain/textsplitters": "^1.0.1",

--- a/src/specs/langsmith-stream.test.ts
+++ b/src/specs/langsmith-stream.test.ts
@@ -1,0 +1,80 @@
+import { Client } from 'langsmith';
+import { randomUUID } from 'node:crypto';
+import { HumanMessage } from '@langchain/core/messages';
+import { awaitAllCallbacks } from '@langchain/core/callbacks/promises';
+import { LangChainTracer } from '@langchain/core/tracers/tracer_langchain';
+import { Providers } from '@/common';
+import { Run } from '@/run';
+
+describe('agent streaming with LangSmith tracing', () => {
+  beforeEach(() => {
+    jest.replaceProperty(process, 'env', {
+      ...process.env,
+      LANGCHAIN_TRACING: 'false',
+      LANGCHAIN_TRACING_V2: 'false',
+      LANGSMITH_TRACING_V2: 'false',
+      LANGSMITH_TRACING: 'false',
+      LANGCHAIN_API_KEY: 'test-key',
+      LANGSMITH_API_KEY: 'test-key',
+    });
+    jest.spyOn(Client.prototype, 'createRun').mockResolvedValue(undefined);
+    jest.spyOn(Client.prototype, 'updateRun').mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await awaitAllCallbacks();
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    { tracing: 'disabled', background: 'true' },
+    { tracing: 'explicit', background: 'true' },
+    { tracing: 'environment', background: 'true' },
+    { tracing: 'environment', background: 'false' },
+  ])(
+    'completes with $tracing tracing and background=$background',
+    async ({ tracing, background }) => {
+      process.env.LANGCHAIN_CALLBACKS_BACKGROUND = background;
+      if (tracing === 'environment') {
+        process.env.LANGCHAIN_TRACING_V2 = 'true';
+      }
+
+      const run = await Run.create({
+        runId: randomUUID(),
+        langfuse: { enabled: false },
+        graphConfig: {
+          type: 'standard',
+          agents: [
+            {
+              agentId: 'agent',
+              provider: Providers.OPENAI,
+              clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'test-key' },
+              instructions: 'Reply with the single word OK.',
+              maxContextTokens: 8000,
+            },
+          ],
+        },
+      });
+      run.Graph?.overrideTestModel(['OK'], 1);
+
+      await run.processStream(
+        { messages: [new HumanMessage('say OK')] },
+        {
+          version: 'v2',
+          callbacks: tracing === 'explicit' ? [new LangChainTracer()] : [],
+        }
+      );
+      await awaitAllCallbacks();
+
+      expect(
+        run.Graph?.getRunMessages()?.map((message) => message.content)
+      ).toEqual(['OK']);
+      if (tracing === 'disabled') {
+        expect(Client.prototype.createRun).not.toHaveBeenCalled();
+      } else {
+        expect(Client.prototype.createRun).toHaveBeenCalled();
+        expect(Client.prototype.updateRun).toHaveBeenCalled();
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary

I fixed agent streaming failures when LangSmith tracing is enabled, as reported in [LibreChat discussion #15740](https://github.com/danny-avila/LibreChat/discussions/15740).

- Bump `@langchain/langgraph` from `1.4.8` to `1.4.11`, the first release containing [upstream fix #2706](https://github.com/langchain-ai/langgraphjs/pull/2706). Nested graphs merged the same streaming callback twice with LangSmith enabled, so the second chain-end callback threw `onChainEnd: Run ID … not found in run map` before the model ran.
- Refresh the lockfile, including LangGraph's SDK dependency from `1.9.28` to `1.9.31`.
- Add a real `Run.processStream` regression covering tracing disabled, an explicit LangSmith tracer, and environment-enabled tracing with background callbacks both enabled and disabled. Use the SDK's fake model and replace only LangSmith network writes.

## Compatibility

This upgrade includes behavior changes beyond callback deduplication:

- **Checkpoint rollback compatibility (1.4.9, [#2653](https://github.com/langchain-ai/langgraphjs/pull/2653)):** Non-unique `Topic` channels, including `__pregel_tasks`, now write flat values instead of `[seen, values]`. The new reader accepts legacy checkpoints. I verified with a real interrupted StateGraph and MemorySaver that 1.4.8 → 1.4.11 resumes successfully, while 1.4.11 → 1.4.8 fails with `Cannot read properties of undefined (reading 'length')`. Avoid sending checkpoints written by the new runtime to old workers during a mixed-version rollout or rollback. Existing checkpoints do not require an upgrade migration.
- **Trace metadata (1.4.10, [#2690](https://github.com/langchain-ai/langgraphjs/pull/2690)):** Runtime `context` aliases are no longer implicitly promoted from `configurable` into LangSmith trace metadata. Explicit trace metadata remains the appropriate way to attach those values. This does not change runtime context values.
- **Callback delivery (1.4.11, [#2706](https://github.com/langchain-ai/langgraphjs/pull/2706)):** Repeated references to the same handler in merged callback managers now receive an event once. Distinct handler instances remain separate.
- **Transitive SDK:** `@langchain/langgraph-sdk` 1.9.28 → 1.9.31 includes remote-client hydration, interrupt, SSE, and HTTPError fixes; this repository does not import that client directly.

Additional validation: `npx jest ToolNode.approvalScope hitl.test agent-handoffs.test durability-checkpoint.integration.test toolBatchReplay.test ToolNode.replayCheckpoint --runInBand` — **189 passed across 6 suites**, including the private approval-resume fields and real Mongo checkpoint persistence. All PR CI checks also passed.

## Change Type

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I reproduced the exact failure both in the agents SDK and in a standalone nested LangGraph. On `1.4.8`, all three tracing-enabled regression cases fail and the tracing-disabled control passes; on `1.4.11`, all four pass.

- `npm audit`: 0 vulnerabilities.
- `npx tsc --noEmit`: passed.
- `npx eslint src/`: 0 errors; 59 pre-existing warnings, verified identical against the unmodified base with its original dependencies.
- `npx eslint src/specs/langsmith-stream.test.ts --max-warnings=0`: passed.
- `npx prettier --check src/specs/langsmith-stream.test.ts`: passed.
- `npx jest src/specs/langsmith-stream.test.ts --runInBand`: 4 passed.
- `npx jest langfuse deterministic-trace-id --runInBand`: 203 passed across 11 suites.

### Test Configuration

Node.js 24.16.0. No live model or LangSmith API requests were used for the new regression.

## Checklist

- [x] My code adheres to this project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes do not introduce new warnings
- [x] I have written tests demonstrating that my changes are effective or that my feature works
- [x] Local unit tests pass with my changes

