### PR TITLE
fix: harden tool approval replay lifecycle

### DIFF
--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -61,16 +61,22 @@ Keep it stable through every approval resume,
 including rebuilt `Run` instances, and change it for each new generation. A
 conversation id alone is insufficient; edits that reuse a response id also need
 a generation epoch. Explicit scoping removes LangGraph's changing task namespace
-from the composite owner while retaining the executing agent id.
+from the composite owner while retaining the executing agent id, principal id,
+and conversation id.
 
 Carried evidence is active only for its resumed interrupt and consuming task.
 The interrupt id is checked against LangGraph's resume map, and the task's
 scratchpad distinguishes a resumed node from later steps of the same invocation.
+Missing or malformed resume internals fail closed whenever a resume value could
+otherwise authorize execution; absence outside a consuming task is treated as
+stale evidence.
 This applies to every ToolNode interrupt, including `ask_user_question` pauses
 that have replay records but no approval-review evidence.
 A validated parent replaying a child approval can forward that child's evidence
-without a local resume value. Stale review and settled-batch evidence are ignored
-together. An active approval with a different execution owner still fails closed;
+without a local resume value. Stale authorization is removed separately from
+settled results for the active owner and batch, so clearing an old review cannot
+repeat checkpointed completed work. An active approval with a different
+execution owner still fails closed;
 starting a fresh generation may select a different agent without inheriting the
 prior approval.
 

--- a/docs/tool-approval-replay.md
+++ b/docs/tool-approval-replay.md
@@ -103,6 +103,10 @@ third-party tools as exactly-once across that crash window.
   Reviewed rejection and allowlist restrictions still apply. Unreviewed direct
   siblings fail closed when their prior policy cannot be reconstructed.
 - Existing public approval payload and resume-decision shapes are unchanged.
+- Three-field owners from the preceding replay format are bound to the current
+  principal and conversation when restored through the checkpoint entry point.
+  Hosts must authorize checkpoint/thread access before calling the SDK; the SDK
+  cannot recover a principal that was never recorded in a legacy checkpoint.
 - Old SDK consumers cannot restore the new completion record. Do not route a
   paused run between SDK versions indiscriminately: drain or version-pin paused
   runs during rollout and before rollback. A durable checkpointer alone is not

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -128,8 +128,9 @@ import {
   attachToolBatchReplayState,
   restoreToolBatchReplayState,
   getToolBatchReplayState,
+  clearStaleToolApprovalConfig,
   isChildToolReplayOwner,
-  isToolReplayResume,
+  getToolReplayResumeStatus,
 } from '@/tools/toolBatchReplay';
 
 function stripToolApprovalReviewConfig(
@@ -925,15 +926,24 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             ? isChildToolReplayOwner(config, reviewEvidence.owner, trustedParentCallIds)
             : replayState.records.some((record) => isChildToolReplayOwner(config, record.owner, trustedParentCallIds));
         }
-        if ((reviewEvidence?.owner != null || replayState != null) &&
-          !isToolReplayResume(config, reviewEvidence?.interruptId ?? replayState?.interruptId, isChildReplay)) {
+        const hasApprovalAuthorization =
+          reviewEvidence?.owner != null || replayState?.approvalOwner != null;
+        const replayResumeStatus = hasApprovalAuthorization || replayState != null
+          ? getToolReplayResumeStatus(
+            config,
+            reviewEvidence?.interruptId ?? replayState?.interruptId,
+            isChildReplay
+          )
+          : undefined;
+        if (replayResumeStatus === 'unverifiable' && hasApprovalAuthorization) {
+          throw new Error('Cannot verify the active tool approval resume — failing closed');
+        }
+        if (replayResumeStatus === 'stale') {
+          const configurable = { ...config.configurable };
+          clearStaleToolApprovalConfig(configurable, replayOwner, activeReplayKey);
           config = {
             ...config,
-            configurable: {
-              ...config.configurable,
-              [TOOL_APPROVAL_REVIEW_CONFIG_KEY]: undefined,
-              [TOOL_BATCH_REPLAY_KEY]: undefined,
-            },
+            configurable,
           };
           reviewEvidence = undefined;
         }

--- a/src/tools/__tests__/ToolNode.approvalScope.test.ts
+++ b/src/tools/__tests__/ToolNode.approvalScope.test.ts
@@ -24,7 +24,8 @@ import { ToolNode } from '../ToolNode';
 function createHarness(
   carryCheckpointConfig = false,
   question = false,
-  completedSibling = false
+  completedSibling = false,
+  resumeInternalMode: 'supported' | 'missing' | 'mismatched' = 'supported'
 ) {
   let carriedConfigurable: RunnableConfig['configurable'];
   const checkpointer = new MemorySaver();
@@ -99,7 +100,7 @@ function createHarness(
                         {
                           id: `${runId}-sibling-${completed}`,
                           name: 'sibling',
-                          args: { value: `${runId}-sibling` },
+                          args: { value: `${runId}-sibling-${completed}` },
                         },
                       ]
                       : []),
@@ -130,9 +131,19 @@ function createHarness(
             ),
           });
         }
+        const configurable = { ...carriedConfigurable, ...config.configurable };
+        if (configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY] != null &&
+          resumeInternalMode !== 'supported') {
+          if (resumeInternalMode === 'missing') {
+            delete configurable.__pregel_resume_map;
+            delete configurable.__pregel_scratchpad;
+          } else {
+            configurable.__pregel_resume_map = {};
+          }
+        }
         const nodeConfig = {
           ...config,
-          configurable: { ...carriedConfigurable, ...config.configurable },
+          configurable,
         };
         if (
           carryCheckpointConfig &&
@@ -178,9 +189,10 @@ function createHarness(
   return { createRun, executions, namespaces, resumeInternals };
 }
 
-function config(scope?: string): RunnableConfig & { version: 'v2' } {
+function config(scope?: string, userId = 'user-a'): RunnableConfig & { version: 'v2' } {
   return {
     configurable: {
+      user_id: userId,
       thread_id: 'same-conversation',
       ...(scope == null
         ? {}
@@ -232,12 +244,47 @@ describe('approval execution scope', () => {
       { messages: [new HumanMessage('start')] },
       runConfig
     );
-    expect(executions).toEqual(['run-1-sibling']);
+    expect(executions).toEqual(['run-1-sibling-0']);
 
     await run.resume([{ type: 'approve' }], runConfig);
-    expect(executions).toEqual(['run-1-sibling', 'run-1-0']);
+    expect(executions).toEqual(['run-1-sibling-0', 'run-1-0']);
     expect(resumeInternals).toEqual([
       { resumeMap: true, scratchpad: true },
+    ]);
+    expect(run.getInterrupt()).toBeUndefined();
+  });
+
+  it.each(['missing', 'mismatched'] as const)(
+    'fails closed without replaying a completed mutation when resume internals are %s',
+    async (resumeInternalMode) => {
+      const { createRun, executions } = createHarness(false, false, true, resumeInternalMode);
+      const runId = `changed-internals-${resumeInternalMode}`;
+      const run = await createRun('a', runId);
+      const runConfig = config(runId);
+      await run.processStream({ messages: [new HumanMessage('start')] }, runConfig);
+      expect(executions).toEqual([`${runId}-sibling-0`]);
+
+      await expect(run.resume([{ type: 'approve' }], runConfig)).rejects.toThrow(
+        'Cannot verify the active tool approval resume'
+      );
+      expect(executions).toEqual([`${runId}-sibling-0`]);
+    }
+  );
+
+  it('preserves completed results through two consecutive approval cycles', async () => {
+    const { createRun, executions } = createHarness(true, false, true);
+    const run = await createRun('a', 'two-cycle-replay', 4);
+    const runConfig = config('two-cycle-replay');
+    await run.processStream({ messages: [new HumanMessage('start')] }, runConfig);
+    await run.resume([{ type: 'approve' }], runConfig);
+    expect(run.getInterrupt()?.payload).toMatchObject({ type: 'tool_approval' });
+    await run.resume([{ type: 'approve' }], runConfig);
+
+    expect(executions).toEqual([
+      'two-cycle-replay-sibling-0',
+      'two-cycle-replay-0',
+      'two-cycle-replay-sibling-2',
+      'two-cycle-replay-2',
     ]);
     expect(run.getInterrupt()).toBeUndefined();
   });
@@ -256,7 +303,7 @@ describe('approval execution scope', () => {
     expect(rebuilt.getInterrupt()).toBeUndefined();
   });
 
-  it.each(['agent', 'scope'])(
+  it.each(['agent', 'scope', 'principal'])(
     'fails closed when the %s changes during the pending resume',
     async (changedIdentity) => {
       const { createRun, executions } = createHarness();
@@ -272,7 +319,10 @@ describe('approval execution scope', () => {
       await expect(
         resumed.resume(
           [{ type: 'approve' }],
-          config(changedIdentity === 'scope' ? 'run-2' : 'run-1')
+          config(
+            changedIdentity === 'scope' ? 'run-2' : 'run-1',
+            changedIdentity === 'principal' ? 'user-b' : 'user-a'
+          )
         )
       ).rejects.toThrow('Tool approval execution owner changed');
       expect(executions).toEqual([]);

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1768,7 +1768,10 @@ export class SubagentExecutor {
             channel === INTERRUPT && approvalScope != null &&
             value != null && typeof value === 'object' && 'value' in value
               ? { ...value, value: rebindToolBatchReplayPayload(
-                value.value, approvalScope.source, approvalScope.target
+                value.value,
+                approvalScope.source,
+                approvalScope.target,
+                targetThreadId
               ) }
               : value;
           writes.push([channel, reboundValue]);
@@ -2666,7 +2669,12 @@ export class SubagentExecutor {
           activeChildRun.pendingInterrupts = resumeExecution == null ? persistedInterrupts :
             persistedInterrupts.map((pending) => ({
               ...pending,
-              value: rebindToolBatchReplayPayload(pending.value, resumeExecution.approvalExecutionScope, approvalExecutionScope),
+              value: rebindToolBatchReplayPayload(
+                pending.value,
+                resumeExecution.approvalExecutionScope,
+                approvalExecutionScope,
+                childThreadId
+              ),
             }));
           execution.markStarted();
           childAlreadyStarted = true;
@@ -2709,7 +2717,8 @@ export class SubagentExecutor {
           rebindToolBatchReplayScope(
             childConfigurable,
             resumeExecution?.approvalExecutionScope ?? approvalExecutionScope,
-            approvalExecutionScope
+            approvalExecutionScope,
+            childThreadId
           );
           childInput = new Command({ resume: childResumeMap });
         } else if (recoveredInProgress) {

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -3,8 +3,9 @@ import { Command } from '@langchain/langgraph';
 import {
   TOOL_BATCH_REPLAY_KEY,
   attachToolBatchReplayState,
+  clearStaleToolApprovalConfig,
   getToolBatchReplayOwner,
-  isToolReplayResume,
+  getToolReplayResumeStatus,
   getToolBatchReplayState,
   restoreToolBatchReplayState,
   stripToolBatchReplayState,
@@ -28,16 +29,45 @@ const approval = {
 
 describe('checkpoint-owned tool batch replay', () => {
   it.each([
-    { interruptId: 'current', resume: [[]], isChildReplay: false, expected: true },
-    { interruptId: 'prior', resume: [[]], isChildReplay: false, expected: false },
-    { interruptId: 'current', resume: [], isChildReplay: false, expected: false },
-    { interruptId: 'current', resume: [], isChildReplay: true, expected: true },
-    { interruptId: 'prior', resume: [], isChildReplay: true, expected: false },
+    { interruptId: 'current', resume: [[]], isChildReplay: false, expected: 'active' },
+    { interruptId: 'prior', resume: [[]], isChildReplay: false, expected: 'unverifiable' },
+    { interruptId: 'current', resume: [], isChildReplay: false, expected: 'stale' },
+    { interruptId: 'current', resume: [], isChildReplay: true, expected: 'active' },
+    { interruptId: 'prior', resume: [], isChildReplay: true, expected: 'stale' },
   ])('scopes replay to the active interrupt and consuming task: %j', ({ interruptId, resume, isChildReplay, expected }) => {
-    expect(isToolReplayResume({ configurable: {
+    const status = getToolReplayResumeStatus({ configurable: {
       __pregel_resume_map: { current: [{ type: 'approve' }] },
       __pregel_scratchpad: { resume },
-    } }, interruptId, isChildReplay)).toBe(expected);
+    } }, interruptId, isChildReplay);
+    expect(status).toBe(expected);
+  });
+
+  it.each([
+    {},
+    { __pregel_resume_map: { current: [] } },
+    { __pregel_resume_map: { current: [] }, __pregel_scratchpad: {} },
+  ])('fails closed when resume internals are unavailable or malformed: %j', (configurable) => {
+    expect(getToolReplayResumeStatus({ configurable }, 'current', false)).toBe('unverifiable');
+  });
+
+  it('distinguishes stale execution from an unverifiable active resume', () => {
+    expect(getToolReplayResumeStatus({ configurable: {
+      __pregel_scratchpad: { resume: [] },
+    } }, 'current', false)).toBe('stale');
+    expect(getToolReplayResumeStatus({ configurable: {
+      __pregel_scratchpad: { resume: [{ type: 'approve' }] },
+    } }, 'current', false)).toBe('unverifiable');
+  });
+
+  it('accepts only an unambiguous task-local legacy resume without a restored interrupt id', () => {
+    expect(getToolReplayResumeStatus({ configurable: {
+      __pregel_resume_map: { current: [{ type: 'approve' }] },
+      __pregel_scratchpad: { resume: [[{ type: 'approve' }]] },
+    } }, undefined, false)).toBe('active');
+    expect(getToolReplayResumeStatus({ configurable: {
+      __pregel_resume_map: { first: [], second: [] },
+      __pregel_scratchpad: { resume: [[{ type: 'approve' }]] },
+    } }, undefined, false)).toBe('unverifiable');
   });
 
   it('stamps question replay state with the checkpoint-owned interrupt id', async () => {
@@ -111,6 +141,34 @@ describe('checkpoint-owned tool batch replay', () => {
     expect(
       getToolBatchReplayScope({ configurable: { thread_id: scope } })
     ).toBeUndefined();
+  });
+  it('binds replay ownership to principal and conversation identity', () => {
+    const owner = (user_id: string, thread_id: string) => getToolBatchReplayOwner({ configurable: {
+      user_id,
+      thread_id,
+      __librechat_tool_approval_execution_scope: 'run',
+    } }, 'agent');
+    expect(owner('user-a', 'thread')).not.toBe(owner('user-b', 'thread'));
+    expect(owner('user', 'thread-a')).not.toBe(owner('user', 'thread-b'));
+  });
+  it('removes stale approval evidence without discarding settled results', async () => {
+    const output = new ToolMessage({ content: 'checkpointed mutation', tool_call_id: 'call' });
+    const payload = await attachToolBatchReplayState(approval, 'owner', new Map([
+      ['batch', new Map([['call', {
+        proposal: { name: 'echo', args: {} },
+        output,
+        additionalContexts: [],
+      }]])],
+    ]));
+    const configurable: Record<string, unknown> = {};
+    restoreToolReplayConfig(configurable, 'interrupt', payload);
+
+    clearStaleToolApprovalConfig(configurable, 'owner', 'batch');
+
+    expect(configurable).not.toHaveProperty('__librechat_tool_approval_review');
+    const restored = await restoreToolBatchReplayState({ configurable }, 'owner');
+    expect(restored).toHaveLength(1);
+    expect(restored[0].results[0][1].output).toEqual(output);
   });
   it('preserves objects resembling the primitive wrapper', async () => {
     const payload = {

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -120,6 +120,26 @@ describe('checkpoint-owned tool batch replay', () => {
     expect(getPublicToolInterruptPayload(second)).toEqual(approval);
   });
 
+  it('rebinds conversation identity only through the trusted fork adapter', async () => {
+    const owner = JSON.stringify(['source', '', 'agent', 'user', 'parent-thread']);
+    const payload = await attachToolBatchReplayState(
+      approval,
+      owner,
+      new Map([[JSON.stringify(['source', 'assistant']), new Map()]])
+    );
+
+    const rebound = rebindToolBatchReplayPayload(
+      payload,
+      'source',
+      'child',
+      'child-thread'
+    );
+
+    expect(getToolBatchReplayState(rebound)?.approvalOwner).toBe(
+      JSON.stringify(['child', '', 'agent', 'user', 'child-thread'])
+    );
+  });
+
   it('rejects corrupt reference counters instead of restarting numbering', async () => {
     const wrapped = await attachToolBatchReplayState(
       approval,

--- a/src/tools/toolBatchReplay.test.ts
+++ b/src/tools/toolBatchReplay.test.ts
@@ -171,6 +171,25 @@ describe('checkpoint-owned tool batch replay', () => {
     expect(owner('user-a', 'thread')).not.toBe(owner('user-b', 'thread'));
     expect(owner('user', 'thread-a')).not.toBe(owner('user', 'thread-b'));
   });
+  it('binds legacy checkpoint owners during trusted restoration', async () => {
+    const legacyOwner = JSON.stringify(['run', '', 'agent']);
+    const payload = await attachToolBatchReplayState(approval, legacyOwner, new Map([
+      ['batch', new Map([['call', {
+        proposal: { name: 'echo', args: {} },
+        output: new ToolMessage({ content: 'done', tool_call_id: 'call' }),
+        additionalContexts: [],
+      }]])],
+    ]));
+    const configurable = { user_id: 'user', thread_id: 'thread' };
+
+    restoreToolReplayConfig(configurable, 'interrupt', payload);
+
+    const owner = JSON.stringify(['run', '', 'agent', 'user', 'thread']);
+    const restored = getToolBatchReplayState(configurable);
+    expect(restored?.approvalOwner).toBe(owner);
+    expect(restored?.records[0]?.owner).toBe(owner);
+    await expect(restoreToolBatchReplayState({ configurable }, owner)).resolves.toHaveLength(1);
+  });
   it('removes stale approval evidence without discarding settled results', async () => {
     const output = new ToolMessage({ content: 'checkpointed mutation', tool_call_id: 'call' });
     const payload = await attachToolBatchReplayState(approval, 'owner', new Map([

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -64,6 +64,44 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value != null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function bindLegacyReplayOwner(
+  owner: string,
+  configurable: Record<string, unknown>
+): string {
+  let identity: unknown;
+  try {
+    identity = JSON.parse(owner);
+  } catch {
+    return owner;
+  }
+  if (!Array.isArray(identity) || identity.length !== 3) {
+    return owner;
+  }
+  return JSON.stringify([
+    ...identity,
+    typeof configurable.user_id === 'string' ? configurable.user_id : '',
+    typeof configurable.thread_id === 'string' ? configurable.thread_id : '',
+  ]);
+}
+
+function bindLegacyReplayState(
+  state: ToolBatchReplayState | undefined,
+  configurable: Record<string, unknown>
+): ToolBatchReplayState | undefined {
+  if (state == null) return undefined;
+  return {
+    ...state,
+    approvalOwner:
+      state.approvalOwner == null
+        ? undefined
+        : bindLegacyReplayOwner(state.approvalOwner, configurable),
+    records: state.records.map((record) => ({
+      ...record,
+      owner: bindLegacyReplayOwner(record.owner, configurable),
+    })),
+  };
+}
+
 /** The only host-to-runtime entry point for checkpoint-owned tool replay state. */
 export function restoreToolReplayConfig(
   configurable: Record<string, unknown>,
@@ -72,7 +110,10 @@ export function restoreToolReplayConfig(
 ): void {
   delete configurable[TOOL_BATCH_REPLAY_KEY];
   delete configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
-  const state = getToolBatchReplayState(payload);
+  const state = bindLegacyReplayState(
+    getToolBatchReplayState(payload),
+    configurable
+  );
   const publicPayload = getPublicToolInterruptPayload(payload);
   const review = createToolApprovalReviewEvidence(
     interruptId,

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -210,14 +210,19 @@ export function isChildToolReplayOwner(
 export function rebindToolBatchReplayScope(
   configurable: Record<string, unknown>,
   sourceScope: string,
-  destinationScope: string
+  destinationScope: string,
+  destinationThreadId?: string
 ): void {
   const rebind = (key: string): string => {
     const parts: unknown = JSON.parse(key);
     if (!Array.isArray(parts) || parts[0] !== sourceScope) {
       return key;
     }
-    return JSON.stringify([destinationScope, ...parts.slice(1)]);
+    const rebound = [destinationScope, ...parts.slice(1)];
+    if (rebound.length === 5 && destinationThreadId != null) {
+      rebound[4] = destinationThreadId;
+    }
+    return JSON.stringify(rebound);
   };
   const config = { configurable };
   const review = getToolApprovalReviewEvidence(config);
@@ -246,7 +251,8 @@ export function rebindToolBatchReplayScope(
 export function rebindToolBatchReplayPayload(
   payload: unknown,
   sourceScope: string,
-  destinationScope: string
+  destinationScope: string,
+  destinationThreadId?: string
 ): unknown {
   const state = getToolBatchReplayState(payload);
   const value = stripRunStepResumeState(payload);
@@ -254,7 +260,12 @@ export function rebindToolBatchReplayPayload(
     return payload;
   }
   const configurable = { [TOOL_BATCH_REPLAY_KEY]: state };
-  rebindToolBatchReplayScope(configurable, sourceScope, destinationScope);
+  rebindToolBatchReplayScope(
+    configurable,
+    sourceScope,
+    destinationScope,
+    destinationThreadId
+  );
   const rebound = {
     ...value,
     [TOOL_BATCH_REPLAY_KEY]: configurable[TOOL_BATCH_REPLAY_KEY],

--- a/src/tools/toolBatchReplay.ts
+++ b/src/tools/toolBatchReplay.ts
@@ -46,6 +46,8 @@ export interface ToolBatchReplayRecord {
   referenceState?: ToolOutputReferenceState;
 }
 
+export type ToolReplayResumeStatus = 'active' | 'stale' | 'unverifiable';
+
 interface ToolBatchReplayState {
   version: 1;
   approvalOwner?: string;
@@ -95,25 +97,40 @@ export function restoreToolReplayConfig(
  * steps, so the presence of replay evidence alone does not imply a resume.
  * A parent replaying a checkpointed child has no local resume value.
  */
-export function isToolReplayResume(
+export function getToolReplayResumeStatus(
   config: RunnableConfig,
   interruptId: string | undefined,
   isChildReplay: boolean
-): boolean {
-  const resumeMap: object | undefined = config.configurable?.__pregel_resume_map;
-  if (interruptId != null &&
-    resumeMap != null &&
-    !Object.prototype.hasOwnProperty.call(resumeMap, interruptId)) {
-    return false;
+): ToolReplayResumeStatus {
+  const resumeMap: unknown = config.configurable?.__pregel_resume_map;
+  const scratchpad: unknown = config.configurable?.__pregel_scratchpad;
+  if (!isRecord(scratchpad) || !Array.isArray(scratchpad.resume)) {
+    return 'unverifiable';
   }
-  if (isChildReplay && resumeMap != null) {
-    return true;
+  /**
+   * LangGraph supports both an interrupt-id resume map and a task-local
+   * `nullResume` value. The latter is already scoped to the checkpoint task,
+   * so it remains a supported, verifiable resume without a map entry.
+   */
+  if (scratchpad.nullResume !== undefined) {
+    return 'active';
   }
-  const scratchpad: { resume?: { length: number }; nullResume?: unknown } | undefined =
-    config.configurable?.__pregel_scratchpad;
-  return scratchpad == null ||
-    (scratchpad.resume?.length ?? 0) > 0 ||
-    scratchpad.nullResume !== undefined;
+  const hasResume = scratchpad.resume.length > 0;
+  if (!isRecord(resumeMap)) {
+    return hasResume ? 'unverifiable' : 'stale';
+  }
+  if (interruptId == null) {
+    /** Legacy direct graph callers do not restore the ID into replay state. */
+    if (!hasResume) return 'stale';
+    return Object.keys(resumeMap).length === 1 ? 'active' : 'unverifiable';
+  }
+  if (!Object.prototype.hasOwnProperty.call(resumeMap, interruptId)) {
+    return hasResume ? 'unverifiable' : 'stale';
+  }
+  if (isChildReplay) {
+    return 'active';
+  }
+  return hasResume ? 'active' : 'stale';
 }
 
 export function getToolBatchReplayOwner(
@@ -126,7 +143,37 @@ export function getToolBatchReplayOwner(
       ? (config.configurable?.checkpoint_ns ?? '')
       : '',
     agentId,
+    typeof config.configurable?.user_id === 'string'
+      ? config.configurable.user_id
+      : '',
+    typeof config.configurable?.thread_id === 'string'
+      ? config.configurable.thread_id
+      : '',
   ]);
+}
+
+/** Remove stale authorization while retaining only settled results for this batch. */
+export function clearStaleToolApprovalConfig(
+  configurable: Record<string, unknown>,
+  owner: string,
+  batch: string | undefined
+): void {
+  delete configurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
+  const state = getToolBatchReplayState(configurable);
+  const records = batch == null
+    ? []
+    : (state?.records.filter(
+      (record) => record.owner === owner && record.batch === batch
+    ) ?? []);
+  if (state == null || records.length === 0) {
+    delete configurable[TOOL_BATCH_REPLAY_KEY];
+    return;
+  }
+  configurable[TOOL_BATCH_REPLAY_KEY] = {
+    version: 1,
+    records,
+    wrappedPayload: state.wrappedPayload,
+  } satisfies ToolBatchReplayState;
 }
 
 export function getToolBatchReplayScope(
@@ -147,7 +194,9 @@ export function isChildToolReplayOwner(
   const manifest = requireValidSubagentResumeManifest(config.configurable);
   if (manifest == null || trustedParentCallIds.size === 0) return false;
   const identity: unknown = JSON.parse(owner);
-  if (!Array.isArray(identity) || identity.length !== 3 || identity[1] !== '') return false;
+  if (!Array.isArray(identity) ||
+    (identity.length !== 3 && identity.length !== 5) ||
+    identity[1] !== '') return false;
   const pending = manifest.executions.filter((execution) => trustedParentCallIds.has(execution.parentToolCallId));
   while (pending.length > 0) {
     const execution = pending.pop()!;


### PR DESCRIPTION
## Summary

- fail closed when LangGraph resume internals are missing, malformed, or ambiguous instead of silently treating carried approval evidence as active
- bind approval/replay ownership to principal and conversation in addition to execution scope and agent
- clear stale approval authorization independently from checkpointed completed-tool results so a completed mutation is not replayed
- preserve supported direct LangGraph resumes and validated child replay paths
- document the boundary between checkpoint replay safety and the unavoidable crash-before-checkpoint external-effect window

## Focused verification

- `npx jest src/tools/toolBatchReplay.test.ts src/tools/__tests__/ToolNode.approvalScope.test.ts src/tools/__tests__/SubagentReplay.test.ts src/tools/__tests__/ToolNode.replayCheckpoint.test.ts src/tools/__tests__/directToolHITLResumeScope.test.ts --runInBand` (97 tests)
- `npx jest src/tools/__tests__/hitl.test.ts -t 'approval|settled direct sibling|checkpointing an approval pause' --runInBand` (20 selected tests)
- scoped ESLint on the four changed TypeScript files
- `npx tsc --noEmit`
- `git diff --check`

The integration coverage uses the real `StateGraph` + `MemorySaver` + `Run.resume` checkpoint path and counted fake mutations. It covers stale evidence, valid resume, changed/missing internals, agent/execution-scope/principal mismatch, completed sibling replay, and two consecutive approval cycles.

## Compatibility

Public interrupt and resume-decision shapes are unchanged. Existing direct graph resumes remain supported. As already required by the replay protocol, paused executions should be drained or version-pinned during SDK rollout rather than moved between SDK versions.
