### PR TITLE
feat: add host-owned context for subagent executions

### DIFF
--- a/docs/subagent-context.md
+++ b/docs/subagent-context.md
@@ -1,0 +1,52 @@
+# Host-owned subagent context
+
+`Run.create({ subagentContext })` lets a host authorize an individual child
+execution, supply its initial messages, partition its tool sessions, and project
+its successful result. The SDK exports `SUBAGENT_CONTEXT_VERSION = 1` so hosts
+can reject an unsupported installation before enabling features that depend on
+execution identity.
+
+`prepare(input)` runs before the child graph is constructed or invoked. Its input
+contains the SDK-owned `executionContext`, `parentThreadId`, `memberAgentIds`, an
+abort `signal`, and a `resumed` marker. The last ancestry entry's `subagentRunId`
+identifies this execution; saved agent IDs alone do not distinguish concurrent
+copies of an agent. Nested children inherit the adapter and receive their full
+ancestry. A graph subagent has one execution identity and multiple member IDs.
+
+Preparation may return:
+
+- `messages`: actual LangChain messages appended after the task description for
+  a fresh child. They may contain multimodal file content. Existing checkpoint
+  messages are preserved on resume without inserting these messages again.
+- `configurable`: host runtime context. SDK run, thread, checkpoint, and execution
+  identities cannot be replaced through this object.
+- `agentSessions`: entries keyed by child member ID, each replacing that member's
+  `codeSessionKey` and `initialSessions`. Omitting `initialSessions` in an entry
+  clears inherited session seeds. Unknown members are rejected. A paused live
+  graph cannot change its session partition when it resumes.
+
+The SDK calls preparation again when a completed execution is retried and when a
+host rebuilds a paused execution, allowing the host to reauthorize access. Make
+authorization idempotent for the execution identity. Throwing or aborting during
+preparation prevents child execution and produces a generic failure result.
+
+`complete(input, result)` runs after successful child work. It returns the text
+delivered to the parent and can append durable file references. The SDK retains
+the original completed result if delivery fails, so retrying delivery does not
+repeat model or tool side effects. Completion must be idempotent. Failed and
+cancelled child work does not invoke completion.
+
+The same canonical `executionContext` reaches child tool hooks,
+`ToolExecuteBatchRequest.executionContext`, and the `configurable.executionContext`
+and `metadata.executionContext` of direct tool calls. Root tools have no child
+context. Event-driven hosts should use the batch field as authority and overwrite
+inherited configurable or metadata values before invoking tools and handling
+their artifacts.
+
+The adapter does not implement file authorization, storage, publication, or
+sandbox isolation. In particular, `codeSessionKey` partitions the SDK's transient
+session map; the host must also assign a private runtime workspace and prevent
+inherited runtime hints or direct tool implementations from bypassing that
+workspace. Published files and any private artifact recovery remain the host's
+responsibility. The host must reconstruct its adapter and authorization when resuming. The SDK
+does not replay private artifacts to the host when restoring a checkpoint.

--- a/docs/subagent-context.md
+++ b/docs/subagent-context.md
@@ -29,6 +29,9 @@ The SDK calls preparation again when a completed execution is retried and when a
 host rebuilds a paused execution, allowing the host to reauthorize access. Make
 authorization idempotent for the execution identity. Throwing or aborting during
 preparation prevents child execution and produces a generic failure result.
+Cancellation is different: aborting the supplied signal rejects preparation
+and propagates as an execution error, so callers must handle it as cancellation
+rather than as a normal subagent result.
 
 `complete(input, result)` runs after successful child work. It returns the text
 delivered to the parent and can append durable file references. The SDK retains

--- a/docs/subagent-context.md
+++ b/docs/subagent-context.md
@@ -27,11 +27,10 @@ Preparation may return:
 
 The SDK calls preparation again when a completed execution is retried and when a
 host rebuilds a paused execution, allowing the host to reauthorize access. Make
-authorization idempotent for the execution identity. Throwing or aborting during
-preparation prevents child execution and produces a generic failure result.
-Cancellation is different: aborting the supplied signal rejects preparation
-and propagates as an execution error, so callers must handle it as cancellation
-rather than as a normal subagent result.
+authorization idempotent for the execution identity. An ordinary preparation
+failure prevents child execution and produces a generic failure result. Aborting
+the supplied signal instead propagates as an execution error, so callers must
+handle it as cancellation rather than as a normal subagent result.
 
 `complete(input, result)` runs after successful child work. It returns the text
 delivered to the parent and can append durable file references. The SDK retains

--- a/src/__tests__/stream.eagerEventExecution.test.ts
+++ b/src/__tests__/stream.eagerEventExecution.test.ts
@@ -238,6 +238,83 @@ describe('ChatModelStreamHandler eager event tool execution', () => {
     expect(graph.toolCallStepIds.has('call_weather')).toBe(true);
   });
 
+  it('captures normalized code-session identity before eager dispatch', async () => {
+    const graph = createGraph({
+      sessions: new Map([
+        [
+          Constants.EXECUTE_CODE,
+          {
+            session_id: 'exec-session',
+            files: [{ id: 'old-file', name: 'report.csv' }],
+            lastUpdated: 1,
+          },
+        ],
+      ]),
+      getAgentContext: jest.fn(
+        (): Partial<AgentContext> => ({
+          provider: Providers.ANTHROPIC,
+          toolDefinitions: [{ name: Constants.EXECUTE_CODE }],
+          graphTools: [],
+          agentId: 'agent_1',
+          codeSessionKey: Constants.EXECUTE_CODE,
+          getCallerCapabilityProjectionSnapshot: jest.fn(() => ({
+            version: 1 as const,
+            directToolNames: [],
+            codeExecutionToolNames: [Constants.EXECUTE_CODE],
+            directOnlyToolNames: [],
+            codeExecutionOnlyToolNames: [Constants.EXECUTE_CODE],
+          })),
+        })
+      ) as unknown as StandardGraph['getAgentContext'],
+    });
+    jest
+      .spyOn(events, 'safeDispatchCustomEvent')
+      .mockImplementation(async (event, data): Promise<void> => {
+        if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+        const batch = data as t.ToolExecuteBatchRequest;
+        batch.toolCalls[0].codeSessionContext = {
+          session_id: 'new-session',
+          files: [
+            {
+              id: 'new-file',
+              resource_id: 'new-file',
+              name: 'report.csv',
+              storage_session_id: 'new-storage',
+              kind: 'user',
+            },
+          ],
+        };
+        batch.resolve([
+          {
+            toolCallId: 'call_code',
+            status: 'success',
+            content: '',
+          },
+        ]);
+      });
+
+    await new ChatModelStreamHandler().handle(
+      GraphEvents.CHAT_MODEL_STREAM,
+      {
+        chunk: {
+          content: '',
+          tool_calls: [
+            { id: 'call_code', name: Constants.EXECUTE_CODE, args: {} },
+          ],
+          response_metadata: finalToolCallResponseMetadata,
+        } as unknown as t.StreamChunk,
+      },
+      { langgraph_node: 'agent' },
+      graph
+    );
+
+    const record = graph.eagerEventToolExecutions.get('call_code');
+    expect(record?.codeSessionBaselineByName?.get('report.csv')).toBe(
+      'exec-session\0old-file'
+    );
+    expect(record?.request.codeSessionContext?.files?.[0].id).toBe('new-file');
+  });
+
   it('prestarts when subagent callback forwarding can execute tools without a handler registry', async () => {
     const graph = createGraph({
       handlerRegistry: undefined,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,6 @@
+/** Host context preparation and trusted subagent execution identity are supported. */
+export const SUBAGENT_CONTEXT_VERSION = 1;
+
 /**
  * Anthropic direct API tool schema overhead multiplier.
  * Empirically calibrated against real MCP tool sets (29 tools).

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -5353,6 +5353,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
               });
             }
             const result = await executor.execute(executeParams);
+            if (result.retryableDelivery === true) {
+              throw new Error(result.content);
+            }
             return result.content;
           },
           buildSubagentToolParams(executableConfigs, {

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -5537,6 +5537,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
             },
             runId: this.runId,
             isMultiAgent: this.isMultiAgentGraph(),
+            getSubagentExecutionContext: () => this.subagentExecutionContext,
             hookRegistry: this.hookRegistry,
             getToolsForBinding: (
               provider: t.ProviderName,

--- a/src/graphs/Graph.ts
+++ b/src/graphs/Graph.ts
@@ -134,9 +134,17 @@ import {
   ToolOutputReferenceRegistry,
 } from '@/tools/toolOutputReferences';
 import {
+  prepareProviderRequest,
+  usesNativeOpenAIResponses,
+} from '@/llm/prepareProviderRequest';
+import {
   resolveLangfuseRuntimeScope,
   withLangfuseRuntimeScope,
 } from '@/langfuseRuntimeScope';
+import {
+  ManualSummarizationSkippedError,
+  shouldTriggerSummarization,
+} from '@/summarization';
 import {
   getToolContentCharLength,
   serializeToolContentBounded,
@@ -150,6 +158,11 @@ import {
   PreparedSubagents,
   PreparedSubagentError,
 } from '@/tools/preparedSubagents';
+import {
+  createRemoveAllMessage,
+  messagesStateReducer,
+} from '@/messages/reducer';
+import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
 import { ToolNode as CustomToolNode, toolsCondition } from '@/tools/ToolNode';
 import { shouldTraceToolNodeForLangfuse } from '@/langfuseToolOutputTracing';
 import { createLocalCodingToolBundle } from '@/tools/local/LocalCodingTools';
@@ -157,29 +170,16 @@ import { SUBAGENT_REPLAY_CONTROLLER } from '@/tools/subagent/SubagentReplay';
 import { applyGraphRuntimeConfig } from '@/graphs/applyGraphRuntimeConfig';
 import { isFadingTier, isInformativeFadingTier } from '@/messages/fading';
 import { createContextPressureMeter } from '@/llm/contextPressureMeter';
-import { createToolHistoryPreparation } from '@/messages/toolHistoryProjection';
 import { safeDispatchCustomEvent, emitAgentLog } from '@/utils/events';
-import {
-  prepareProviderRequest,
-  usesNativeOpenAIResponses,
-} from '@/llm/prepareProviderRequest';
 import { createCloudflareCodingToolBundle } from '@/tools/cloudflare';
 import { calculateMaxToolCallInputChars } from '@/utils/truncation';
 import { prepareToolsForPromptCache } from '@/llm/promptCacheTools';
 import { providerRequiresStrictAlternation } from '@/llm/providers';
 import { buildSubagentToolParams } from '@/tools/SubagentTool';
 import { initializeLangfuseTracing } from '@/instrumentation';
-import {
-  ManualSummarizationSkippedError,
-  shouldTriggerSummarization,
-} from '@/summarization';
 import { isRunStepResumeState } from '@/tools/runStepResume';
 import { resolveLocalToolsForBinding } from '@/tools/local';
 import { createSummarizeNode } from '@/summarization/node';
-import {
-  createRemoveAllMessage,
-  messagesStateReducer,
-} from '@/messages/reducer';
 import { getTruncationStopReason } from '@/llm/truncation';
 import { createSchemaOnlyTools } from '@/tools/schema';
 import { AgentContext } from '@/agents/AgentContext';
@@ -1356,7 +1356,8 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
   /** See {@link t.StandardGraphInput.subagentTasks}. */
   subagentTasks: t.SubagentTaskConfig | undefined;
   /** See {@link t.StandardGraphInput.subagentExecutionContext}. */
-  private readonly subagentExecutionContext?: t.SubagentExecutionContext;
+  readonly subagentExecutionContext?: t.SubagentExecutionContext;
+  private readonly subagentContext?: t.SubagentContextAdapter;
   /** See {@link t.StandardGraphInput.preemption}. */
   preemption?: t.StreamPreemption;
   /**
@@ -1534,6 +1535,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       subagentTasks,
       subagentScope,
       subagentExecutionContext,
+      subagentContext,
       preemption,
       streamLimits,
       toolExecution,
@@ -1560,6 +1562,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
     this.subagentTasks = subagentTasks;
     this.subagentScope = subagentScope === true;
     this.subagentExecutionContext = subagentExecutionContext;
+    this.subagentContext = subagentContext;
     this.preemption = preemption;
     this.streamLimits = resolveStreamLimits(streamLimits);
     this.toolExecution = toolExecution;
@@ -2881,6 +2884,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         // run_id); `executingAgentId` always identifies the owning agent.
         agentId: this.subagentScope ? agentContext?.agentId : undefined,
         executingAgentId: agentContext?.agentId,
+        executionContext: this.subagentExecutionContext,
         executingAgentName: agentContext?.name,
         rootAgentId: this.defaultAgentId,
         rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
@@ -2965,6 +2969,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
       // hooks can attribute the batch even at the top level.
       agentId: this.subagentScope ? agentContext?.agentId : undefined,
       executingAgentId: agentContext?.agentId,
+      executionContext: this.subagentExecutionContext,
       executingAgentName: agentContext?.name,
       rootAgentId: this.defaultAgentId,
       rootAgentName: this.agentContexts.get(this.defaultAgentId)?.name,
@@ -4627,7 +4632,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       fallbackProvider,
                       fallbackClientOptions
                     );
-                    let projection: ReturnType<typeof measureProviderPayload> | undefined;
+                    let projection:
+                      | ReturnType<typeof measureProviderPayload>
+                      | undefined;
                     const request = prepareProviderRequest({
                       model: fallbackModel,
                       messages: cached,
@@ -4644,7 +4651,9 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                       },
                     });
                     if (projection == null) {
-                      throw new Error('Fallback preparation did not measure its payload');
+                      throw new Error(
+                        'Fallback preparation did not measure its payload'
+                      );
                     }
                     return { request, projection };
                   };
@@ -4664,8 +4673,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
                   if (!projection.fits) {
                     const compacted = compactSyntheticProviderContext(
                       servingFallbackMessages,
-                      (candidate) =>
-                        prepareFallback(candidate).projection
+                      (candidate) => prepareFallback(candidate).projection
                     );
                     if (compacted !== servingFallbackMessages) {
                       preparedFallbackRequest = prepareFallback(compacted);
@@ -5025,6 +5033,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
         runId,
         threadId: configurable?.thread_id as string | undefined,
         agentId: this.subagentScope ? agentId : undefined,
+        executionContext: this.subagentExecutionContext,
         executingAgentId: agentId,
         sealCount: this.preemptSealCount,
       },
@@ -5247,6 +5256,7 @@ export class StandardGraph extends Graph<t.BaseGraphState, t.GraphNode> {
           tokenCounter: agentContext.tokenCounter,
           usageSink: this.subagentUsageSink,
           taskConfig: this.subagentTasks,
+          subagentContext: this.subagentContext,
           streamLimits: this.streamLimits,
           humanInTheLoop: this.humanInTheLoop,
           checkpointer: this.compileOptions?.checkpointer,

--- a/src/hooks/__tests__/compactHooks.test.ts
+++ b/src/hooks/__tests__/compactHooks.test.ts
@@ -24,6 +24,21 @@ const callerConfig = {
   version: 'v2' as const,
 };
 
+const childExecutionContext: t.SubagentExecutionContext = {
+  rootRunId: 'root-run',
+  hookSessionId: 'compact-run',
+  depth: 1,
+  ancestry: [
+    {
+      subagentRunId: 'child-run',
+      subagentType: 'worker',
+      subagentKind: 'agent',
+      subagentAgentId: 'worker',
+      parentRunId: 'root-run',
+    },
+  ],
+};
+
 let getChatModelClassSpy: jest.SpyInstance;
 const originalGetChatModelClass = providers.getChatModelClass;
 
@@ -143,6 +158,29 @@ describe('Compaction hook integration', () => {
       expect(captured!.trigger).toBe('default');
       expect(captured!.agentId).toBeDefined();
     });
+  });
+
+  it('carries child execution identity through compact hooks', async () => {
+    const registry = new HookRegistry();
+    let pre: PreCompactHookInput | undefined;
+    let post: PostCompactHookInput | undefined;
+    registry.register('PreCompact', {
+      hooks: [async (input) => ((pre = input), {})],
+    });
+    registry.register('PostCompact', {
+      hooks: [async (input) => ((post = input), {})],
+    });
+    const run = await createCompactingRun(tokenCounter, registry);
+    Object.defineProperty(run.Graph, 'subagentExecutionContext', {
+      value: childExecutionContext,
+    });
+    expect(run.Graph?.subagentExecutionContext).toEqual(childExecutionContext);
+    run.Graph!.overrideTestModel(['Final answer after compaction.']);
+
+    await run.processStream(buildConversation(), callerConfig);
+
+    expect(pre?.executionContext).toEqual(childExecutionContext);
+    expect(post?.executionContext).toEqual(childExecutionContext);
   });
 
   describe('PostCompact', () => {

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -1,5 +1,6 @@
 // src/hooks/types.ts
 import type { BaseMessage } from '@langchain/core/messages';
+import type { SubagentExecutionContext } from '@/types/graph';
 import type { InjectedMessage } from '@/types/tools';
 
 /**
@@ -57,6 +58,8 @@ export type StopDecision = 'continue' | 'block';
  *   hook to a specific agent regardless of subagent scope.
  */
 export interface BaseHookInput {
+  /** SDK-owned child lineage, including distinct identities for concurrent self-spawns. */
+  executionContext?: SubagentExecutionContext;
   runId: string;
   threadId?: string;
   agentId?: string;

--- a/src/run.ts
+++ b/src/run.ts
@@ -38,11 +38,6 @@ import {
   DEFAULT_RECURSION_LIMIT,
 } from '@/common';
 import {
-  requireValidSubagentResumeManifest,
-  SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
-  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
-} from '@/tools/subagent/SubagentReplay';
-import {
   ACTIVITY_PHASE_LABEL_PROMPT,
   ACTIVITY_LABEL_PROMPT,
   buildActivityLabelPrompt,
@@ -58,11 +53,22 @@ import {
   withLangfuseAttributes,
 } from '@/langfuse';
 import {
+  requireValidSubagentResumeManifest,
+  SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
+  SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
+} from '@/tools/subagent/SubagentReplay';
+import {
   REASONING_LABEL_PROMPT,
   buildReasoningLabelTraceSeed,
   buildReasoningLabelPrompt,
   normalizeReasoningLabel,
 } from '@/prompts/reasoningLabel';
+import {
+  TOOL_BATCH_REPLAY_KEY,
+  restoreToolReplayConfig,
+  stripToolBatchReplayState,
+  getPublicToolInterruptPayload,
+} from '@/tools/toolBatchReplay';
 import {
   hasToolOutputTracingConfig,
   resolveLangfuseConfig,
@@ -72,12 +78,6 @@ import {
   cloneToolApprovalInterruptPayload,
   TOOL_APPROVAL_REVIEW_CONFIG_KEY,
 } from '@/hitl/approvalReview';
-import {
-  TOOL_BATCH_REPLAY_KEY,
-  restoreToolReplayConfig,
-  stripToolBatchReplayState,
-  getPublicToolInterruptPayload,
-} from '@/tools/toolBatchReplay';
 import {
   resolveLangfuseDestinationKey,
   resolveLangfuseTraceAnchorParent,
@@ -474,6 +474,7 @@ export class Run<_T extends t.BaseGraphState> {
   private maxStopContinuations: number;
   private streamLimits?: t.StreamLimits;
   private subagentTasks?: t.SubagentTaskConfig;
+  private subagentContext?: t.SubagentContextAdapter;
   private indexTokenCountMap?: Record<string, number>;
   calibrationRatio: number = 1;
   fadingTier?: t.FadingTier;
@@ -556,6 +557,7 @@ export class Run<_T extends t.BaseGraphState> {
     this.toolExecution = config.toolExecution;
     this.subagentUsageSink = config.subagentUsageSink;
     this.subagentTasks = config.subagentTasks;
+    this.subagentContext = config.subagentContext;
     this.preemption = config.preemption;
     this.maxStopContinuations = resolveMaxStopContinuations(
       config.maxStopContinuations
@@ -654,6 +656,7 @@ export class Run<_T extends t.BaseGraphState> {
         fadingTiers: this.fadingTiers,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
+        subagentContext: this.subagentContext,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
         toolExecution: this.toolExecution,
@@ -696,6 +699,7 @@ export class Run<_T extends t.BaseGraphState> {
         fadingTiers: this.fadingTiers,
         subagentUsageSink: this.subagentUsageSink,
         subagentTasks: this.subagentTasks,
+        subagentContext: this.subagentContext,
         preemption: this.preemption,
         streamLimits: this.streamLimits,
         toolExecution: this.toolExecution,
@@ -1283,7 +1287,11 @@ export class Run<_T extends t.BaseGraphState> {
       );
       const publicPayload = stripRunStepResumeState(this._interrupt?.payload);
       if (config.configurable != null) {
-        restoreToolReplayConfig(config.configurable, this._interrupt?.interruptId, publicPayload);
+        restoreToolReplayConfig(
+          config.configurable,
+          this._interrupt?.interruptId,
+          publicPayload
+        );
       }
       if (graph.getStopContinuationExecutionId() === '') {
         graph.startStopContinuationExecution(nanoid());
@@ -2015,8 +2023,11 @@ export class Run<_T extends t.BaseGraphState> {
     await this.restoreInterruptFromCheckpoint(callerConfig, resumeUpdate);
     const interrupt = this._interrupt;
     const replayPayload = stripRunStepResumeState(interrupt?.payload);
-    const resumeManifest = requireValidSubagentResumeManifest(replayPayload) ??
-      requireValidSubagentResumeManifest(stripToolBatchReplayState(replayPayload));
+    const resumeManifest =
+      requireValidSubagentResumeManifest(replayPayload) ??
+      requireValidSubagentResumeManifest(
+        stripToolBatchReplayState(replayPayload)
+      );
     const resumeConfigurable = { ...callerConfig.configurable };
     delete resumeConfigurable[TOOL_APPROVAL_REVIEW_CONFIG_KEY];
     delete resumeConfigurable[TOOL_BATCH_REPLAY_KEY];
@@ -2027,7 +2038,11 @@ export class Run<_T extends t.BaseGraphState> {
       resumeConfigurable[SUBAGENT_RESUME_MANIFEST_CONFIG_KEY] = resumeManifest;
     }
     const publicPayload = stripRunStepResumeState(interrupt?.payload);
-    restoreToolReplayConfig(resumeConfigurable, interrupt?.interruptId, publicPayload);
+    restoreToolReplayConfig(
+      resumeConfigurable,
+      interrupt?.interruptId,
+      publicPayload
+    );
     const manifestConfig = {
       ...callerConfig,
       configurable: resumeConfigurable,

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -818,6 +818,7 @@ function startEagerToolExecutions(args: {
       }
     };
     const batchRequest: t.ToolExecuteBatchRequest = {
+      executionContext: graph.subagentExecutionContext,
       toolCalls: entries.map((entry) => entry.request),
       userId: graph.config?.configurable?.user_id as string | undefined,
       agentId: agentContext?.agentId,
@@ -826,10 +827,14 @@ function startEagerToolExecutions(args: {
           | Partial<Pick<AgentContext, 'getCallerCapabilityProjectionSnapshot'>>
           | undefined
       )?.getCallerCapabilityProjectionSnapshot?.(),
-      configurable: graph.config?.configurable as
-        | Record<string, unknown>
-        | undefined,
-      metadata,
+      configurable: {
+        ...graph.config?.configurable,
+        executionContext: graph.subagentExecutionContext,
+      },
+      metadata: {
+        ...metadata,
+        executionContext: graph.subagentExecutionContext,
+      },
       signal: composeAbortSignals(
         graph.config?.signal,
         graph.breakerAbort.signal
@@ -1653,7 +1658,8 @@ export class ChatModelStreamHandler implements t.EventHandler {
       if (
         eventBreaker != null &&
         eventBreaker.signal.aborted &&
-        (eventBreaker.signal.reason instanceof StreamLimitExceededError || eventBreaker.signal.reason instanceof PreparedSubagentError)
+        (eventBreaker.signal.reason instanceof StreamLimitExceededError ||
+          eventBreaker.signal.reason instanceof PreparedSubagentError)
       ) {
         throw eventBreaker.signal.reason;
       }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -878,6 +878,12 @@ function startEagerToolExecutions(args: {
       toolName: entry.toolName,
       args: entry.coercedArgs,
       request: entry.request,
+      codeSessionBaselineByName: new Map(
+        (entry.request.codeSessionContext?.files ?? []).map((file) => [
+          file.name,
+          `${file.storage_session_id}\0${file.id}`,
+        ])
+      ),
       promise,
     };
     records.push(record);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -816,6 +816,10 @@ function startEagerToolExecutions(args: {
       ),
     ])
   );
+  for (const entry of entries) {
+    entry.request.codeSessionBaselineId =
+      entry.request.codeSessionContext?.session_id;
+  }
   const records: t.EagerEventToolExecution[] = [];
   const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
     t.ToolExecuteResult[]

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -805,6 +805,17 @@ function startEagerToolExecutions(args: {
     return;
   }
 
+  const codeSessionBaselineById = new Map(
+    entries.map((entry) => [
+      entry.id,
+      new Map(
+        (entry.request.codeSessionContext?.files ?? []).map((file) => [
+          file.name,
+          `${file.storage_session_id}\0${file.id}`,
+        ])
+      ),
+    ])
+  );
   const records: t.EagerEventToolExecution[] = [];
   const promise: Promise<t.EagerEventToolExecutionOutcome> = new Promise<
     t.ToolExecuteResult[]
@@ -878,12 +889,7 @@ function startEagerToolExecutions(args: {
       toolName: entry.toolName,
       args: entry.coercedArgs,
       request: entry.request,
-      codeSessionBaselineByName: new Map(
-        (entry.request.codeSessionContext?.files ?? []).map((file) => [
-          file.name,
-          `${file.storage_session_id}\0${file.id}`,
-        ])
-      ),
+      codeSessionBaselineByName: codeSessionBaselineById.get(entry.id),
       promise,
     };
     records.push(record);

--- a/src/summarization/node.ts
+++ b/src/summarization/node.ts
@@ -924,6 +924,7 @@ async function dispatchCompletionEvents(params: {
         runId: sessionId,
         threadId,
         agentId,
+        executionContext: graph.getSubagentExecutionContext?.(),
         summary: summaryText,
         messagesAfterCount,
       },
@@ -948,6 +949,7 @@ interface CreateSummarizeNodeParams {
     config?: RunnableConfig;
     runId?: string;
     isMultiAgent: boolean;
+    getSubagentExecutionContext?: () => t.SubagentExecutionContext | undefined;
     hookRegistry?: HookRegistry;
     getToolsForBinding?: (
       provider: t.ProviderName,
@@ -1331,6 +1333,7 @@ export function createSummarizeNode({
           runId: sessionId,
           threadId,
           agentId: request.agentId,
+          executionContext: graph.getSubagentExecutionContext?.(),
           messagesBeforeCount: messagesToRefine.length,
           trigger:
             request.reason === 'manual'

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -4224,17 +4224,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         })
       );
 
-      let eagerResults: Awaited<typeof eagerResultsPromise>;
-      let dispatchedResults: Awaited<typeof dispatchPromise>;
-      try {
-        [eagerResults, dispatchedResults] = await Promise.all([
-          eagerResultsPromise,
-          dispatchPromise,
-        ]);
-      } catch (error) {
+      const [eagerOutcome, dispatchedOutcome] = await Promise.allSettled([
+        eagerResultsPromise,
+        dispatchPromise,
+      ]);
+      if (eagerOutcome.status === 'rejected') {
         this.retainCodeSessionInputsFromRequests(requestMap.values());
-        throw error;
+        throw eagerOutcome.reason;
       }
+      if (dispatchedOutcome.status === 'rejected') {
+        this.retainCodeSessionInputsFromRequests(requestMap.values());
+        throw dispatchedOutcome.reason;
+      }
+      const eagerResults = eagerOutcome.value;
+      const dispatchedResults = dispatchedOutcome.value;
       // Settle in-flight early completion dispatches before the batch loop
       // below decides which completions still need emitting.
       await Promise.allSettled(earlyCompletionDispatches);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3136,6 +3136,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     if (!this.sessions) {
       return;
     }
+    const existing = this.sessions.get(this.codeSessionKey) as
+      | t.CodeSessionContext
+      | undefined;
+    const baselineIdentityByName = new Map(
+      (existing?.files ?? []).map((file) => [
+        file.name,
+        fileIdentityKey(file),
+      ])
+    );
+    const refreshedByName = new Map<string, t.CodeEnvFile>();
+    let sessionId: string | undefined;
     for (const request of requests) {
       if (
         request.name === '' ||
@@ -3144,12 +3155,22 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       ) {
         continue;
       }
-      retainCodeSessionInputs(
-        this.sessions,
-        this.codeSessionKey,
-        request.codeSessionContext
-      );
+      const context = request.codeSessionContext;
+      if (context?.session_id == null || context.session_id === '') continue;
+      sessionId ??= context.session_id;
+      for (const file of context.files ?? []) {
+        if (!file.id || !file.name || !file.storage_session_id) continue;
+        if (baselineIdentityByName.get(file.name) === fileIdentityKey(file)) {
+          continue;
+        }
+        refreshedByName.set(file.name, file);
+      }
     }
+    if (sessionId == null || refreshedByName.size === 0) return;
+    retainCodeSessionInputs(this.sessions, this.codeSessionKey, {
+      session_id: sessionId,
+      files: [...refreshedByName.values()],
+    });
   }
 
   /**

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -4098,22 +4098,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const requestMap = new Map(plan.allRequests.map((r) => [r.id, r]));
-      const codeSessionBaselineByName = new Map(
-        (
-          (
-            this.sessions?.get(this.codeSessionKey) as
-              | t.CodeSessionContext
-              | undefined
-          )?.files ?? []
-        ).map((file) => [file.name, fileIdentityKey(file)])
-      );
       const codeSessionBaselineByRequestId = new Map<
         string,
         ReadonlyMap<string, string>
       >(
         plan.allRequests.map((request) => [
           request.id,
-          codeSessionBaselineByName,
+          new Map(
+            (request.codeSessionContext?.files ?? []).map((file) => [
+              file.name,
+              fileIdentityKey(file),
+            ])
+          ),
         ])
       );
       const eagerExecutions: Array<{

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3126,6 +3126,28 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     }
   }
 
+  private retainCodeSessionInputsFromRequests(
+    requests: Iterable<t.ToolCallRequest>
+  ): void {
+    if (!this.sessions) {
+      return;
+    }
+    for (const request of requests) {
+      if (
+        request.name === '' ||
+        (!this.participatesInCodeSession(request.name) &&
+          request.name !== Constants.SKILL_TOOL)
+      ) {
+        continue;
+      }
+      retainCodeSessionInputs(
+        this.sessions,
+        this.codeSessionKey,
+        request.codeSessionContext
+      );
+    }
+  }
+
   /**
    * Post-processes standard runTool outputs: dispatches ON_RUN_STEP_COMPLETED
    * and stores code session context. Mirrors the completion handling in
@@ -4182,27 +4204,37 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
       const eagerResultsPromise = Promise.all(
         eagerExecutions.map(async ({ request, execution }) => {
-          const results = await this.resolveEagerEventExecution(
-            request,
-            execution
-          );
-          if (execution.request.codeSessionContext != null) {
-            request.codeSessionContext = execution.request.codeSessionContext;
+          try {
+            const results = await this.resolveEagerEventExecution(
+              request,
+              execution
+            );
+            return {
+              results,
+              completionDispatched:
+                execution.completionDispatched === true &&
+                execution.request.turn === request.turn,
+              toolCallId: request.id,
+            };
+          } finally {
+            if (execution.request.codeSessionContext != null) {
+              request.codeSessionContext = execution.request.codeSessionContext;
+            }
           }
-          return {
-            results,
-            completionDispatched:
-              execution.completionDispatched === true &&
-              execution.request.turn === request.turn,
-            toolCallId: request.id,
-          };
         })
       );
 
-      const [eagerResults, dispatchedResults] = await Promise.all([
-        eagerResultsPromise,
-        dispatchPromise,
-      ]);
+      let eagerResults: Awaited<typeof eagerResultsPromise>;
+      let dispatchedResults: Awaited<typeof dispatchPromise>;
+      try {
+        [eagerResults, dispatchedResults] = await Promise.all([
+          eagerResultsPromise,
+          dispatchPromise,
+        ]);
+      } catch (error) {
+        this.retainCodeSessionInputsFromRequests(requestMap.values());
+        throw error;
+      }
       // Settle in-flight early completion dispatches before the batch loop
       // below decides which completions still need emitting.
       await Promise.allSettled(earlyCompletionDispatches);

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -49,10 +49,21 @@ import type {
   PostToolBatchEntry,
   ToolApprovalReplayKey,
 } from '@/hooks';
-import type { PreparedSubagents } from '@/tools/preparedSubagents';
 import type { SettledToolBatchResult } from '@/tools/toolBatchReplay';
+import type { PreparedSubagents } from '@/tools/preparedSubagents';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type * as t from '@/types';
+import {
+  TOOL_BATCH_REPLAY_KEY,
+  getToolBatchReplayOwner,
+  getToolBatchReplayScope,
+  attachToolBatchReplayState,
+  restoreToolBatchReplayState,
+  getToolBatchReplayState,
+  clearStaleToolApprovalConfig,
+  isChildToolReplayOwner,
+  getToolReplayResumeStatus,
+} from '@/tools/toolBatchReplay';
 import {
   type CallerCapabilityProjection,
   createCallerCapabilityProjectionSnapshot,
@@ -121,25 +132,14 @@ import { stripCodeSessionFileSummary } from '@/tools/CodeSessionFileSummary';
 import { Constants, GraphEvents, CODE_EXECUTION_TOOLS } from '@/common';
 import { PreparedSubagentError } from '@/tools/preparedSubagents';
 import { attachRunStepResumeState } from '@/tools/runStepResume';
-import {
-  TOOL_BATCH_REPLAY_KEY,
-  getToolBatchReplayOwner,
-  getToolBatchReplayScope,
-  attachToolBatchReplayState,
-  restoreToolBatchReplayState,
-  getToolBatchReplayState,
-  clearStaleToolApprovalConfig,
-  isChildToolReplayOwner,
-  getToolReplayResumeStatus,
-} from '@/tools/toolBatchReplay';
 
 function stripToolApprovalReviewConfig(
   configurable: Record<string, unknown> | undefined
 ): Record<string, unknown> | undefined {
   if (
     configurable == null ||
-    !(TOOL_APPROVAL_REVIEW_CONFIG_KEY in configurable) &&
-    !(TOOL_BATCH_REPLAY_KEY in configurable)
+    (!(TOOL_APPROVAL_REVIEW_CONFIG_KEY in configurable) &&
+      !(TOOL_BATCH_REPLAY_KEY in configurable))
   ) {
     return configurable;
   }
@@ -474,8 +474,12 @@ function getAssistantBatchReplayKey(
 ): string {
   return JSON.stringify([
     threadId ?? null,
-    batch.message.id == null || batch.message.id === '' ? null : batch.message.id,
-    createHash('sha256').update(stableStringify(batch.message.tool_calls ?? [])).digest('hex'),
+    batch.message.id == null || batch.message.id === ''
+      ? null
+      : batch.message.id,
+    createHash('sha256')
+      .update(stableStringify(batch.message.tool_calls ?? []))
+      .digest('hex'),
   ]);
 }
 
@@ -712,6 +716,46 @@ function updateCodeSession(
   });
 }
 
+/** Retains host-provisioned inputs even when execution returns no usable artifact.
+ * Existing session versions win over older request snapshots from the same batch. */
+function retainCodeSessionInputs(
+  sessions: t.ToolSessionMap,
+  sessionKey: string,
+  context: t.ToolCallRequest['codeSessionContext']
+): void {
+  if (
+    context?.session_id == null ||
+    context.session_id === '' ||
+    context.files == null ||
+    context.files.length === 0
+  )
+    return;
+  const existing = sessions.get(sessionKey) as t.CodeSessionContext | undefined;
+  const existingFiles = existing?.files ?? [];
+  const identities = new Set<string>();
+  const names = new Set<string>();
+  for (const file of existingFiles) {
+    identities.add(fileIdentityKey(file));
+    names.add(file.name);
+  }
+  let files: t.FileRefs | undefined;
+  for (const file of context.files) {
+    if (!file.id || !file.name || !file.storage_session_id) continue;
+    const identity = fileIdentityKey(file);
+    if (identities.has(identity) || names.has(file.name)) continue;
+    identities.add(identity);
+    names.add(file.name);
+    files ??= [...existingFiles];
+    files.push({ ...file });
+  }
+  if (!files) return;
+  sessions.set(sessionKey, {
+    session_id: existing?.session_id ?? context.session_id,
+    files,
+    lastUpdated: Date.now(),
+  });
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private toolMap: Map<string, StructuredToolInterface | RunnableToolLike>;
@@ -787,6 +831,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
    * even where `agentId` (the subagent-scope marker) is undefined.
    */
   private executingAgentId?: string;
+  private readonly executionContext?: t.ToolNodeOptions['executionContext'];
   private executingAgentName?: string;
   private rootAgentId?: string;
   private rootAgentName?: string;
@@ -876,6 +921,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     eagerEventToolSuppressions,
     agentId,
     executingAgentId,
+    executionContext,
     executingAgentName,
     rootAgentId,
     rootAgentName,
@@ -900,65 +946,124 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       name: name ?? TOOL_NODE_RUN_NAME,
       tags,
       func: async (input, config) => {
-        const messages = Array.isArray(input) ? input as BaseMessage[] :
-          (input as { messages?: BaseMessage[] }).messages;
-        const assistantBatch = messages == null ? undefined : findAssistantBatch(messages);
-        const activeReplayKey = assistantBatch == null || getToolBatchReplayScope(config) == null ? undefined : getAssistantBatchReplayKey(
-          assistantBatch, getToolBatchReplayScope(config)
-        );
+        const messages = Array.isArray(input)
+          ? (input as BaseMessage[])
+          : (input as { messages?: BaseMessage[] }).messages;
+        const assistantBatch =
+          messages == null ? undefined : findAssistantBatch(messages);
+        const activeReplayKey =
+          assistantBatch == null || getToolBatchReplayScope(config) == null
+            ? undefined
+            : getAssistantBatchReplayKey(
+              assistantBatch,
+              getToolBatchReplayScope(config)
+            );
         const replayOwner = getToolBatchReplayOwner(
           config,
           this.executingAgentId ?? this.agentId ?? ''
         );
         let reviewEvidence = getToolApprovalReviewEvidence(config);
         const replayState = getToolBatchReplayState(config.configurable);
-        const ownsParentBatch = replayState?.records.some(
-          (record) => record.owner === replayOwner && record.batch === activeReplayKey
-        ) === true;
+        const ownsParentBatch =
+          replayState?.records.some(
+            (record) =>
+              record.owner === replayOwner && record.batch === activeReplayKey
+          ) === true;
         let isChildReplay = false;
         if (ownsParentBatch) {
-          const calls = this.isSendInput(input) ? [input.lg_tool_call] : assistantBatch?.message.tool_calls ?? [];
-          const trustedParentCallIds = new Set(calls.filter((call) =>
-            call.name === Constants.SUBAGENT &&
-            (this.toolMap.get(call.name) as ReplayableSubagentTool | undefined)?.[SUBAGENT_REPLAY_CONTROLLER] != null
-          ).map((call) => call.id ?? ''));
-          isChildReplay = reviewEvidence?.owner != null
-            ? isChildToolReplayOwner(config, reviewEvidence.owner, trustedParentCallIds)
-            : replayState.records.some((record) => isChildToolReplayOwner(config, record.owner, trustedParentCallIds));
+          const calls = this.isSendInput(input)
+            ? [input.lg_tool_call]
+            : (assistantBatch?.message.tool_calls ?? []);
+          const trustedParentCallIds = new Set(
+            calls
+              .filter(
+                (call) =>
+                  call.name === Constants.SUBAGENT &&
+                  (
+                    this.toolMap.get(call.name) as
+                      | ReplayableSubagentTool
+                      | undefined
+                  )?.[SUBAGENT_REPLAY_CONTROLLER] != null
+              )
+              .map((call) => call.id ?? '')
+          );
+          isChildReplay =
+            reviewEvidence?.owner != null
+              ? isChildToolReplayOwner(
+                config,
+                reviewEvidence.owner,
+                trustedParentCallIds
+              )
+              : replayState.records.some((record) =>
+                isChildToolReplayOwner(
+                  config,
+                  record.owner,
+                  trustedParentCallIds
+                )
+              );
         }
         const hasApprovalAuthorization =
           reviewEvidence?.owner != null || replayState?.approvalOwner != null;
-        const replayResumeStatus = hasApprovalAuthorization || replayState != null
-          ? getToolReplayResumeStatus(
-            config,
-            reviewEvidence?.interruptId ?? replayState?.interruptId,
-            isChildReplay
-          )
-          : undefined;
+        const replayResumeStatus =
+          hasApprovalAuthorization || replayState != null
+            ? getToolReplayResumeStatus(
+              config,
+              reviewEvidence?.interruptId ?? replayState?.interruptId,
+              isChildReplay
+            )
+            : undefined;
         if (replayResumeStatus === 'unverifiable' && hasApprovalAuthorization) {
-          throw new Error('Cannot verify the active tool approval resume — failing closed');
+          throw new Error(
+            'Cannot verify the active tool approval resume — failing closed'
+          );
         }
         if (replayResumeStatus === 'stale') {
           const configurable = { ...config.configurable };
-          clearStaleToolApprovalConfig(configurable, replayOwner, activeReplayKey);
+          clearStaleToolApprovalConfig(
+            configurable,
+            replayOwner,
+            activeReplayKey
+          );
           config = {
             ...config,
             configurable,
           };
           reviewEvidence = undefined;
         }
-        if (reviewEvidence?.owner != null && reviewEvidence.owner !== replayOwner && !isChildReplay) {
-          throw new Error('Tool approval execution owner changed before resume — failing closed');
+        if (
+          reviewEvidence?.owner != null &&
+          reviewEvidence.owner !== replayOwner &&
+          !isChildReplay
+        ) {
+          throw new Error(
+            'Tool approval execution owner changed before resume — failing closed'
+          );
         }
         const referenceReplay: { state?: ToolOutputReferenceState } = {};
-        const restoredBatches = await restoreToolBatchReplayState(config, replayOwner);
-        if (restoredBatches.length > 0 && !restoredBatches.some(({ batch }) => batch === activeReplayKey)) {
-          throw new Error('Tool batch proposal changed before approval replay — failing closed');
+        const restoredBatches = await restoreToolBatchReplayState(
+          config,
+          replayOwner
+        );
+        if (
+          restoredBatches.length > 0 &&
+          !restoredBatches.some(({ batch }) => batch === activeReplayKey)
+        ) {
+          throw new Error(
+            'Tool batch proposal changed before approval replay — failing closed'
+          );
         }
-        if (activeReplayKey != null && getToolBatchReplayState(config.configurable) != null) {
+        if (
+          activeReplayKey != null &&
+          getToolBatchReplayState(config.configurable) != null
+        ) {
           this.settledDirectResultsByBatch.delete(activeReplayKey);
         }
-        for (const { batch, results, turnState, referenceState } of restoredBatches) {
+        for (const {
+          batch,
+          results,
+          turnState,
+          referenceState,
+        } of restoredBatches) {
           if (batch !== activeReplayKey) {
             continue;
           }
@@ -978,27 +1083,45 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             throw error;
           }
           const resumeState = createRunStepResumeState?.();
-          const activeResults = activeReplayKey == null ? undefined : this.settledDirectResultsByBatch.get(activeReplayKey);
-          const activeBatches = activeReplayKey == null
-            ? new Map<string, Map<string, SettledDirectToolResult>>()
-            : new Map([[activeReplayKey, activeResults ?? new Map<string, SettledDirectToolResult>()]]);
+          const activeResults =
+            activeReplayKey == null
+              ? undefined
+              : this.settledDirectResultsByBatch.get(activeReplayKey);
+          const activeBatches =
+            activeReplayKey == null
+              ? new Map<string, Map<string, SettledDirectToolResult>>()
+              : new Map([
+                [
+                  activeReplayKey,
+                  activeResults ?? new Map<string, SettledDirectToolResult>(),
+                ],
+              ]);
           const turnState = this.createSubagentResumeState();
-          const activeCallIds = new Set(assistantBatch?.message.tool_calls?.map((call) => call.id));
-          turnState.directPathTurns = turnState.directPathTurns.filter(({ toolCallId }) => activeCallIds.has(toolCallId));
+          const activeCallIds = new Set(
+            assistantBatch?.message.tool_calls?.map((call) => call.id)
+          );
+          turnState.directPathTurns = turnState.directPathTurns.filter(
+            ({ toolCallId }) => activeCallIds.has(toolCallId)
+          );
           throw new GraphInterrupt(
-            await Promise.all(error.interrupts.map(async (pendingInterrupt) => {
-              const value = await attachToolBatchReplayState(
-                pendingInterrupt.value,
-                replayOwner,
-                activeBatches,
-                turnState,
-                referenceReplay.state
-              );
-              return {
-                ...pendingInterrupt,
-                value: resumeState == null ? value : attachRunStepResumeState(value, resumeState),
-              };
-            }))
+            await Promise.all(
+              error.interrupts.map(async (pendingInterrupt) => {
+                const value = await attachToolBatchReplayState(
+                  pendingInterrupt.value,
+                  replayOwner,
+                  activeBatches,
+                  turnState,
+                  referenceReplay.state
+                );
+                return {
+                  ...pendingInterrupt,
+                  value:
+                    resumeState == null
+                      ? value
+                      : attachRunStepResumeState(value, resumeState),
+                };
+              })
+            )
           );
         }
         if (createRunStepResumeState == null) {
@@ -1040,6 +1163,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     // Default to agentId so callers constructing ToolNode directly (who pass the
     // existing agentId option) still get attribution without knowing the new option.
     this.executingAgentId = executingAgentId ?? agentId;
+    this.executionContext = executionContext;
     this.executingAgentName = executingAgentName;
     this.rootAgentId = rootAgentId;
     this.rootAgentName = rootAgentName;
@@ -1109,8 +1233,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ? options
         : {
           ...options,
+          configurable: {
+            ...options?.configurable,
+            executionContext: this.executionContext,
+          },
           metadata: {
             ...options?.metadata,
+            executionContext: this.executionContext,
             agentId: this.executingAgentId,
             activeAgentId: this.executingAgentId,
             ...(this.executingAgentName == null
@@ -1668,7 +1797,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           return next;
         })();
       this.recordToolUsageTurn(call.name, usageCount, call.id);
-      if (batchContext.replayBatchKey != null && call.id != null && call.id !== '') {
+      if (
+        batchContext.replayBatchKey != null &&
+        call.id != null &&
+        call.id !== ''
+      ) {
         this.directPathTurns.set(call.id, usageCount);
       }
       let args = call.args;
@@ -1732,6 +1865,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             runId: (config.configurable?.run_id as string | undefined) ?? '',
             threadId: config.configurable?.thread_id as string | undefined,
             agentId: this.agentId,
+            executionContext: this.executionContext,
             executingAgentId: this.executingAgentId,
           },
         };
@@ -2167,8 +2301,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           approvalReplaySessionId,
           approvalReplayKey
         );
-    const approvalReviewEvidence = getToolApprovalReviewEvidence(config,
-      getToolBatchReplayOwner(config, this.executingAgentId ?? this.agentId ?? ''));
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(
+      config,
+      getToolBatchReplayOwner(
+        config,
+        this.executingAgentId ?? this.agentId ?? ''
+      )
+    );
     const reviewedApproval = getReviewedToolApproval(
       approvalReviewEvidence?.payload,
       call.id
@@ -2294,6 +2433,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               runId,
               threadId,
               agentId: this.agentId,
+              executionContext: this.executionContext,
               executingAgentId: this.executingAgentId,
               toolName: call.name,
               toolInput: resolvedArgs,
@@ -2305,11 +2445,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             matchQuery: call.name,
             onceReplayKey: approvalReplayKey,
             onceReplaySessionId: approvalReplaySessionId,
-          }).catch((): AggregatedHookResult | undefined => approvalReviewEvidence == null ? undefined : {
-            decision: 'deny',
-            reason: 'Approval policy could not be evaluated on resume',
-            additionalContexts: [], injectedMessages: [], errors: [],
-          });
+          }).catch((): AggregatedHookResult | undefined =>
+            approvalReviewEvidence == null
+              ? undefined
+              : {
+                decision: 'deny',
+                reason: 'Approval policy could not be evaluated on resume',
+                additionalContexts: [],
+                injectedMessages: [],
+                errors: [],
+              }
+          );
 
       if (preResult != null) {
         // Forward any additionalContext strings hooks returned into
@@ -2651,6 +2797,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executionContext: this.executionContext,
           executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: effectiveCall.args as Record<string, unknown>,
@@ -2688,6 +2835,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executionContext: this.executionContext,
           executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: effectiveCall.args as Record<string, unknown>,
@@ -2804,6 +2952,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executionContext: this.executionContext,
           executingAgentId: this.executingAgentId,
           toolName: call.name,
           toolInput: resolvedArgs,
@@ -2943,10 +3092,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
-      if (result.status !== 'success' || result.artifact == null) {
-        continue;
-      }
-
       const request = requestMap.get(result.toolCallId);
       if (
         request?.name == null ||
@@ -2954,6 +3099,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         (!this.participatesInCodeSession(request.name) &&
           request.name !== Constants.SKILL_TOOL)
       ) {
+        continue;
+      }
+
+      retainCodeSessionInputs(
+        this.sessions,
+        this.codeSessionKey,
+        request.codeSessionContext
+      );
+      if (result.status !== 'success' || result.artifact == null) {
         continue;
       }
 
@@ -3178,10 +3332,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           unresolvedByCallId.set(call.id, pre.unresolved);
         }
       } else if (registry != null) {
-        const options = { substituteIntentKey: this.toolDeclaresBusinessIntent(call.name) };
-        const { resolved, unresolved } = preBatchSnapshot != null
-          ? preBatchSnapshot.resolve(originalArgs, options)
-          : registry.resolve(registryRunId, originalArgs, options);
+        const options = {
+          substituteIntentKey: this.toolDeclaresBusinessIntent(call.name),
+        };
+        const { resolved, unresolved } =
+          preBatchSnapshot != null
+            ? preBatchSnapshot.resolve(originalArgs, options)
+            : registry.resolve(registryRunId, originalArgs, options);
         resolvedArgs = resolved as Record<string, unknown>;
         if (unresolved.length > 0 && call.id != null) {
           unresolvedByCallId.set(call.id, unresolved);
@@ -3229,8 +3386,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       config,
       runId
     );
-    const approvalReviewEvidence = getToolApprovalReviewEvidence(config,
-      getToolBatchReplayOwner(config, this.executingAgentId ?? this.agentId ?? ''));
+    const approvalReviewEvidence = getToolApprovalReviewEvidence(
+      config,
+      getToolBatchReplayOwner(
+        config,
+        this.executingAgentId ?? this.agentId ?? ''
+      )
+    );
     const hasPendingApproval = preToolCalls.some(
       (entry) =>
         entry.call.id != null &&
@@ -3295,6 +3457,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                   runId,
                   threadId,
                   agentId: this.agentId,
+                  executionContext: this.executionContext,
                   executingAgentId: this.executingAgentId,
                   toolName: entry.call.name,
                   toolInput: entry.args,
@@ -3397,6 +3560,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executionContext: this.executionContext,
                 executingAgentId: this.executingAgentId,
                 toolName: item.toolName,
                 toolInput: item.args,
@@ -3504,9 +3668,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           if (hookResult.updatedInput != null) {
             applyInputOverride(entry, hookResult.updatedInput);
           } else {
-            const reviewed = getReviewedToolApproval(approvalReviewEvidence?.payload, entry.call.id);
+            const reviewed = getReviewedToolApproval(
+              approvalReviewEvidence?.payload,
+              entry.call.id
+            );
             if (reviewed != null) {
-              entry.args = this.coerceEventToolArgs(entry.call.name, reviewed.request.arguments);
+              entry.args = this.coerceEventToolArgs(
+                entry.call.name,
+                reviewed.request.arguments
+              );
               if (entry.call.id != null) {
                 unresolvedByCallId.delete(entry.call.id);
               }
@@ -3972,6 +4142,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             };
 
             const batchRequest: t.ToolExecuteBatchRequest = {
+              executionContext: this.executionContext,
               toolCalls: dispatchRequests,
               userId: config.configurable?.user_id as string | undefined,
               // Dispatch attribution, NOT the hook subagent-scope marker:
@@ -4015,6 +4186,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             request,
             execution
           );
+          if (execution.request.codeSessionContext != null) {
+            request.codeSessionContext = execution.request.codeSessionContext;
+          }
           return {
             results,
             completionDispatched:
@@ -4115,6 +4289,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executionContext: this.executionContext,
                 executingAgentId: this.executingAgentId,
                 toolName,
                 toolInput: request?.args ?? {},
@@ -4167,6 +4342,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
                 runId,
                 threadId,
                 agentId: this.agentId,
+                executionContext: this.executionContext,
                 executingAgentId: this.executingAgentId,
                 toolName,
                 toolInput: request?.args ?? {},
@@ -4439,6 +4615,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           runId,
           threadId,
           agentId: this.agentId,
+          executionContext: this.executionContext,
           executingAgentId: this.executingAgentId,
           entries: orderedBatchEntries,
         },
@@ -4647,13 +4824,16 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       position: number,
       result: SettledDirectToolResult
     ): void => {
-      if (
-        baseContext.replayBatchKey == null ||
-        settledBatchResults == null
-      ) {
+      if (baseContext.replayBatchKey == null || settledBatchResults == null) {
         return;
       }
-      settledBatchResults.set(directReplayKey(call, baseContext.replayCallPositions?.get(call) ?? batchIndices[position]), result);
+      settledBatchResults.set(
+        directReplayKey(
+          call,
+          baseContext.replayCallPositions?.get(call) ?? batchIndices[position]
+        ),
+        result
+      );
       this.settledDirectResultsByBatch.set(
         baseContext.replayBatchKey,
         settledBatchResults
@@ -4668,14 +4848,26 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (turn != null) {
         this.recordToolUsageTurn(call.name, turn, call.id);
       }
-      const refMeta = isBaseMessage(result.output) ? result.output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
+      const refMeta = isBaseMessage(result.output)
+        ? (result.output.additional_kwargs as t.ToolMessageRefMetadata)
+        : undefined;
       if (refMeta?._refKey != null && result.referenceContent != null) {
-        this.toolOutputRegistry?.set(baseContext.batchScopeId, refMeta._refKey, result.referenceContent);
+        this.toolOutputRegistry?.set(
+          baseContext.batchScopeId,
+          refMeta._refKey,
+          result.referenceContent
+        );
         if (isBaseMessage(result.output)) {
-          result = { ...result, output: new ToolMessage({
-            ...(result.output as ToolMessage),
-            additional_kwargs: { ...result.output.additional_kwargs, _refScope: baseContext.batchScopeId },
-          }) };
+          result = {
+            ...result,
+            output: new ToolMessage({
+              ...(result.output as ToolMessage),
+              additional_kwargs: {
+                ...result.output.additional_kwargs,
+                _refScope: baseContext.batchScopeId,
+              },
+            }),
+          };
         }
       }
       if (
@@ -4691,11 +4883,23 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       call: ToolCall,
       position: number
     ): Promise<SettledDirectToolResult> => {
-      const cachedResult = settledBatchResults?.get(directReplayKey(call, baseContext.replayCallPositions?.get(call) ?? batchIndices[position]));
+      const cachedResult = settledBatchResults?.get(
+        directReplayKey(
+          call,
+          baseContext.replayCallPositions?.get(call) ?? batchIndices[position]
+        )
+      );
       if (cachedResult != null) {
-        if (cachedResult.proposal.name !== call.name ||
-          !recordArgsEqual(cachedResult.proposal.args, call.args as Record<string, unknown>)) {
-          throw new Error('Cannot change an already completed tool call during approval replay');
+        if (
+          cachedResult.proposal.name !== call.name ||
+          !recordArgsEqual(
+            cachedResult.proposal.args,
+            call.args as Record<string, unknown>
+          )
+        ) {
+          throw new Error(
+            'Cannot change an already completed tool call during approval replay'
+          );
         }
         return restoreResult(call, cachedResult);
       }
@@ -4710,15 +4914,27 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           ? undefined
           : baseContext.resolvedArgsByCallId?.get(call.id);
       const result: SettledDirectToolResult = {
-        proposal: structuredClone({ name: call.name, args: call.args as Record<string, unknown> }),
-        turn: call.id == null ? undefined : this.toolCallTurns.get(call.id) ?? this.directPathTurns.get(call.id),
+        proposal: structuredClone({
+          name: call.name,
+          args: call.args as Record<string, unknown>,
+        }),
+        turn:
+          call.id == null
+            ? undefined
+            : (this.toolCallTurns.get(call.id) ??
+              this.directPathTurns.get(call.id)),
         output,
         additionalContexts,
         ...(resolvedArgs == null ? {} : { resolvedArgs }),
       };
-      const refMeta = isBaseMessage(output) ? output.additional_kwargs as t.ToolMessageRefMetadata : undefined;
+      const refMeta = isBaseMessage(output)
+        ? (output.additional_kwargs as t.ToolMessageRefMetadata)
+        : undefined;
       if (refMeta?._refKey != null) {
-        result.referenceContent = this.toolOutputRegistry?.get(refMeta._refScope, refMeta._refKey);
+        result.referenceContent = this.toolOutputRegistry?.get(
+          refMeta._refScope,
+          refMeta._refKey
+        );
       }
       cacheResult(call, position, result);
       return restoreResult(call, result);
@@ -4734,8 +4950,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         directCalls.map((call, i) => runOne(call, i))
       );
       this.throwIfBreakerTripped(config);
-      const failed = results.find((result) => result.status === 'rejected' && !isGraphInterrupt(result.reason)) ??
-        results.find((result) => result.status === 'rejected');
+      const failed =
+        results.find(
+          (result) =>
+            result.status === 'rejected' && !isGraphInterrupt(result.reason)
+        ) ?? results.find((result) => result.status === 'rejected');
       if (failed?.status === 'rejected') {
         throw failed.reason;
       }
@@ -4877,8 +5096,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     return (Array.isArray(input) ? outputs : { messages: outputs }) as T;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  protected async run(input: any, config: RunnableConfig, referenceReplay: { state?: ToolOutputReferenceState } = {}): Promise<T> {
+  protected async run(
+    input: T,
+    config: RunnableConfig,
+    referenceReplay: { state?: ToolOutputReferenceState } = {}
+  ): Promise<T> {
     /**
      * Breaker read once at batch entry: every downstream path (direct
      * `tool.invoke` runtimes and the ON_TOOL_EXECUTE dispatch) inherits this
@@ -4938,10 +5160,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
     const incomingRunId = config.configurable?.run_id as string | undefined;
     const batchScopeId = incomingRunId ?? `\0anon-${this.anonBatchCounter++}`;
     const resumedReferenceState = referenceReplay.state;
-    const replayInputSnapshot = resumedReferenceState == null ? undefined :
-      this.toolOutputRegistry?.resumeBatch(batchScopeId, resumedReferenceState);
-    referenceReplay.state = resumedReferenceState ?? this.toolOutputRegistry?.snapshotState(batchScopeId);
-    const turn = resumedReferenceState?.turnCounter ?? this.toolOutputRegistry?.nextTurn(batchScopeId) ?? 0;
+    const replayInputSnapshot =
+      resumedReferenceState == null
+        ? undefined
+        : this.toolOutputRegistry?.resumeBatch(
+          batchScopeId,
+          resumedReferenceState
+        );
+    referenceReplay.state =
+      resumedReferenceState ??
+      this.toolOutputRegistry?.snapshotState(batchScopeId);
+    const turn =
+      resumedReferenceState?.turnCounter ??
+      this.toolOutputRegistry?.nextTurn(batchScopeId) ??
+      0;
     let outputs: (BaseMessage | Command)[];
     let replayBatchKey: string | undefined;
     /** Hoisted from the messages-state branch so the Command tail can carry
@@ -5045,10 +5277,13 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         throw new Error('ToolNode only accepts AIMessages as input.');
       }
       const aiMessage = assistantBatch.message;
-      replayBatchKey = getToolBatchReplayScope(config) == null ? undefined : getAssistantBatchReplayKey(
-        assistantBatch,
-        getToolBatchReplayScope(config)
-      );
+      replayBatchKey =
+        getToolBatchReplayScope(config) == null
+          ? undefined
+          : getAssistantBatchReplayKey(
+            assistantBatch,
+            getToolBatchReplayScope(config)
+          );
 
       if (this.loadRuntimeTools) {
         const { tools, toolMap } = this.loadRuntimeTools(
@@ -5059,7 +5294,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         this.applyToolExecutionOverrides();
       }
 
-      const replayCallPositions = new Map((aiMessage.tool_calls ?? []).map((call, i) => [call, i]));
+      const replayCallPositions = new Map(
+        (aiMessage.tool_calls ?? []).map((call, i) => [call, i])
+      );
       const filteredCalls =
         aiMessage.tool_calls?.filter((call) => {
           /**
@@ -5069,7 +5306,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
            *    which are executed by the provider's API and don't require invocation
            */
           return (
-            (call.id == null || call.id === '' || !toolMessageIds.has(call.id)) &&
+            (call.id == null ||
+              call.id === '' ||
+              !toolMessageIds.has(call.id)) &&
             !(
               call.id?.startsWith(Constants.ANTHROPIC_SERVER_TOOL_PREFIX) ??
               false
@@ -5234,7 +5473,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
          * same-turn direct outputs.
          */
         const preBatchSnapshot =
-          replayInputSnapshot ?? this.toolOutputRegistry?.snapshot(batchScopeId);
+          replayInputSnapshot ??
+          this.toolOutputRegistry?.snapshot(batchScopeId);
         if (preBatchSnapshot != null) {
           for (const entry of eventEntries) {
             if (entry.call.id != null) {
@@ -5281,11 +5521,18 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             : [];
 
         const settledDirectResults =
-          replayBatchKey == null ? undefined : this.settledDirectResultsByBatch.get(replayBatchKey);
+          replayBatchKey == null
+            ? undefined
+            : this.settledDirectResultsByBatch.get(replayBatchKey);
         const unhandledDirectCalls: ToolCall[] = [];
         const unhandledDirectOutputs: (BaseMessage | Command)[] = [];
         for (let i = 0; i < directCalls.length; i++) {
-          const settled = settledDirectResults?.get(directReplayKey(directCalls[i], replayCallPositions.get(directCalls[i])!));
+          const settled = settledDirectResults?.get(
+            directReplayKey(
+              directCalls[i],
+              replayCallPositions.get(directCalls[i])!
+            )
+          );
           if (settled?.completionHandled === true) {
             continue;
           }
@@ -5302,7 +5549,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
             errorOwnership
           );
           for (let i = 0; i < directCalls.length; i++) {
-            const settled = settledDirectResults?.get(directReplayKey(directCalls[i], replayCallPositions.get(directCalls[i])!));
+            const settled = settledDirectResults?.get(
+              directReplayKey(
+                directCalls[i],
+                replayCallPositions.get(directCalls[i])!
+              )
+            );
             if (settled != null) {
               settled.completionHandled = true;
             }
@@ -5355,7 +5607,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         // leak a sibling's just-registered output into a sister
         // call's args mid-await (Codex P1 #18).
         const preBatchSnapshot =
-          replayInputSnapshot ?? this.toolOutputRegistry?.snapshot(batchScopeId);
+          replayInputSnapshot ??
+          this.toolOutputRegistry?.snapshot(batchScopeId);
         const directAdditionalContexts: string[] = [];
         const approvalScopeCallIds = new Set(
           filteredCalls.flatMap((call) => (call.id == null ? [] : [call.id]))

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3147,7 +3147,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return;
     }
     const refreshedByName = new Map<string, t.CodeEnvFile>();
-    let sessionId: string | undefined;
+    let refreshedSessionId: string | undefined;
+    let fileSessionId: string | undefined;
     for (const request of requests) {
       if (
         request.name === '' ||
@@ -3161,7 +3162,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const context = request.codeSessionContext;
       if (context?.session_id == null || context.session_id === '') continue;
       if (context.session_id !== request.codeSessionBaselineId) {
-        sessionId = context.session_id;
+        refreshedSessionId = context.session_id;
       }
       const baselineIdentityByName = baselineByRequestId.get(request.id);
       for (const file of context.files ?? []) {
@@ -3169,10 +3170,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         if (baselineIdentityByName?.get(file.name) === fileIdentityKey(file)) {
           continue;
         }
-        sessionId = context.session_id;
+        fileSessionId = context.session_id;
         refreshedByName.set(file.name, file);
       }
     }
+    const sessionId = refreshedSessionId ?? fileSessionId;
     if (sessionId == null) return;
     retainCodeSessionInputs(this.sessions, this.codeSessionKey, {
       session_id: sessionId,

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3092,13 +3092,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
-    requestMap: Map<string, t.ToolCallRequest>
+    requestMap: Map<string, t.ToolCallRequest>,
+    baselineIdentityByName: ReadonlyMap<string, string>
   ): void {
     if (!this.sessions) {
       return;
     }
 
-    this.retainCodeSessionInputsFromRequests(requestMap.values());
+    this.retainCodeSessionInputsFromRequests(
+      requestMap.values(),
+      baselineIdentityByName
+    );
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       const request = requestMap.get(result.toolCallId);
@@ -3131,27 +3135,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   }
 
   private retainCodeSessionInputsFromRequests(
-    requests: Iterable<t.ToolCallRequest>
+    requests: Iterable<t.ToolCallRequest>,
+    baselineIdentityByName: ReadonlyMap<string, string>
   ): void {
     if (!this.sessions) {
       return;
     }
-    const existing = this.sessions.get(this.codeSessionKey) as
-      | t.CodeSessionContext
-      | undefined;
-    const baselineIdentityByName = new Map(
-      (existing?.files ?? []).map((file) => [
-        file.name,
-        fileIdentityKey(file),
-      ])
-    );
     const refreshedByName = new Map<string, t.CodeEnvFile>();
     let sessionId: string | undefined;
     for (const request of requests) {
       if (
         request.name === '' ||
         (!this.participatesInCodeSession(request.name) &&
-          request.name !== Constants.SKILL_TOOL)
+          request.name !== Constants.SKILL_TOOL &&
+          request.name !== Constants.READ_FILE)
       ) {
         continue;
       }
@@ -4094,6 +4091,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const requestMap = new Map(plan.allRequests.map((r) => [r.id, r]));
+      const codeSessionBaselineByName = new Map(
+        (
+          (
+            this.sessions?.get(this.codeSessionKey) as
+              | t.CodeSessionContext
+              | undefined
+          )?.files ?? []
+        ).map((file) => [file.name, fileIdentityKey(file)])
+      );
       const eagerExecutions: Array<{
         request: t.ToolCallRequest;
         execution: t.EagerEventToolExecution;
@@ -4254,11 +4260,17 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         dispatchPromise,
       ]);
       if (eagerOutcome.status === 'rejected') {
-        this.retainCodeSessionInputsFromRequests(requestMap.values());
+        this.retainCodeSessionInputsFromRequests(
+          requestMap.values(),
+          codeSessionBaselineByName
+        );
         throw eagerOutcome.reason;
       }
       if (dispatchedOutcome.status === 'rejected') {
-        this.retainCodeSessionInputsFromRequests(requestMap.values());
+        this.retainCodeSessionInputsFromRequests(
+          requestMap.values(),
+          codeSessionBaselineByName
+        );
         throw dispatchedOutcome.reason;
       }
       const eagerResults = eagerOutcome.value;
@@ -4280,7 +4292,11 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         ...dispatchedResults,
       ];
 
-      this.storeCodeSessionFromResults(results, requestMap);
+      this.storeCodeSessionFromResults(
+        results,
+        requestMap,
+        codeSessionBaselineByName
+      );
 
       for (const result of results) {
         if (result.injectedMessages && result.injectedMessages.length > 0) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -758,7 +758,7 @@ function retainCodeSessionInputs(
   }
   if (!changed) return;
   sessions.set(sessionKey, {
-    session_id: existing?.session_id ?? context.session_id,
+    session_id: context.session_id,
     files,
     lastUpdated: Date.now(),
   });
@@ -3154,19 +3154,20 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         request.name === '' ||
         (!this.participatesInCodeSession(request.name) &&
           request.name !== Constants.SKILL_TOOL &&
-          request.name !== Constants.READ_FILE)
+          request.name !== Constants.READ_FILE &&
+          request.retainCodeSessionInputs !== true)
       ) {
         continue;
       }
       const context = request.codeSessionContext;
       if (context?.session_id == null || context.session_id === '') continue;
-      sessionId ??= context.session_id;
       const baselineIdentityByName = baselineByRequestId.get(request.id);
       for (const file of context.files ?? []) {
         if (!file.id || !file.name || !file.storage_session_id) continue;
         if (baselineIdentityByName?.get(file.name) === fileIdentityKey(file)) {
           continue;
         }
+        sessionId = context.session_id;
         refreshedByName.set(file.name, file);
       }
     }
@@ -4596,29 +4597,40 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       // effects) every round.
       this.eagerEventToolSuppressions?.add(request.name);
       this.eagerEventToolSuppressions?.add(execution.toolName);
+      if (
+        this.participatesInCodeSession(execution.toolName) ||
+        execution.toolName === Constants.SKILL_TOOL ||
+        execution.toolName === Constants.READ_FILE
+      ) {
+        request.retainCodeSessionInputs = true;
+      }
       // eslint-disable-next-line no-console
       console.warn(
         '[ToolNode] eager prestart args diverged from the final request for ' +
           `tool "${request.name}" (toolCallId=${request.id}); suppressing ` +
           'eager prestart for this tool for the rest of the run'
       );
+      const createMismatchOutcome = (): t.EagerEventToolExecutionOutcome => ({
+        results: [
+          {
+            toolCallId: request.id,
+            status: 'error',
+            content: '',
+            errorMessage:
+              'Tool call changed after eager execution started; refusing to re-run the tool to avoid duplicate side effects.',
+          },
+        ],
+      });
       return {
         toolCallId: request.id,
         toolName: request.name,
         args: request.args,
         request: execution.request,
         codeSessionBaselineByName: execution.codeSessionBaselineByName,
-        promise: Promise.resolve({
-          results: [
-            {
-              toolCallId: request.id,
-              status: 'error',
-              content: '',
-              errorMessage:
-                'Tool call changed after eager execution started; refusing to re-run the tool to avoid duplicate side effects.',
-            },
-          ],
-        }),
+        promise: execution.promise.then(
+          createMismatchOutcome,
+          createMismatchOutcome
+        ),
       };
     }
 

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -725,8 +725,7 @@ function retainCodeSessionInputs(
   if (
     context?.session_id == null ||
     context.session_id === '' ||
-    context.files == null ||
-    context.files.length === 0
+    context.files == null
   )
     return;
   const existing = sessions.get(sessionKey) as t.CodeSessionContext | undefined;
@@ -738,7 +737,7 @@ function retainCodeSessionInputs(
     indexByIdentity.set(fileIdentityKey(files[i]), i);
     indexByName.set(files[i].name, i);
   }
-  let changed = false;
+  let changed = existing?.session_id !== context.session_id;
   for (const file of context.files) {
     if (!file.id || !file.name || !file.storage_session_id) continue;
     const identity = fileIdentityKey(file);
@@ -3161,6 +3160,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
       const context = request.codeSessionContext;
       if (context?.session_id == null || context.session_id === '') continue;
+      if (context.session_id !== request.codeSessionBaselineId) {
+        sessionId = context.session_id;
+      }
       const baselineIdentityByName = baselineByRequestId.get(request.id);
       for (const file of context.files ?? []) {
         if (!file.id || !file.name || !file.storage_session_id) continue;
@@ -3171,7 +3173,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         refreshedByName.set(file.name, file);
       }
     }
-    if (sessionId == null || refreshedByName.size === 0) return;
+    if (sessionId == null) return;
     retainCodeSessionInputs(this.sessions, this.codeSessionKey, {
       session_id: sessionId,
       files: [...refreshedByName.values()],
@@ -4099,6 +4101,9 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       }
 
       const requestMap = new Map(plan.allRequests.map((r) => [r.id, r]));
+      for (const request of plan.allRequests) {
+        request.codeSessionBaselineId = request.codeSessionContext?.session_id;
+      }
       const codeSessionBaselineByRequestId = new Map<
         string,
         ReadonlyMap<string, string>
@@ -4129,6 +4134,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
               eagerExecution.codeSessionBaselineByName
             );
           }
+          request.codeSessionBaselineId =
+            eagerExecution.request.codeSessionBaselineId;
         } else {
           dispatchRequests.push(request);
         }

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -4606,7 +4606,8 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         toolCallId: request.id,
         toolName: request.name,
         args: request.args,
-        request,
+        request: execution.request,
+        codeSessionBaselineByName: execution.codeSessionBaselineByName,
         promise: Promise.resolve({
           results: [
             {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -3093,7 +3093,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
   private storeCodeSessionFromResults(
     results: t.ToolExecuteResult[],
     requestMap: Map<string, t.ToolCallRequest>,
-    baselineIdentityByName: ReadonlyMap<string, string>
+    baselineByRequestId: ReadonlyMap<
+      string,
+      ReadonlyMap<string, string>
+    >
   ): void {
     if (!this.sessions) {
       return;
@@ -3101,7 +3104,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
     this.retainCodeSessionInputsFromRequests(
       requestMap.values(),
-      baselineIdentityByName
+      baselineByRequestId
     );
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
@@ -3136,7 +3139,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
 
   private retainCodeSessionInputsFromRequests(
     requests: Iterable<t.ToolCallRequest>,
-    baselineIdentityByName: ReadonlyMap<string, string>
+    baselineByRequestId: ReadonlyMap<
+      string,
+      ReadonlyMap<string, string>
+    >
   ): void {
     if (!this.sessions) {
       return;
@@ -3155,9 +3161,10 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       const context = request.codeSessionContext;
       if (context?.session_id == null || context.session_id === '') continue;
       sessionId ??= context.session_id;
+      const baselineIdentityByName = baselineByRequestId.get(request.id);
       for (const file of context.files ?? []) {
         if (!file.id || !file.name || !file.storage_session_id) continue;
-        if (baselineIdentityByName.get(file.name) === fileIdentityKey(file)) {
+        if (baselineIdentityByName?.get(file.name) === fileIdentityKey(file)) {
           continue;
         }
         refreshedByName.set(file.name, file);
@@ -4100,6 +4107,15 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
           )?.files ?? []
         ).map((file) => [file.name, fileIdentityKey(file)])
       );
+      const codeSessionBaselineByRequestId = new Map<
+        string,
+        ReadonlyMap<string, string>
+      >(
+        plan.allRequests.map((request) => [
+          request.id,
+          codeSessionBaselineByName,
+        ])
+      );
       const eagerExecutions: Array<{
         request: t.ToolCallRequest;
         execution: t.EagerEventToolExecution;
@@ -4110,6 +4126,12 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         const eagerExecution = this.takeMatchingEagerEventExecution(request);
         if (eagerExecution != null) {
           eagerExecutions.push({ request, execution: eagerExecution });
+          if (eagerExecution.codeSessionBaselineByName != null) {
+            codeSessionBaselineByRequestId.set(
+              request.id,
+              eagerExecution.codeSessionBaselineByName
+            );
+          }
         } else {
           dispatchRequests.push(request);
         }
@@ -4262,14 +4284,14 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       if (eagerOutcome.status === 'rejected') {
         this.retainCodeSessionInputsFromRequests(
           requestMap.values(),
-          codeSessionBaselineByName
+          codeSessionBaselineByRequestId
         );
         throw eagerOutcome.reason;
       }
       if (dispatchedOutcome.status === 'rejected') {
         this.retainCodeSessionInputsFromRequests(
           requestMap.values(),
-          codeSessionBaselineByName
+          codeSessionBaselineByRequestId
         );
         throw dispatchedOutcome.reason;
       }
@@ -4295,7 +4317,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       this.storeCodeSessionFromResults(
         results,
         requestMap,
-        codeSessionBaselineByName
+        codeSessionBaselineByRequestId
       );
 
       for (const result of results) {

--- a/src/tools/ToolNode.ts
+++ b/src/tools/ToolNode.ts
@@ -716,8 +716,7 @@ function updateCodeSession(
   });
 }
 
-/** Retains host-provisioned inputs even when execution returns no usable artifact.
- * Existing session versions win over older request snapshots from the same batch. */
+/** Retains host-provisioned inputs even when execution returns no usable artifact. */
 function retainCodeSessionInputs(
   sessions: t.ToolSessionMap,
   sessionKey: string,
@@ -732,23 +731,32 @@ function retainCodeSessionInputs(
     return;
   const existing = sessions.get(sessionKey) as t.CodeSessionContext | undefined;
   const existingFiles = existing?.files ?? [];
-  const identities = new Set<string>();
-  const names = new Set<string>();
-  for (const file of existingFiles) {
-    identities.add(fileIdentityKey(file));
-    names.add(file.name);
+  const files = [...existingFiles];
+  const indexByIdentity = new Map<string, number>();
+  const indexByName = new Map<string, number>();
+  for (let i = 0; i < files.length; i++) {
+    indexByIdentity.set(fileIdentityKey(files[i]), i);
+    indexByName.set(files[i].name, i);
   }
-  let files: t.FileRefs | undefined;
+  let changed = false;
   for (const file of context.files) {
     if (!file.id || !file.name || !file.storage_session_id) continue;
     const identity = fileIdentityKey(file);
-    if (identities.has(identity) || names.has(file.name)) continue;
-    identities.add(identity);
-    names.add(file.name);
-    files ??= [...existingFiles];
+    if (indexByIdentity.has(identity)) continue;
+    const replacementIndex = indexByName.get(file.name);
+    if (replacementIndex !== undefined) {
+      indexByIdentity.delete(fileIdentityKey(files[replacementIndex]));
+      files[replacementIndex] = { ...file };
+      indexByIdentity.set(identity, replacementIndex);
+      changed = true;
+      continue;
+    }
+    indexByIdentity.set(identity, files.length);
+    indexByName.set(file.name, files.length);
     files.push({ ...file });
+    changed = true;
   }
-  if (!files) return;
+  if (!changed) return;
   sessions.set(sessionKey, {
     session_id: existing?.session_id ?? context.session_id,
     files,
@@ -3090,6 +3098,7 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
       return;
     }
 
+    this.retainCodeSessionInputsFromRequests(requestMap.values());
     for (let i = 0; i < results.length; i++) {
       const result = results[i];
       const request = requestMap.get(result.toolCallId);
@@ -3102,11 +3111,6 @@ export class ToolNode<T = any> extends RunnableCallable<T, T> {
         continue;
       }
 
-      retainCodeSessionInputs(
-        this.sessions,
-        this.codeSessionKey,
-        request.codeSessionContext
-      );
       if (result.status !== 'success' || result.artifact == null) {
         continue;
       }

--- a/src/tools/__tests__/ProgrammaticToolCalling.test.ts
+++ b/src/tools/__tests__/ProgrammaticToolCalling.test.ts
@@ -1611,27 +1611,41 @@ for member in team:
       expect(gate.denyReason).toContain('no writes from bridge');
     });
 
-    it('threads executingAgentId from the hook context to bridge PreToolUse hooks', async () => {
+    it('threads agent identity from the hook context to bridge PreToolUse hooks', async () => {
       const { HookRegistry } = await import('@/hooks');
 
       const ptcMod = require('../local/LocalProgrammaticToolCalling');
       const registry = new HookRegistry();
       let seen: string | undefined = 'UNSET';
+      let seenContext: t.SubagentExecutionContext | undefined;
+      const executionContext: t.SubagentExecutionContext = {
+        rootRunId: 'root-run',
+        hookSessionId: 'r1',
+        depth: 1,
+        ancestry: [],
+      };
       registry.register('PreToolUse', {
         hooks: [
           async (input) => {
             seen = input.executingAgentId;
+            seenContext = input.executionContext;
             return { decision: 'allow' };
           },
         ],
       });
       await ptcMod.applyPreToolUseHooksForBridge(
-        { registry, runId: 'r1', executingAgentId: 'repo_investigator' },
+        {
+          registry,
+          runId: 'r1',
+          executingAgentId: 'repo_investigator',
+          executionContext,
+        },
         'write_file',
         'call_1',
         { path: '/tmp/x' }
       );
       expect(seen).toBe('repo_investigator');
+      expect(seenContext).toEqual(executionContext);
     });
 
     it('passes through when no hook denies (allow path)', async () => {

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -755,6 +755,46 @@ describe('SubagentExecutor', () => {
     });
   });
 
+  it('releases detached state when result delivery hangs past task timeout', async () => {
+    const store = new InMemorySubagentTaskStore({ taskTimeoutMs: 20 });
+    const clearHeavyState = jest.fn();
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      subagentContext: {
+        prepare: async () => ({}),
+        complete: () => new Promise(() => undefined),
+      },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({
+            invoke: jest.fn().mockResolvedValue({
+              messages: [new AIMessage('detached result')],
+            }),
+          }),
+          clearHeavyState,
+        }) as unknown as StandardGraph,
+    });
+
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Research independently.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_delivery_timeout',
+      })
+    ) as { background_task_id: string };
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'error'
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(clearHeavyState).toHaveBeenCalled();
+    expect(
+      store.get('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'error', error: 'Detached subagent task timed out.' });
+  });
+
   it('replaces the ambient parent run config for detached child execution', async () => {
     const store = new InMemorySubagentTaskStore();
     const parentController = new AbortController();

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -670,6 +670,54 @@ describe('SubagentExecutor', () => {
     expect(hookRegistry.hasHookFor('PreToolUse', 'test-run')).toBe(false);
   });
 
+  it('retries detached result delivery without rerunning the child', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const invoke = jest.fn().mockResolvedValue({
+      messages: [new AIMessage('detached result')],
+    });
+    let deliveryAttempts = 0;
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      subagentContext: {
+        prepare: async () => ({}),
+        complete: async (_input, result) => {
+          deliveryAttempts += 1;
+          if (deliveryAttempts === 1) {
+            throw new Error('Transient delivery failure');
+          }
+          return { content: `${result.content} delivered` };
+        },
+      },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Research independently.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_delivery_retry',
+      })
+    ) as { background_task_id: string };
+    await waitForTask(
+      store,
+      response.background_task_id,
+      (status) => status === 'completed'
+    );
+
+    expect(
+      store.get('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'completed' });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(deliveryAttempts).toBe(2);
+    expect(
+      store.claim('owner:conversation', response.background_task_id)
+    ).toMatchObject({ status: 'completed', result: 'detached result delivered' });
+  });
+
   it('replaces the ambient parent run config for detached child execution', async () => {
     const store = new InMemorySubagentTaskStore();
     const parentController = new AbortController();

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -718,6 +718,43 @@ describe('SubagentExecutor', () => {
     ).toMatchObject({ status: 'completed', result: 'detached result delivered' });
   });
 
+  it('bounds detached result delivery retries', async () => {
+    const store = new InMemorySubagentTaskStore();
+    const invoke = jest.fn().mockResolvedValue({
+      messages: [new AIMessage('detached result')],
+    });
+    const complete = jest.fn(async () => {
+      throw new Error('Persistent delivery failure');
+    });
+    const executor = createExecutor({
+      taskConfig: { store, scopeId: 'owner:conversation' },
+      subagentContext: { prepare: async () => ({}), complete },
+      createChildGraph: (): StandardGraph =>
+        ({
+          createWorkflow: () => ({ invoke }),
+          clearHeavyState: jest.fn(),
+        }) as unknown as StandardGraph,
+    });
+
+    const response = JSON.parse(
+      executor.executeInBackground({
+        description: 'Research independently.',
+        subagentType: 'researcher',
+        parentToolCallId: 'call_delivery_failure',
+      })
+    ) as { background_task_id: string };
+    await new Promise<void>((resolve) => setTimeout(resolve, 150));
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(complete).toHaveBeenCalledTimes(3);
+    expect(
+      store.get('owner:conversation', response.background_task_id)
+    ).toMatchObject({
+      status: 'error',
+      error: 'Subagent result delivery failed.',
+    });
+  });
+
   it('replaces the ambient parent run config for detached child execution', async () => {
     const store = new InMemorySubagentTaskStore();
     const parentController = new AbortController();

--- a/src/tools/__tests__/SubagentExecutor.test.ts
+++ b/src/tools/__tests__/SubagentExecutor.test.ts
@@ -600,15 +600,13 @@ describe('SubagentExecutor', () => {
     const invoke = jest.fn(() => invocation);
     const clearHeavyState = jest.fn();
     let detachedGraph: StandardGraph | undefined;
-    const createDetachedChildGraphFactory = jest.fn(
-      () => (): StandardGraph => {
-        detachedGraph = {
-          createWorkflow: () => ({ invoke }),
-          clearHeavyState,
-        } as unknown as StandardGraph;
-        return detachedGraph;
-      }
-    );
+    const createDetachedChildGraphFactory = jest.fn(() => (): StandardGraph => {
+      detachedGraph = {
+        createWorkflow: () => ({ invoke }),
+        clearHeavyState,
+      } as unknown as StandardGraph;
+      return detachedGraph;
+    });
     const fallbackFactory = jest.fn(
       (): StandardGraph =>
         ({
@@ -3221,7 +3219,14 @@ describe('SubagentExecutor', () => {
         string,
         unknown
       >;
-      expect(Object.keys(configurable)).toEqual(['thread_id']);
+      expect(Object.keys(configurable)).toEqual([
+        'executionContext',
+        'thread_id',
+      ]);
+      expect(configurable.executionContext).toMatchObject({
+        rootRunId: 'test-run',
+        depth: 1,
+      });
     });
   });
 

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -279,5 +279,113 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(captured[0].id).toBe('retry');
       expect(captured[0].codeSessionContext?.files).toEqual(inputs);
     });
+
+    it('retains lazily provisioned inputs when an event batch rejects', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      let attempt = 0;
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          const request = batch.toolCalls[0];
+          if (attempt++ === 0) {
+            request.codeSessionContext = {
+              session_id: 'input-context',
+              files: structuredClone(inputs),
+            };
+            batch.reject(new Error('transport failed'));
+            return;
+          }
+          expect(request.codeSessionContext?.files).toEqual(inputs);
+          batch.resolve([
+            { toolCallId: request.id, status: 'success', content: '' },
+          ]);
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'first', name: toolName, args: {} }],
+            }),
+          ],
+        })
+      ).rejects.toThrow('transport failed');
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'retry', name: toolName, args: {} }],
+          }),
+        ],
+      });
+    });
+
+    it('retains lazily provisioned inputs when eager execution rejects', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const request: t.ToolCallRequest = {
+        id: 'first',
+        name: toolName,
+        args: {},
+      };
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
+        [
+          request.id,
+          {
+            toolCallId: request.id,
+            toolName,
+            args: {},
+            request,
+            promise: Promise.resolve().then(() => {
+              request.codeSessionContext = {
+                session_id: 'input-context',
+                files: structuredClone(inputs),
+              };
+              return { error: new Error('eager failed') };
+            }),
+          },
+        ],
+      ]);
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'first', name: toolName, args: {} }],
+            }),
+          ],
+        })
+      ).rejects.toThrow('eager failed');
+      expect(sessions.get('child-agent')?.files).toEqual(inputs);
+    });
   }
 );

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -493,6 +493,58 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(sessions.get('child-agent')?.session_id).toBe('input-context');
     });
 
+    it('retains an execution session refresh without file changes', async () => {
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'old-exec', files: inputs, lastUpdated: 1 },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          batch.toolCalls[0].codeSessionContext = {
+            session_id: 'refreshed-exec',
+            files: structuredClone(inputs),
+          };
+          batch.resolve([
+            {
+              toolCallId: batch.toolCalls[0].id,
+              status: 'success',
+              content: '',
+            },
+          ]);
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: 'refresh-session', name: toolName, args: {} }],
+          }),
+        ],
+      });
+
+      expect(sessions.get('child-agent')).toMatchObject({
+        session_id: 'refreshed-exec',
+        files: inputs,
+      });
+    });
+
     it('ignores a later request carrying the original batch snapshot', async () => {
       const stale = inputs[0];
       const refreshed = {

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -387,5 +387,73 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       ).rejects.toThrow('eager failed');
       expect(sessions.get('child-agent')?.files).toEqual(inputs);
     });
+
+    it('waits for peer execution input provisioning before retaining a rejected batch', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const eagerRequest: t.ToolCallRequest = {
+        id: 'eager',
+        name: toolName,
+        args: {},
+      };
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
+        [
+          eagerRequest.id,
+          {
+            toolCallId: eagerRequest.id,
+            toolName,
+            args: {},
+            request: eagerRequest,
+            promise: Promise.resolve({ error: new Error('eager failed') }),
+          },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          await Promise.resolve();
+          batch.toolCalls[0].codeSessionContext = {
+            session_id: 'input-context',
+            files: structuredClone(inputs),
+          };
+          batch.resolve([
+            {
+              toolCallId: batch.toolCalls[0].id,
+              status: 'success',
+              content: '',
+            },
+          ]);
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [
+                { id: 'eager', name: toolName, args: {} },
+                { id: 'dispatched', name: toolName, args: {} },
+              ],
+            }),
+          ],
+        })
+      ).rejects.toThrow('eager failed');
+      expect(sessions.get('child-agent')?.files).toEqual(inputs);
+    });
   }
 );

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -397,6 +397,131 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       ]);
     });
 
+    it('uses the pre-dispatch baseline across concurrent batches', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'old-exec', files: [stale], lastUpdated: 1 },
+        ],
+      ]);
+      let finishStale = (): void => undefined;
+      const staleGate = new Promise<void>((resolve) => {
+        finishStale = resolve;
+      });
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          const request = batch.toolCalls[0];
+          if (request.id === 'stale') {
+            await staleGate;
+          } else {
+            request.codeSessionContext = {
+              session_id: 'input-context',
+              files: [refreshed],
+            };
+          }
+          batch.resolve([
+            { toolCallId: request.id, status: 'success', content: '' },
+          ]);
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+      const invoke = (id: string) =>
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id, name: toolName, args: {} }],
+            }),
+          ],
+        });
+
+      const staleBatch = invoke('stale');
+      await invoke('refreshed');
+      finishStale();
+      await staleBatch;
+
+      expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+    });
+
+    it('retains refreshed inputs from read_file requests', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'old-exec', files: [stale], lastUpdated: 1 },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          const request = batch.toolCalls[0];
+          if (request.name === Constants.READ_FILE) {
+            request.codeSessionContext = {
+              session_id: 'input-context',
+              files: [refreshed],
+            };
+          } else {
+            expect(request.codeSessionContext?.files).toEqual([refreshed]);
+          }
+          batch.resolve([
+            { toolCallId: request.id, status: 'success', content: '' },
+          ]);
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+          tool(async () => 'unused', {
+            name: Constants.READ_FILE,
+            description: 'Read file',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+      for (const [id, name] of [
+        ['read', Constants.READ_FILE],
+        ['execute', toolName],
+      ]) {
+        await node.invoke({
+          messages: [
+            new AIMessage({ content: '', tool_calls: [{ id, name, args: {} }] }),
+          ],
+        });
+      }
+    });
+
     it('retains lazily provisioned inputs when an event batch rejects', async () => {
       const sessions: t.ToolSessionMap = new Map();
       let attempt = 0;

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -335,6 +335,68 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
     });
 
+    it('ignores a later request carrying the original batch snapshot', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        resource_id: 'user-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          {
+            session_id: 'old-exec',
+            files: structuredClone(inputs),
+            lastUpdated: 1,
+          },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          batch.toolCalls[0].codeSessionContext = {
+            session_id: 'input-context',
+            files: [refreshed, inputs[1]],
+          };
+          batch.reject(new Error('transport failed'));
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: ['refresh', 'stale'].map((id) => ({
+                id,
+                name: toolName,
+                args: {},
+              })),
+            }),
+          ],
+        })
+      ).rejects.toThrow('transport failed');
+      expect(sessions.get('child-agent')?.files).toEqual([
+        refreshed,
+        inputs[1],
+      ]);
+    });
+
     it('retains lazily provisioned inputs when an event batch rejects', async () => {
       const sessions: t.ToolSessionMap = new Map();
       let attempt = 0;

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -280,6 +280,61 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(captured[0].codeSessionContext?.files).toEqual(inputs);
     });
 
+    it('replaces a stale same-name session file with a refreshed input', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        resource_id: 'user-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          {
+            session_id: 'old-exec',
+            files: [stale],
+            lastUpdated: 1,
+          },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          batch.toolCalls[0].codeSessionContext = {
+            session_id: 'input-context',
+            files: [refreshed],
+          };
+          batch.reject(new Error('transport failed'));
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id: 'refresh', name: toolName, args: {} }],
+            }),
+          ],
+        })
+      ).rejects.toThrow('transport failed');
+      expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+    });
+
     it('retains lazily provisioned inputs when an event batch rejects', async () => {
       const sessions: t.ToolSessionMap = new Map();
       let attempt = 0;

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -352,6 +352,79 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
     });
 
+    it('retains refreshed eager inputs when the final tool identity differs', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const finalToolName =
+        toolName === Constants.EXECUTE_CODE
+          ? Constants.BASH_TOOL
+          : Constants.EXECUTE_CODE;
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'old-exec', files: [stale], lastUpdated: 1 },
+        ],
+      ]);
+      const request: t.ToolCallRequest = {
+        id: 'eager',
+        name: toolName,
+        args: {},
+        codeSessionContext: {
+          session_id: 'input-context',
+          files: [refreshed],
+        },
+      };
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
+        [
+          request.id,
+          {
+            toolCallId: request.id,
+            toolName,
+            args: {},
+            request,
+            codeSessionBaselineByName: new Map([
+              [stale.name, `${stale.storage_session_id}\0${stale.id}`],
+            ]),
+            promise: Promise.resolve({ results: [] }),
+          },
+        ],
+      ]);
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+          tool(async () => 'unused', {
+            name: finalToolName,
+            description: 'Final code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+      });
+
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: request.id, name: finalToolName, args: {} }],
+          }),
+        ],
+      });
+
+      expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+    });
+
     it('replaces a stale same-name session file with a refreshed input', async () => {
       const stale = inputs[0];
       const refreshed = {

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -280,6 +280,78 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       expect(captured[0].codeSessionContext?.files).toEqual(inputs);
     });
 
+    it('uses the eager request creation baseline for retained inputs', async () => {
+      const stale = inputs[0];
+      const refreshed = {
+        ...stale,
+        id: 'order-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'new-exec', files: [refreshed], lastUpdated: 2 },
+        ],
+      ]);
+      const request: t.ToolCallRequest = {
+        id: 'eager',
+        name: toolName,
+        args: {},
+        codeSessionContext: {
+          session_id: 'old-exec',
+          files: [stale],
+        },
+      };
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
+        [
+          request.id,
+          {
+            toolCallId: request.id,
+            toolName,
+            args: {},
+            request,
+            codeSessionBaselineByName: new Map([
+              [stale.name, `${stale.storage_session_id}\0${stale.id}`],
+            ]),
+            promise: Promise.resolve({
+              results: [
+                {
+                  toolCallId: request.id,
+                  status: 'success',
+                  content: '',
+                },
+              ],
+            }),
+          },
+        ],
+      ]);
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+      });
+
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: [{ id: request.id, name: toolName, args: {} }],
+          }),
+        ],
+      });
+
+      expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+    });
+
     it('replaces a stale same-name session file with a refreshed input', async () => {
       const stale = inputs[0];
       const refreshed = {

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -545,6 +545,66 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
       });
     });
 
+    it('prefers an explicit session refresh over a sibling file session', async () => {
+      const refreshed = {
+        ...inputs[0],
+        id: 'order-refreshed',
+        storage_session_id: 'refreshed-storage',
+      };
+      const sessions: t.ToolSessionMap = new Map([
+        [
+          'child-agent',
+          { session_id: 'old-exec', files: inputs, lastUpdated: 1 },
+        ],
+      ]);
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          batch.toolCalls[0].codeSessionContext = {
+            session_id: 'refreshed-exec',
+            files: structuredClone(inputs),
+          };
+          batch.toolCalls[1].codeSessionContext = {
+            session_id: 'old-exec',
+            files: [refreshed, inputs[1]],
+          };
+          batch.reject(new Error('transport failed'));
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await expect(
+        node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: ['session', 'file'].map((id) => ({
+                id,
+                name: toolName,
+                args: {},
+              })),
+            }),
+          ],
+        })
+      ).rejects.toThrow('transport failed');
+      expect(sessions.get('child-agent')).toMatchObject({
+        session_id: 'refreshed-exec',
+        files: [refreshed, inputs[1]],
+      });
+    });
+
     it('ignores a later request carrying the original batch snapshot', async () => {
       const stale = inputs[0];
       const refreshed = {

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -359,10 +359,7 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
         id: 'order-refreshed',
         storage_session_id: 'refreshed-storage',
       };
-      const finalToolName =
-        toolName === Constants.EXECUTE_CODE
-          ? Constants.BASH_TOOL
-          : Constants.EXECUTE_CODE;
+      const finalToolName = 'weather';
       const sessions: t.ToolSessionMap = new Map([
         [
           'child-agent',
@@ -374,10 +371,17 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
         name: toolName,
         args: {},
         codeSessionContext: {
-          session_id: 'input-context',
-          files: [refreshed],
+          session_id: 'old-exec',
+          files: [stale],
         },
       };
+      let finishEager = (_outcome: t.EagerEventToolExecutionOutcome): void =>
+        undefined;
+      const eagerPromise = new Promise<t.EagerEventToolExecutionOutcome>(
+        (resolve) => {
+          finishEager = resolve;
+        }
+      );
       const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
         [
           request.id,
@@ -389,7 +393,7 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
             codeSessionBaselineByName: new Map([
               [stale.name, `${stale.storage_session_id}\0${stale.id}`],
             ]),
-            promise: Promise.resolve({ results: [] }),
+            promise: eagerPromise,
           },
         ],
       ]);
@@ -413,7 +417,7 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
         eagerEventToolExecutions: eagerExecutions,
       });
 
-      await node.invoke({
+      const result = node.invoke({
         messages: [
           new AIMessage({
             content: '',
@@ -421,8 +425,16 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
           }),
         ],
       });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      request.codeSessionContext = {
+        session_id: 'input-context',
+        files: [refreshed],
+      };
+      finishEager({ results: [] });
+      await result;
 
       expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+      expect(sessions.get('child-agent')?.session_id).toBe('input-context');
     });
 
     it('replaces a stale same-name session file with a refreshed input', async () => {
@@ -478,6 +490,7 @@ describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
         })
       ).rejects.toThrow('transport failed');
       expect(sessions.get('child-agent')?.files).toEqual([refreshed]);
+      expect(sessions.get('child-agent')?.session_id).toBe('input-context');
     });
 
     it('ignores a later request carrying the original batch snapshot', async () => {

--- a/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
+++ b/src/tools/__tests__/ToolNode.lazyCodeFiles.test.ts
@@ -1,0 +1,283 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { AIMessage } from '@langchain/core/messages';
+import { describe, it, expect, jest, afterEach } from '@jest/globals';
+import type * as t from '@/types';
+import { Constants, GraphEvents } from '@/common';
+import * as events from '@/utils/events';
+import { ToolNode } from '../ToolNode';
+
+const inputs: t.CodeEnvFile[] = [
+  {
+    id: 'order',
+    name: 'order.pdf',
+    resource_id: 'user',
+    storage_session_id: 'user-storage',
+    kind: 'user',
+  },
+  {
+    id: 'discounts',
+    name: 'discounts.csv',
+    resource_id: 'worker',
+    storage_session_id: 'agent-storage',
+    kind: 'agent',
+  },
+];
+
+const firstResults = [
+  {
+    label: 'HTTP-success execution with stderr and no output files',
+    result: {
+      status: 'success',
+      artifact: { session_id: 'first-exec', files: [] },
+    },
+  },
+  {
+    label: 'execution without an artifact files field',
+    result: { status: 'success', artifact: { session_id: 'first-exec' } },
+  },
+  {
+    label: 'execution without an artifact',
+    result: { status: 'success' },
+  },
+  {
+    label: 'tool error without an artifact',
+    result: { status: 'error', errorMessage: 'Code API unavailable' },
+  },
+  {
+    label: 'tool error carrying unusable output files',
+    result: {
+      status: 'error',
+      errorMessage: 'Code execution failed',
+      artifact: {
+        session_id: 'failed-exec',
+        files: [{ id: 'failed-output', name: 'failed.csv' }],
+      },
+    },
+  },
+] satisfies Array<{
+  label: string;
+  result: Pick<t.ToolExecuteResult, 'status' | 'artifact' | 'errorMessage'>;
+}>;
+
+describe.each([Constants.EXECUTE_CODE, Constants.BASH_TOOL])(
+  '%s lazy input retention',
+  (toolName) => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it.each(firstResults)(
+      'preserves inputs after $label',
+      async ({ result }) => {
+        const sessions: t.ToolSessionMap = new Map([
+          [
+            'other-agent',
+            {
+              session_id: 'foreign-exec',
+              files: [{ id: 'foreign', name: 'foreign.txt' }],
+              lastUpdated: 1,
+            },
+          ],
+        ]);
+        const requests: t.ToolCallRequest[] = [];
+        jest
+          .spyOn(events, 'safeDispatchCustomEvent')
+          .mockImplementation(async (event, data) => {
+            if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+            const batch = data as t.ToolExecuteBatchRequest;
+            const request = batch.toolCalls[0];
+            requests.push(structuredClone(request));
+            if (requests.length === 1) {
+              request.codeSessionContext = {
+                session_id: 'input-context',
+                files: structuredClone(inputs),
+              };
+            }
+            batch.resolve([
+              {
+                toolCallId: request.id,
+                content: 'stderr: missing optional Python package',
+                ...(requests.length === 1
+                  ? result
+                  : { status: 'success' as const }),
+              },
+            ]);
+          });
+        const node = new ToolNode({
+          tools: [
+            tool(async () => 'unused', {
+              name: toolName,
+              description: 'Code tool',
+              schema: z.object({}),
+            }),
+          ],
+          sessions,
+          codeSessionKey: 'child-agent',
+          eventDrivenMode: true,
+        });
+        for (const id of ['first', 'retry']) {
+          await node.invoke({
+            messages: [
+              new AIMessage({
+                content: '',
+                tool_calls: [{ id, name: toolName, args: {} }],
+              }),
+            ],
+          });
+        }
+
+        expect(requests[0].codeSessionContext).toBeUndefined();
+        expect(requests[1].codeSessionContext?.files).toEqual(inputs);
+        expect(sessions.get('child-agent')?.files).toEqual(inputs);
+        expect(sessions.get('other-agent')).toEqual({
+          session_id: 'foreign-exec',
+          files: [{ id: 'foreign', name: 'foreign.txt' }],
+          lastUpdated: 1,
+        });
+        if (result.status === 'error') {
+          expect(sessions.get('child-agent')?.session_id).toBe('input-context');
+        }
+      }
+    );
+
+    it('keeps successful replacements when a later batch result carries older input refs', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const updated: t.FileRef = {
+        id: 'updated-discounts',
+        name: 'discounts.csv',
+        storage_session_id: 'output-storage',
+      };
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          for (const request of batch.toolCalls) {
+            request.codeSessionContext = {
+              session_id: 'input-context',
+              files: structuredClone(inputs),
+            };
+          }
+          batch.resolve(
+            batch.toolCalls.map((request, index) => ({
+              toolCallId: request.id,
+              status: 'success',
+              content: '',
+              artifact: {
+                session_id: `exec-${index}`,
+                files: index === 0 ? [updated] : [],
+              },
+            }))
+          );
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+      });
+
+      await node.invoke({
+        messages: [
+          new AIMessage({
+            content: '',
+            tool_calls: ['write', 'read'].map((id) => ({
+              id,
+              name: toolName,
+              args: {},
+            })),
+          }),
+        ],
+      });
+
+      expect(sessions.get('child-agent')?.files).toEqual([inputs[0], updated]);
+      expect(sessions.get('child-agent')?.session_id).toBe('exec-1');
+    });
+
+    it('retains files provisioned into the actual eager request before its result settles', async () => {
+      const sessions: t.ToolSessionMap = new Map();
+      const request: t.ToolCallRequest = {
+        id: 'first',
+        name: toolName,
+        args: {},
+      };
+      const eagerExecutions = new Map<string, t.EagerEventToolExecution>([
+        [
+          request.id,
+          {
+            toolCallId: request.id,
+            toolName,
+            args: {},
+            request,
+            promise: Promise.resolve().then(() => {
+              request.codeSessionContext = {
+                session_id: 'input-context',
+                files: structuredClone(inputs),
+              };
+              return {
+                results: [
+                  {
+                    toolCallId: request.id,
+                    status: 'success',
+                    content: '',
+                    artifact: { session_id: 'first-exec', files: [] },
+                  },
+                ],
+              };
+            }),
+          },
+        ],
+      ]);
+      const captured: t.ToolCallRequest[] = [];
+      jest
+        .spyOn(events, 'safeDispatchCustomEvent')
+        .mockImplementation(async (event, data) => {
+          if (event !== GraphEvents.ON_TOOL_EXECUTE) return;
+          const batch = data as t.ToolExecuteBatchRequest;
+          captured.push(...batch.toolCalls);
+          batch.resolve(
+            batch.toolCalls.map((tc) => ({
+              toolCallId: tc.id,
+              status: 'success',
+              content: '',
+            }))
+          );
+        });
+      const node = new ToolNode({
+        tools: [
+          tool(async () => 'unused', {
+            name: toolName,
+            description: 'Code tool',
+            schema: z.object({}),
+          }),
+        ],
+        sessions,
+        codeSessionKey: 'child-agent',
+        eventDrivenMode: true,
+        eagerEventToolExecution: { enabled: true },
+        eagerEventToolExecutions: eagerExecutions,
+      });
+      for (const id of ['first', 'retry']) {
+        await node.invoke({
+          messages: [
+            new AIMessage({
+              content: '',
+              tool_calls: [{ id, name: toolName, args: {} }],
+            }),
+          ],
+        });
+      }
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].id).toBe('retry');
+      expect(captured[0].codeSessionContext?.files).toEqual(inputs);
+    });
+  }
+);

--- a/src/tools/__tests__/subagentContext.test.ts
+++ b/src/tools/__tests__/subagentContext.test.ts
@@ -1,0 +1,477 @@
+import { z } from 'zod';
+import { tool } from '@langchain/core/tools';
+import { HumanMessage } from '@langchain/core/messages';
+import type { RunnableConfig } from '@langchain/core/runnables';
+import type { ToolCall } from '@langchain/core/messages/tool';
+import type { BaseMessage } from '@langchain/core/messages';
+import type {
+  AgentInputs,
+  GraphSubagentConfig,
+  LCTool,
+  PreparedSubagentContext,
+  ResolvedSubagentConfig,
+  StandardGraphInput,
+  SubagentContextAdapter,
+  SubagentContextInput,
+  SubagentExecutionContext,
+  ToolExecuteBatchRequest,
+} from '@/types';
+import {
+  Constants,
+  GraphEvents,
+  Providers,
+  SUBAGENT_CONTEXT_VERSION,
+} from '@/common';
+import { SubagentExecutor } from '../subagent/SubagentExecutor';
+import { StandardGraph } from '@/graphs/Graph';
+import { HandlerRegistry } from '@/events';
+import { FakeChatModel } from '@/llm/fake';
+import { HookRegistry } from '@/hooks';
+import { createGraph } from '@/graphs';
+
+const toolDefinition: LCTool = {
+  name: 'inspect_file',
+  description: 'Inspect a shared file.',
+  parameters: { type: 'object', properties: {} },
+};
+
+function agent(agentId = 'worker'): AgentInputs {
+  return {
+    agentId,
+    provider: Providers.OPENAI,
+    clientOptions: { modelName: 'gpt-4o-mini', apiKey: 'unused' },
+    maxContextTokens: 8000,
+    toolDefinitions: [toolDefinition],
+  };
+}
+
+function config(inputs = agent()): ResolvedSubagentConfig {
+  return {
+    type: 'worker',
+    name: 'Worker',
+    description: 'Analyze files',
+    agentInputs: inputs,
+  };
+}
+
+function executionId(
+  context: SubagentExecutionContext | undefined
+): string | undefined {
+  return context?.ancestry.at(-1)?.subagentRunId;
+}
+
+function createHarness({
+  adapter,
+  childConfig = config(),
+  toolCalls,
+}: {
+  adapter: SubagentContextAdapter;
+  childConfig?: ResolvedSubagentConfig | GraphSubagentConfig;
+  toolCalls?: (input: StandardGraphInput) => ToolCall[];
+}) {
+  const batches: ToolExecuteBatchRequest[] = [];
+  const hookContexts: SubagentExecutionContext[] = [];
+  const graphs: StandardGraph[] = [];
+  const graphInputs: StandardGraphInput[] = [];
+  const registry = new HandlerRegistry();
+  const hooks = new HookRegistry();
+  hooks.register('PreToolUse', {
+    hooks: [
+      async (input) => {
+        if (input.executionContext != null)
+          hookContexts.push(input.executionContext);
+        return {};
+      },
+    ],
+  });
+  registry.register(GraphEvents.ON_TOOL_EXECUTE, {
+    handle: (_event, rawData) => {
+      const batch = rawData as ToolExecuteBatchRequest;
+      batches.push(batch);
+      batch.resolve(
+        batch.toolCalls.map((call) => ({
+          toolCallId: call.id,
+          status: 'success',
+          content: 'File inspected',
+        }))
+      );
+    },
+  });
+  const configureGraph = (
+    graph: StandardGraph,
+    input: StandardGraphInput
+  ): StandardGraph => {
+    graph.hookRegistry = hooks;
+    graph.handlerRegistry = registry;
+    graph.eventToolExecutionAvailable = true;
+    graph.overrideTestModel(
+      ['Inspecting file', 'Analysis complete'],
+      0,
+      toolCalls?.(input) ?? [
+        {
+          name: 'inspect_file',
+          args: {},
+          id: 'inspect-call',
+          type: 'tool_call',
+        },
+      ]
+    );
+    graph.setSubagentModelOverride(
+      new FakeChatModel({
+        responses: ['Inspecting nested file', 'Nested analysis complete'],
+        toolCalls: [
+          {
+            name: 'inspect_file',
+            args: {},
+            id: 'nested-inspect-call',
+            type: 'tool_call',
+          },
+        ],
+      })
+    );
+    graphInputs.push(input);
+    graphs.push(graph);
+    return graph;
+  };
+  const executor = new SubagentExecutor({
+    configs: new Map([[childConfig.type, childConfig]]),
+    parentRunId: 'root-run',
+    parentAgentId: 'parent',
+    parentHandlerRegistry: registry,
+    hookRegistry: hooks,
+    maxDepth: 3,
+    subagentContext: adapter,
+    createChildGraph: (input) =>
+      configureGraph(new StandardGraph(input), input),
+    createChildGraphByKind: (request) =>
+      configureGraph(createGraph(request), request.input),
+  });
+  const execute = (parentToolCallId = 'spawn-call', signal?: AbortSignal) =>
+    executor.execute({
+      description: 'Analyze the attached PDF',
+      subagentType: childConfig.type,
+      parentToolCallId,
+      threadId: 'conversation',
+      signal,
+      parentConfigurable: { run_id: 'root-run', thread_id: 'conversation' },
+    });
+  return { batches, hookContexts, graphs, graphInputs, executor, execute };
+}
+
+describe('host-owned subagent context', () => {
+  it('prepares actual file content and carries trusted lineage through tools and hooks', async () => {
+    const prepared: SubagentContextInput[] = [];
+    let transcript: BaseMessage[] = [];
+    const adapter: SubagentContextAdapter = {
+      prepare: async (input) => {
+        prepared.push(input);
+        return {
+          messages: [
+            new HumanMessage({
+              id: 'shared-file',
+              content: [
+                { type: 'text', text: 'Shared PDF: Quarterly results' },
+                {
+                  type: 'image_url',
+                  image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+                },
+              ],
+            }),
+          ],
+          configurable: {
+            sharedFileGrant: executionId(input.executionContext),
+            run_id: 'spoofed',
+          },
+        };
+      },
+      complete: async (_input, result) => {
+        transcript = result.messages;
+        return { content: `${result.content}\nPublished file: durable-csv-id` };
+      },
+    };
+    const harness = createHarness({ adapter });
+    const result = await harness.execute();
+    expect(SUBAGENT_CONTEXT_VERSION).toBe(1);
+    expect(result.error).toBeUndefined();
+    expect(result.content).toContain('Published file: durable-csv-id');
+    expect(
+      transcript.find((message) => message.id === 'shared-file')?.content
+    ).toEqual([
+      { type: 'text', text: 'Shared PDF: Quarterly results' },
+      {
+        type: 'image_url',
+        image_url: { url: 'data:image/png;base64,aGVsbG8=' },
+      },
+    ]);
+    expect(prepared[0]).toMatchObject({
+      parentThreadId: 'conversation',
+      memberAgentIds: ['worker'],
+      resumed: false,
+      executionContext: { rootRunId: 'root-run', depth: 1 },
+    });
+    expect(harness.batches).toHaveLength(1);
+    expect(harness.batches[0].executionContext).toEqual(
+      prepared[0].executionContext
+    );
+    expect(harness.batches[0].metadata?.executionContext).toEqual(
+      prepared[0].executionContext
+    );
+    expect(harness.batches[0].configurable?.executionContext).toEqual(
+      prepared[0].executionContext
+    );
+    expect(harness.batches[0].configurable?.run_id).toBe('root-run');
+    expect(harness.batches[0].configurable?.sharedFileGrant).toBe(
+      executionId(prepared[0].executionContext)
+    );
+    expect(harness.hookContexts).toContainEqual(prepared[0].executionContext);
+  });
+
+  it('isolates simultaneous copies of the same agent and reauthorizes a completed retry', async () => {
+    const prepared: SubagentContextInput[] = [];
+    const adapter: SubagentContextAdapter = {
+      prepare: async (input) => {
+        prepared.push(input);
+        return {
+          configurable: {
+            sharedFileGrant: executionId(input.executionContext),
+          },
+        };
+      },
+    };
+    const harness = createHarness({ adapter });
+    await Promise.all([harness.execute('first'), harness.execute('second')]);
+    expect(
+      new Set(
+        harness.batches.map((batch) => executionId(batch.executionContext))
+      ).size
+    ).toBe(2);
+    expect(harness.batches.map((batch) => batch.agentId)).toEqual([
+      'worker',
+      'worker',
+    ]);
+    for (const batch of harness.batches) {
+      expect(batch.configurable?.sharedFileGrant).toBe(
+        executionId(batch.executionContext)
+      );
+    }
+    await harness.execute('first');
+    expect(prepared).toHaveLength(3);
+    expect(prepared[2].resumed).toBe(true);
+    expect(executionId(prepared[2].executionContext)).toBe(
+      executionId(prepared[0].executionContext)
+    );
+    expect(harness.batches).toHaveLength(2);
+  });
+
+  it('replaces inherited sandbox sessions with private execution partitions', async () => {
+    const inherited = {
+      session_id: 'parent-session',
+      lastUpdated: Date.now(),
+      files: [{ id: 'private-parent-file', name: 'private.txt' }],
+    };
+    const inputs: AgentInputs = {
+      ...agent(),
+      codeSessionKey: 'parent-partition',
+      initialSessions: new Map([[Constants.EXECUTE_CODE, inherited]]),
+      toolDefinitions: [{ ...toolDefinition, name: Constants.EXECUTE_CODE }],
+    };
+    const harness = createHarness({
+      childConfig: config(inputs),
+      adapter: {
+        prepare: async (input) => ({
+          agentSessions: {
+            worker: { codeSessionKey: executionId(input.executionContext) },
+          },
+        }),
+      },
+      toolCalls: () => [
+        {
+          name: Constants.EXECUTE_CODE,
+          args: { code: 'print("hello")', lang: 'python' },
+          id: 'code-call',
+          type: 'tool_call',
+        },
+      ],
+    });
+    const results = await Promise.all([
+      harness.execute('first'),
+      harness.execute('second'),
+    ]);
+    expect(results.every((result) => result.error == null)).toBe(true);
+    expect(harness.batches).toHaveLength(2);
+    for (const batch of harness.batches) {
+      expect(batch.toolCalls[0].codeSessionContext).toBeUndefined();
+    }
+    for (const graphInput of harness.graphInputs) {
+      expect(graphInput.agents[0].codeSessionKey).toBe(
+        executionId(graphInput.subagentExecutionContext)
+      );
+      expect(graphInput.agents[0].initialSessions).toBeUndefined();
+    }
+    expect(harness.graphInputs[0].agents[0].codeSessionKey).not.toBe(
+      harness.graphInputs[1].agents[0].codeSessionKey
+    );
+    expect(inputs.codeSessionKey).toBe('parent-partition');
+    expect(inputs.initialSessions?.get(Constants.EXECUTE_CODE)).toBe(inherited);
+  });
+
+  it('rejects sandbox overrides for agents outside the child graph', async () => {
+    const harness = createHarness({
+      adapter: { prepare: async () => ({ agentSessions: { outsider: {} } }) },
+    });
+    expect((await harness.execute()).error).toContain('access was denied');
+    expect(harness.graphs).toHaveLength(0);
+  });
+
+  it('blocks execution when preparation denies or is aborted', async () => {
+    const controller = new AbortController();
+    const adapter: SubagentContextAdapter = {
+      prepare: async () => {
+        throw new Error('Cross-run access denied');
+      },
+    };
+    const harness = createHarness({ adapter });
+    const denied = await harness.execute('denied');
+    expect(denied.error).toContain('access was denied');
+    expect(denied.content).not.toContain('Cross-run');
+    expect(harness.graphs).toHaveLength(0);
+    adapter.prepare = async (): Promise<PreparedSubagentContext> => {
+      controller.abort();
+      return { messages: [new HumanMessage('Must never reach a model')] };
+    };
+    const aborted = await harness.execute('aborted', controller.signal);
+    expect(aborted.error).toBeDefined();
+    expect(harness.graphs).toHaveLength(0);
+  });
+
+  it('retains completed work when result delivery needs retry', async () => {
+    let attempts = 0;
+    const adapter: SubagentContextAdapter = {
+      prepare: async () => ({}),
+      complete: async (_input, result) => {
+        attempts++;
+        if (attempts === 1) throw new Error('Transient publication failure');
+        return { content: `${result.content}\nPublished file: durable-id` };
+      },
+    };
+    const harness = createHarness({ adapter });
+    expect((await harness.execute()).error).toContain('delivery failed');
+    expect((await harness.execute()).content).toContain('durable-id');
+    expect(harness.batches).toHaveLength(1);
+    expect(harness.graphs).toHaveLength(1);
+  });
+
+  it('stamps self-spawn direct tools with the child execution identity', async () => {
+    const configurations: RunnableConfig[] = [];
+    const direct = tool(
+      async (_input, runnableConfig) => {
+        configurations.push(runnableConfig);
+        return 'Read-only shared input';
+      },
+      {
+        name: 'inspect_file',
+        description: 'Inspect a file',
+        schema: z.object({}),
+      }
+    );
+    const self = config({
+      ...agent('parent'),
+      tools: [direct],
+      toolDefinitions: undefined,
+    });
+    self.self = true;
+    const harness = createHarness({
+      adapter: { prepare: async () => ({}) },
+      childConfig: self,
+    });
+    await harness.execute();
+    expect(configurations).toHaveLength(1);
+    const identity = configurations[0].metadata
+      ?.executionContext as SubagentExecutionContext;
+    expect(identity.ancestry[0]).toMatchObject({
+      parentAgentId: 'parent',
+      parentToolCallId: 'spawn-call',
+      subagentAgentId: 'parent',
+    });
+    expect(configurations[0].configurable?.executionContext).toEqual(identity);
+    expect(harness.hookContexts).toContainEqual(identity);
+  });
+
+  it('prepares graph members together with one graph execution identity', async () => {
+    const prepared: SubagentContextInput[] = [];
+    const harness = createHarness({
+      adapter: {
+        prepare: async (input) => {
+          prepared.push(input);
+          return {};
+        },
+      },
+      childConfig: {
+        kind: 'graph',
+        type: 'team',
+        name: 'Team',
+        description: 'Analyze together',
+        agents: [agent('reader'), agent('writer')],
+        edges: [{ from: 'reader', to: 'writer', edgeType: 'direct' }],
+        entryAgentId: 'reader',
+        resultAgentId: 'writer',
+      },
+    });
+    const result = await harness.execute();
+    expect(result.error).toBeUndefined();
+    expect(prepared[0].memberAgentIds).toEqual(['reader', 'writer']);
+    expect(prepared[0].executionContext.ancestry[0].subagentKind).toBe('graph');
+    expect(harness.batches.length).toBeGreaterThan(0);
+    for (const batch of harness.batches)
+      expect(batch.executionContext).toEqual(prepared[0].executionContext);
+  });
+
+  it('preserves the complete ancestry through nested delegation', async () => {
+    const prepared: SubagentContextInput[] = [];
+    const child = config({
+      ...agent(),
+      subagentConfigs: [config(agent('grandchild'))],
+    });
+    child.allowNested = true;
+    const harness = createHarness({
+      adapter: {
+        prepare: async (input) => {
+          prepared.push(input);
+          return {
+            configurable: {
+              sharedFileGrant: executionId(input.executionContext),
+            },
+          };
+        },
+      },
+      childConfig: child,
+      toolCalls: () => [
+        {
+          name: Constants.SUBAGENT,
+          args: { subagent_type: 'worker', description: 'Inspect the file' },
+          id: 'nested-spawn',
+          type: 'tool_call',
+        },
+      ],
+    });
+    const result = await harness.execute();
+    expect(result.error).toBeUndefined();
+    expect(prepared).toHaveLength(2);
+    expect(prepared[1].executionContext.depth).toBe(2);
+    expect(prepared[1].executionContext.ancestry[0]).toEqual(
+      prepared[0].executionContext.ancestry[0]
+    );
+    expect(prepared[1].executionContext.ancestry[1]).toMatchObject({
+      parentRunId: executionId(prepared[0].executionContext),
+      parentToolCallId: 'nested-spawn',
+      subagentAgentId: 'grandchild',
+    });
+    expect(harness.batches).toHaveLength(1);
+    expect(harness.batches[0].executionContext).toEqual(
+      prepared[1].executionContext
+    );
+    expect(harness.batches[0].configurable?.sharedFileGrant).toBe(
+      executionId(prepared[1].executionContext)
+    );
+  });
+});

--- a/src/tools/__tests__/subagentContext.test.ts
+++ b/src/tools/__tests__/subagentContext.test.ts
@@ -350,8 +350,9 @@ describe('host-owned subagent context', () => {
       controller.abort();
       return { messages: [new HumanMessage('Must never reach a model')] };
     };
-    const aborted = await harness.execute('aborted', controller.signal);
-    expect(aborted.error).toBeDefined();
+    await expect(
+      harness.execute('aborted', controller.signal)
+    ).rejects.toThrow();
     expect(harness.graphs).toHaveLength(0);
   });
 
@@ -367,9 +368,7 @@ describe('host-owned subagent context', () => {
     }
     controller.abort(new Error('cancelled'));
 
-    await expect(result).resolves.toMatchObject({
-      error: expect.stringContaining('access was denied'),
-    });
+    await expect(result).rejects.toThrow('cancelled');
     expect(harness.graphs).toHaveLength(0);
   });
 

--- a/src/tools/__tests__/subagentContext.test.ts
+++ b/src/tools/__tests__/subagentContext.test.ts
@@ -373,9 +373,16 @@ describe('host-owned subagent context', () => {
   });
 
   it('retains completed work when result delivery needs retry', async () => {
+    let preparations = 0;
     let attempts = 0;
     const adapter: SubagentContextAdapter = {
-      prepare: async () => ({}),
+      prepare: async () => {
+        preparations++;
+        if (preparations === 2) {
+          throw new Error('Transient reauthorization failure');
+        }
+        return {};
+      },
       complete: async (_input, result) => {
         attempts++;
         if (attempts === 1) throw new Error('Transient publication failure');
@@ -384,7 +391,10 @@ describe('host-owned subagent context', () => {
     };
     const harness = createHarness({ adapter });
     expect((await harness.execute()).error).toContain('delivery failed');
+    expect((await harness.execute()).error).toContain('access was denied');
     expect((await harness.execute()).content).toContain('durable-id');
+    expect(preparations).toBe(3);
+    expect(attempts).toBe(2);
     expect(harness.batches).toHaveLength(1);
     expect(harness.graphs).toHaveLength(1);
   });

--- a/src/tools/__tests__/subagentContext.test.ts
+++ b/src/tools/__tests__/subagentContext.test.ts
@@ -355,6 +355,24 @@ describe('host-owned subagent context', () => {
     expect(harness.graphs).toHaveLength(0);
   });
 
+  it('unwinds when preparation ignores cancellation', async () => {
+    const controller = new AbortController();
+    const prepare = jest.fn(() => new Promise<PreparedSubagentContext>(() => undefined));
+    const harness = createHarness({
+      adapter: { prepare },
+    });
+    const result = harness.execute('cancelled', controller.signal);
+    while (prepare.mock.calls.length === 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
+    controller.abort(new Error('cancelled'));
+
+    await expect(result).resolves.toMatchObject({
+      error: expect.stringContaining('access was denied'),
+    });
+    expect(harness.graphs).toHaveLength(0);
+  });
+
   it('retains completed work when result delivery needs retry', async () => {
     let attempts = 0;
     const adapter: SubagentContextAdapter = {

--- a/src/tools/__tests__/subagentContext.test.ts
+++ b/src/tools/__tests__/subagentContext.test.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { tool } from '@langchain/core/tools';
-import { HumanMessage } from '@langchain/core/messages';
+import { MemorySaver } from '@langchain/langgraph';
+import { HumanMessage, ToolMessage } from '@langchain/core/messages';
 import type { RunnableConfig } from '@langchain/core/runnables';
 import type { ToolCall } from '@langchain/core/messages/tool';
 import type { BaseMessage } from '@langchain/core/messages';
@@ -64,15 +65,18 @@ function createHarness({
   adapter,
   childConfig = config(),
   toolCalls,
+  durable = false,
 }: {
   adapter: SubagentContextAdapter;
   childConfig?: ResolvedSubagentConfig | GraphSubagentConfig;
   toolCalls?: (input: StandardGraphInput) => ToolCall[];
+  durable?: boolean;
 }) {
   const batches: ToolExecuteBatchRequest[] = [];
   const hookContexts: SubagentExecutionContext[] = [];
   const graphs: StandardGraph[] = [];
   const graphInputs: StandardGraphInput[] = [];
+  const checkpointer = durable ? new MemorySaver() : undefined;
   const registry = new HandlerRegistry();
   const hooks = new HookRegistry();
   hooks.register('PreToolUse', {
@@ -101,6 +105,9 @@ function createHarness({
     graph: StandardGraph,
     input: StandardGraphInput
   ): StandardGraph => {
+    if (checkpointer != null) {
+      graph.compileOptions = { checkpointer };
+    }
     graph.hookRegistry = hooks;
     graph.handlerRegistry = registry;
     graph.eventToolExecutionAvailable = true;
@@ -141,6 +148,10 @@ function createHarness({
     hookRegistry: hooks,
     maxDepth: 3,
     subagentContext: adapter,
+    ...(checkpointer != null && {
+      checkpointer,
+      humanInTheLoop: { enabled: true },
+    }),
     createChildGraph: (input) =>
       configureGraph(new StandardGraph(input), input),
     createChildGraphByKind: (request) =>
@@ -358,6 +369,55 @@ describe('host-owned subagent context', () => {
     expect((await harness.execute()).error).toContain('delivery failed');
     expect((await harness.execute()).content).toContain('durable-id');
     expect(harness.batches).toHaveLength(1);
+    expect(harness.graphs).toHaveLength(1);
+  });
+
+  it('does not settle a retryable delivery failure', async () => {
+    let attempts = 0;
+    const harness = createHarness({
+      durable: true,
+      adapter: {
+        prepare: async () => ({}),
+        complete: async (_input, result) => {
+          attempts++;
+          if (attempts === 1) throw new Error('Transient publication failure');
+          return { content: `${result.content}\nPublished after retry` };
+        },
+      },
+    });
+    const call = {
+      id: 'spawn-call',
+      name: Constants.SUBAGENT,
+      args: {
+        description: 'Analyze the attached PDF',
+        subagent_type: 'worker',
+      },
+      type: 'tool_call' as const,
+    };
+    const runnableConfig = {
+      configurable: { run_id: 'root-run', thread_id: 'conversation' },
+    };
+
+    const failed = await harness.execute();
+    expect(failed.error).toContain('delivery failed');
+    await harness.executor.persistSettledToolOutput(call, runnableConfig, {
+      output: new ToolMessage({
+        status: 'error',
+        content: failed.content,
+        name: call.name,
+        tool_call_id: call.id,
+      }),
+      additionalContexts: [],
+      resolvedArgs: call.args,
+    });
+    await expect(
+      harness.executor.getSettledToolOutput(call, runnableConfig)
+    ).resolves.toBeUndefined();
+
+    await expect(harness.execute()).resolves.toMatchObject({
+      content: expect.stringContaining('Published after retry'),
+    });
+    expect(attempts).toBe(2);
     expect(harness.graphs).toHaveLength(1);
   });
 

--- a/src/tools/__tests__/subagentHooks.test.ts
+++ b/src/tools/__tests__/subagentHooks.test.ts
@@ -1140,6 +1140,8 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
       }
     );
     const resolutionContexts: t.SubagentResolveContext[] = [];
+    const preparedContexts: t.SubagentContextInput[] = [];
+    let completedMessages: t.SubagentContextResult['messages'] = [];
     const createLazyParent = (): t.AgentInputs => {
       const parent = createParentAgentWithPrimitiveInterruptTool(
         primitiveInterruptTool
@@ -1179,6 +1181,23 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
           [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
         },
         humanInTheLoop: { enabled: true },
+        subagentContext: {
+          prepare: async (input) => {
+            preparedContexts.push(input);
+            return {
+              messages: [
+                new HumanMessage({
+                  id: 'shared-file-context',
+                  content: 'Shared file input',
+                }),
+              ],
+            };
+          },
+          complete: async (_input, result) => {
+            completedMessages = result.messages;
+            return { content: result.content };
+          },
+        },
       });
     const runId = `primitive-subagent-rebuild-${Date.now()}`;
     const parentCall = makeSubagentToolCall('call_primitive_rebuild');
@@ -1219,6 +1238,16 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
 
     expect(rebuiltRun.getInterrupt()).toBeUndefined();
     expect(resolutionContexts).toHaveLength(2);
+    expect(preparedContexts).toHaveLength(2);
+    expect(preparedContexts[1].resumed).toBe(true);
+    expect(
+      preparedContexts[0].executionContext.ancestry.at(-1)?.subagentRunId
+    ).toBe(preparedContexts[1].executionContext.ancestry.at(-1)?.subagentRunId);
+    expect(
+      completedMessages.filter(
+        (message) => message.id === 'shared-file-context'
+      )
+    ).toHaveLength(1);
     expect(resolutionContexts[0].executionId).toBe(
       resolutionContexts[1].executionId
     );
@@ -1451,112 +1480,122 @@ describe('Subagent hook integration (end-to-end via Run)', () => {
     ).toBe(true);
   });
 
-  it.each([true, false])('forks nested resumes from each checkpoint in the manifest chain (restore hooks=%s)', async (restoreHooks) => {
-    getChatModelClassSpy.mockImplementation(((provider: Providers) => {
-      if (provider === Providers.OPENAI) {
-        return NestedHitlFakeChatModel;
-      }
-      return originalGetChatModelClass(provider);
-    }) as typeof providers.getChatModelClass);
+  it.each([true, false])(
+    'forks nested resumes from each checkpoint in the manifest chain (restore hooks=%s)',
+    async (restoreHooks) => {
+      getChatModelClassSpy.mockImplementation(((provider: Providers) => {
+        if (provider === Providers.OPENAI) {
+          return NestedHitlFakeChatModel;
+        }
+        return originalGetChatModelClass(provider);
+      }) as typeof providers.getChatModelClass);
 
-    const checkpointer = new MemorySaver();
-    const registry = new HookRegistry();
-    const executedTools: string[] = [];
-    const baseRunId = `nested-subagent-rebuild-${Date.now()}`;
-    registry.registerSession(`${baseRunId}-initial`, 'PreToolUse', {
-      once: true,
-      pattern: '^calculator$',
-      hooks: [
-        async (): Promise<PreToolUseHookOutput> => ({
-          decision: 'ask',
-          reason: 'review nested calculator',
-        }),
-      ],
-    });
-    const customHandlers: Record<string, t.EventHandler> = {
-      [GraphEvents.TOOL_END]: new ToolEndHandler(),
-      [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
-      [GraphEvents.ON_TOOL_EXECUTE]: {
-        handle: (_event, rawData): void => {
-          const request = rawData as t.ToolExecuteBatchRequest;
-          executedTools.push(...request.toolCalls.map((call) => call.name));
-          request.resolve(
-            request.toolCalls.map((call) => ({
-              toolCallId: call.id,
-              status: 'success' as const,
-              content: '42',
-            }))
-          );
-        },
-      },
-    };
-    const createRun = (runId: string): Promise<Run<t.IState>> =>
-      Run.create<t.IState>({
-        runId,
-        graphConfig: {
-          type: 'standard',
-          agents: [createParentAgentWithNestedChildTool()],
-          compileOptions: { checkpointer },
-        },
-        returnContent: true,
-        skipCleanup: true,
-        customHandlers,
-        hooks: restoreHooks || runId.endsWith('-initial') ? registry : undefined,
-        humanInTheLoop: { enabled: true },
+      const checkpointer = new MemorySaver();
+      const registry = new HookRegistry();
+      const executedTools: string[] = [];
+      const baseRunId = `nested-subagent-rebuild-${Date.now()}`;
+      registry.registerSession(`${baseRunId}-initial`, 'PreToolUse', {
+        once: true,
+        pattern: '^calculator$',
+        hooks: [
+          async (): Promise<PreToolUseHookOutput> => ({
+            decision: 'ask',
+            reason: 'review nested calculator',
+          }),
+        ],
       });
-    const parentCall = makeSubagentToolCall(
-      'call_nested_researcher',
-      'Delegate a nested calculation'
-    );
-    const initialRun = await createRun(`${baseRunId}-initial`);
-    initialRun.Graph!.overrideTestModel(['Delegating...', 'Final answer.'], 5, [
-      parentCall,
-    ]);
+      const customHandlers: Record<string, t.EventHandler> = {
+        [GraphEvents.TOOL_END]: new ToolEndHandler(),
+        [GraphEvents.CHAT_MODEL_END]: new ModelEndHandler(),
+        [GraphEvents.ON_TOOL_EXECUTE]: {
+          handle: (_event, rawData): void => {
+            const request = rawData as t.ToolExecuteBatchRequest;
+            executedTools.push(...request.toolCalls.map((call) => call.name));
+            request.resolve(
+              request.toolCalls.map((call) => ({
+                toolCallId: call.id,
+                status: 'success' as const,
+                content: '42',
+              }))
+            );
+          },
+        },
+      };
+      const createRun = (runId: string): Promise<Run<t.IState>> =>
+        Run.create<t.IState>({
+          runId,
+          graphConfig: {
+            type: 'standard',
+            agents: [createParentAgentWithNestedChildTool()],
+            compileOptions: { checkpointer },
+          },
+          returnContent: true,
+          skipCleanup: true,
+          customHandlers,
+          hooks:
+            restoreHooks || runId.endsWith('-initial') ? registry : undefined,
+          humanInTheLoop: { enabled: true },
+        });
+      const parentCall = makeSubagentToolCall(
+        'call_nested_researcher',
+        'Delegate a nested calculation'
+      );
+      const initialRun = await createRun(`${baseRunId}-initial`);
+      initialRun.Graph!.overrideTestModel(
+        ['Delegating...', 'Final answer.'],
+        5,
+        [parentCall]
+      );
 
-    await initialRun.processStream(
-      { messages: [new HumanMessage('calculate through two agents')] },
-      callerConfig
-    );
-    const paused = initialRun.getInterrupt();
-    expect(paused?.payload).toMatchObject({
-      type: 'tool_approval',
-      subagent: {
-        agent_id: 'calculator-grandchild',
-        parent_tool_call_id: 'call_nested_calculator_worker',
-      },
-    });
-    const oldParentCheckpoint = {
-      ...callerConfig,
-      configurable: {
-        ...callerConfig.configurable,
-        checkpoint_id: paused?.checkpointId,
-        checkpoint_ns: paused?.checkpointNs ?? '',
-      },
-    };
-    const rebuiltRun = await createRun(`${baseRunId}-rebuilt`);
-    rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
-    const warningSpy = jest
-      .spyOn(console, 'warn')
-      .mockImplementation((): void => undefined);
-    try {
-      await initialRun.resume([{ type: 'approve' }], callerConfig);
-      await rebuiltRun.resume(
-        [{ type: 'reject', reason: 'reject stale nested branch' }],
-        oldParentCheckpoint
+      await initialRun.processStream(
+        { messages: [new HumanMessage('calculate through two agents')] },
+        callerConfig
       );
-      expect(warningSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining('toolCallStepIds missing entry')
+      const paused = initialRun.getInterrupt();
+      expect(paused?.payload).toMatchObject({
+        type: 'tool_approval',
+        subagent: {
+          agent_id: 'calculator-grandchild',
+          parent_tool_call_id: 'call_nested_calculator_worker',
+        },
+      });
+      const oldParentCheckpoint = {
+        ...callerConfig,
+        configurable: {
+          ...callerConfig.configurable,
+          checkpoint_id: paused?.checkpointId,
+          checkpoint_ns: paused?.checkpointNs ?? '',
+        },
+      };
+      const rebuiltRun = await createRun(`${baseRunId}-rebuilt`);
+      rebuiltRun.Graph!.overrideTestModel(['Final answer.'], 1);
+      const warningSpy = jest
+        .spyOn(console, 'warn')
+        .mockImplementation((): void => undefined);
+      try {
+        await initialRun.resume([{ type: 'approve' }], callerConfig);
+        await rebuiltRun.resume(
+          [{ type: 'reject', reason: 'reject stale nested branch' }],
+          oldParentCheckpoint
+        );
+        expect(warningSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining('toolCallStepIds missing entry')
+        );
+      } finally {
+        warningSpy.mockRestore();
+      }
+
+      expect(initialRun.getInterrupt()).toBeUndefined();
+      expect(rebuiltRun.getInterrupt()).toBeUndefined();
+      expect(executedTools).toEqual(['calculator']);
+      expect(initialRun.getChildCheckpointThreadIds().length).toBeGreaterThan(
+        2
       );
-    } finally {
-      warningSpy.mockRestore();
+      expect(rebuiltRun.getChildCheckpointThreadIds().length).toBeGreaterThan(
+        1
+      );
     }
-
-    expect(initialRun.getInterrupt()).toBeUndefined();
-    expect(rebuiltRun.getInterrupt()).toBeUndefined();
-    expect(executedTools).toEqual(['calculator']);
-    expect(initialRun.getChildCheckpointThreadIds().length).toBeGreaterThan(2);
-    expect(rebuiltRun.getChildCheckpointThreadIds().length).toBeGreaterThan(1);
-  });
+  );
 
   it('restores child tool-output references into rebuilt branches', async () => {
     getChatModelClassSpy.mockImplementation(((provider: Providers) => {

--- a/src/tools/local/LocalProgrammaticToolCalling.ts
+++ b/src/tools/local/LocalProgrammaticToolCalling.ts
@@ -214,6 +214,7 @@ export async function applyPreToolUseHooksForBridge(
       runId: hookContext.runId,
       threadId: hookContext.threadId,
       agentId: hookContext.agentId,
+      executionContext: hookContext.executionContext,
       executingAgentId: hookContext.executingAgentId,
       toolName,
       toolInput,

--- a/src/tools/subagent/SubagentExecutionRegistry.ts
+++ b/src/tools/subagent/SubagentExecutionRegistry.ts
@@ -783,7 +783,6 @@ export class SubagentExecutionRecord<
     this.transitionTo('completed', ['active']);
     this.completedValue = true;
     this.completedResultValue = result;
-    this.resolvedConfigValue = undefined;
   }
 
   releaseActiveRun(): TActiveRun | undefined {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2517,7 +2517,13 @@ export class SubagentExecutor {
     };
     let preparedContext: PreparedSubagentContext | undefined;
     try {
-      preparedContext = await this.subagentContext?.prepare(hostContextInput);
+      preparedContext =
+        this.subagentContext?.prepare == null
+          ? undefined
+          : await awaitWithAbort(
+            Promise.resolve(this.subagentContext.prepare(hostContextInput)),
+            childSignal
+          );
       execution.assertUsable(childSignal);
       for (const [agentId, sessions] of Object.entries(
         preparedContext?.agentSessions ?? {}

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2552,6 +2552,14 @@ export class SubagentExecutor {
           ? childSignal.reason
           : error;
       }
+      if (execution.completedResult != null) {
+        return {
+          ...createSubagentFailure(
+            'Subagent context is unavailable or access was denied.'
+          ),
+          retryableDelivery: true,
+        };
+      }
       return createSubagentFailure(
         'Subagent context is unavailable or access was denied.'
       );

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -1296,15 +1296,18 @@ export class SubagentExecutor {
         }
         return result;
       };
-      let deliveryRetries = 0;
+      let deliveryAttempts = 1;
       let result = await executeAttempt();
-      while (result.retryableDelivery === true) {
-        if (deliveryRetries > 0) {
+      while (
+        result.retryableDelivery === true &&
+        deliveryAttempts < 3
+      ) {
+        if (deliveryAttempts > 1) {
           await sleep(
-            Math.min(100 * 2 ** Math.min(deliveryRetries - 1, 6), 5_000)
+            Math.min(100 * 2 ** Math.min(deliveryAttempts - 2, 6), 5_000)
           );
         }
-        deliveryRetries += 1;
+        deliveryAttempts += 1;
         result = await executeAttempt();
       }
       if (result.error != null) {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -52,6 +52,10 @@ import type {
   ResolvedSubagentConfig,
   ResolvedSubagentConfigEntry,
   SubagentExecutionContext,
+  SubagentContextAdapter,
+  SubagentContextInput,
+  SubagentContextResult,
+  PreparedSubagentContext,
   SubagentTaskConfig,
   SubagentTaskRuntime,
   SubagentResolveConfigurable,
@@ -88,11 +92,6 @@ import type {
   ToolApprovalReplaySnapshot,
 } from '@/hooks';
 import type { GraphFactory } from '@/graphs/graphFactory';
-import {
-  rebindToolBatchReplayScope,
-  rebindToolBatchReplayPayload,
-  restoreToolReplayConfig,
-} from '@/tools/toolBatchReplay';
 import type { StandardGraph } from '@/graphs/Graph';
 import {
   getSubagentApprovalExecutionScope,
@@ -108,6 +107,11 @@ import {
   SUBAGENT_RESUME_ATTEMPT_CONFIG_KEY,
   SUBAGENT_RESUME_MANIFEST_CONFIG_KEY,
 } from './SubagentReplay';
+import {
+  rebindToolBatchReplayScope,
+  rebindToolBatchReplayPayload,
+  restoreToolReplayConfig,
+} from '@/tools/toolBatchReplay';
 import {
   executeHooks,
   HookRegistry,
@@ -831,9 +835,7 @@ export type SubagentExecuteParams = {
   initialMessages?: BaseMessage[];
 };
 
-export type SubagentExecuteResult = {
-  content: string;
-  messages: BaseMessage[];
+export type SubagentExecuteResult = SubagentContextResult & {
   /** Tagged internal failure; foreground callers retain the legacy content. */
   error?: string;
 };
@@ -931,6 +933,7 @@ export type SubagentExecutorOptions = {
   usageSink?: SubagentUsageSink;
   /** Host-owned process-local task namespace for detached execution. */
   taskConfig?: SubagentTaskConfig;
+  subagentContext?: SubagentContextAdapter;
 };
 
 type DurableExecutionRecord = SubagentExecutionRecord<
@@ -968,6 +971,7 @@ export class SubagentExecutor {
   ) => GraphFactory;
   private readonly usageSink?: SubagentUsageSink;
   private readonly taskConfig?: SubagentTaskConfig;
+  private readonly subagentContext?: SubagentContextAdapter;
   private readonly executions: SubagentExecutionRegistry<
     SubagentExecuteResult,
     ResolvedSubagentConfig,
@@ -1012,6 +1016,7 @@ export class SubagentExecutor {
       options.createDetachedChildGraphFactory;
     this.usageSink = options.usageSink;
     this.taskConfig = options.taskConfig;
+    this.subagentContext = options.subagentContext;
     const rawRegistry = options.parentHandlerRegistry;
     if (typeof rawRegistry === 'function') {
       this.resolveParentHandlerRegistry = rawRegistry;
@@ -1257,6 +1262,7 @@ export class SubagentExecutor {
       langfuse: this.langfuse,
       tokenCounter: this.tokenCounter,
       usageSink: this.usageSink,
+      subagentContext: this.subagentContext,
       streamLimits: this.streamLimits,
       maxDepth: this.maxDepth,
       createChildGraph:
@@ -1454,7 +1460,10 @@ export class SubagentExecutor {
         resumeExecution.checkpoints,
         branchChildThreadId,
         lease,
-        { source: resumeExecution.approvalExecutionScope, target: approvalExecutionScope }
+        {
+          source: resumeExecution.approvalExecutionScope,
+          target: approvalExecutionScope,
+        }
       );
       let previousApprovals: ToolApprovalReplaySnapshot[] = [];
       let approvalsMutated = false;
@@ -1765,14 +1774,20 @@ export class SubagentExecutor {
           }
           /** Repeated unconsumed forks must persist their current owner. */
           const reboundValue =
-            channel === INTERRUPT && approvalScope != null &&
-            value != null && typeof value === 'object' && 'value' in value
-              ? { ...value, value: rebindToolBatchReplayPayload(
-                value.value,
-                approvalScope.source,
-                approvalScope.target,
-                targetThreadId
-              ) }
+            channel === INTERRUPT &&
+            approvalScope != null &&
+            value != null &&
+            typeof value === 'object' &&
+            'value' in value
+              ? {
+                ...value,
+                value: rebindToolBatchReplayPayload(
+                  value.value,
+                  approvalScope.source,
+                  approvalScope.target,
+                  targetThreadId
+                ),
+              }
               : value;
           writes.push([channel, reboundValue]);
         }
@@ -2386,11 +2401,6 @@ export class SubagentExecutor {
     if (!bound) {
       return createSubagentFailure(SUBAGENT_CONFIG_CHANGED_MESSAGE);
     }
-    const completedChildResult = execution.completedResult;
-    if (completedChildResult != null) {
-      return completedChildResult;
-    }
-
     let config: ResolvedSubagentConfigEntry;
     try {
       config = await this.resolveExecutionConfig(executableConfig, execution, {
@@ -2450,6 +2460,44 @@ export class SubagentExecutor {
         },
       ],
     };
+    const hostContextInput: SubagentContextInput = {
+      executionContext: childExecutionContext,
+      parentThreadId: threadId,
+      memberAgentIds: childPlan.agents.map((agent) => agent.agentId),
+      signal: childSignal,
+      resumed: execution.started || resumeExecution != null,
+    };
+    let preparedContext: PreparedSubagentContext | undefined;
+    try {
+      preparedContext = await this.subagentContext?.prepare(hostContextInput);
+      execution.assertUsable(childSignal);
+      for (const [agentId, sessions] of Object.entries(
+        preparedContext?.agentSessions ?? {}
+      )) {
+        const member = childPlan.memberInputs.get(agentId);
+        if (member == null) throw new Error('Unknown subagent context member.');
+        const activeMember =
+          execution.activeRun?.graph.agentContexts.get(agentId);
+        if (
+          activeMember != null &&
+          activeMember.codeSessionKey !== sessions.codeSessionKey
+        ) {
+          throw new Error(
+            'Subagent session partition changed during execution.'
+          );
+        }
+        member.codeSessionKey = sessions.codeSessionKey;
+        member.initialSessions = sessions.initialSessions;
+      }
+    } catch {
+      return createSubagentFailure(
+        'Subagent context is unavailable or access was denied.'
+      );
+    }
+    const completedChildResult = execution.completedResult;
+    if (completedChildResult != null) {
+      return this.completeHostContext(hostContextInput, completedChildResult);
+    }
     const maxTurns = config.maxTurns ?? DEFAULT_SUBAGENT_MAX_TURNS;
     const memberRecursionLimit = maxTurns * SUBAGENT_RECURSION_MULTIPLIER;
     const recursionLimit =
@@ -2476,6 +2524,7 @@ export class SubagentExecutor {
       streamLimits: this.streamLimits,
       subagentScope: true,
       subagentExecutionContext: childExecutionContext,
+      subagentContext: this.subagentContext,
       ...(resumeExecution?.graphState.fadingTier == null
         ? {}
         : { fadingTier: resumeExecution.graphState.fadingTier }),
@@ -2626,6 +2675,8 @@ export class SubagentExecutor {
       }
       const childConfigurable: Record<string, unknown> = {
         ...inheritedConfigurable,
+        ...sanitizePreparedConfigurable(preparedContext?.configurable),
+        executionContext: childExecutionContext,
       };
       if (this.humanInTheLoop?.enabled === true) {
         childConfigurable[TOOL_APPROVAL_EXECUTION_SCOPE_CONFIG_KEY] =
@@ -2666,16 +2717,18 @@ export class SubagentExecutor {
         }
         const persistedInterrupts = getPersistedInterrupts(persistedState);
         if (persistedInterrupts.length > 0) {
-          activeChildRun.pendingInterrupts = resumeExecution == null ? persistedInterrupts :
-            persistedInterrupts.map((pending) => ({
-              ...pending,
-              value: rebindToolBatchReplayPayload(
-                pending.value,
-                resumeExecution.approvalExecutionScope,
-                approvalExecutionScope,
-                childThreadId
-              ),
-            }));
+          activeChildRun.pendingInterrupts =
+            resumeExecution == null
+              ? persistedInterrupts
+              : persistedInterrupts.map((pending) => ({
+                ...pending,
+                value: rebindToolBatchReplayPayload(
+                  pending.value,
+                  resumeExecution.approvalExecutionScope,
+                  approvalExecutionScope,
+                  childThreadId
+                ),
+              }));
           execution.markStarted();
           childAlreadyStarted = true;
         } else if (persistedState.next.length > 0) {
@@ -2710,9 +2763,12 @@ export class SubagentExecutor {
         }
         let childInput: BaseGraphState | Command | null;
         if (childResumeMap != null) {
-          const pending = activeChildRun.pendingInterrupts.find((entry) =>
-            entry.id != null && Object.prototype.hasOwnProperty.call(childResumeMap, entry.id)
-          ) ?? activeChildRun.pendingInterrupts[0];
+          const pending =
+            activeChildRun.pendingInterrupts.find(
+              (entry) =>
+                entry.id != null &&
+                Object.prototype.hasOwnProperty.call(childResumeMap, entry.id)
+            ) ?? activeChildRun.pendingInterrupts[0];
           restoreToolReplayConfig(childConfigurable, pending.id, pending.value);
           rebindToolBatchReplayScope(
             childConfigurable,
@@ -2734,6 +2790,7 @@ export class SubagentExecutor {
                   [SUBAGENT_RUN_ID_KEY]: childRunId,
                 },
               }),
+              ...(preparedContext?.messages ?? []),
             ],
           };
         }
@@ -2749,6 +2806,7 @@ export class SubagentExecutor {
             registry: this.hookRegistry,
             input: {
               hook_event_name: 'SubagentStart',
+              executionContext: childExecutionContext,
               runId: currentHookSessionId,
               threadId,
               parentAgentId: this.parentAgentId,
@@ -2955,6 +3013,7 @@ export class SubagentExecutor {
         registry: this.hookRegistry,
         input: {
           hook_event_name: 'SubagentStop',
+          executionContext: childExecutionContext,
           runId: currentHookSessionId,
           threadId,
           agentId: childAgentId,
@@ -2997,12 +3056,27 @@ export class SubagentExecutor {
 
     this.clearChildGraph(childGraph);
 
-    const completedResult = {
+    const completedResult: SubagentExecuteResult = {
       content: filteredContent,
       messages: result.messages,
     };
     execution.markCompleted(completedResult);
-    return completedResult;
+    return this.completeHostContext(hostContextInput, completedResult);
+  }
+
+  private async completeHostContext(
+    input: SubagentContextInput,
+    result: SubagentExecuteResult
+  ): Promise<SubagentExecuteResult> {
+    if (this.subagentContext?.complete == null) return result;
+    try {
+      input.signal.throwIfAborted();
+      const completed = await this.subagentContext.complete(input, result);
+      input.signal.throwIfAborted();
+      return { ...result, content: completed.content };
+    } catch {
+      return createSubagentFailure('Subagent result delivery failed.');
+    }
   }
 
   /**
@@ -3533,6 +3607,17 @@ function sanitizeChildConfigurable(
       ([key]) => !isLangGraphRuntimeConfigKey(key)
     )
   );
+}
+
+function sanitizePreparedConfigurable(
+  configurable: RunnableConfig['configurable']
+): Record<string, unknown> {
+  const prepared = sanitizeChildConfigurable(configurable);
+  delete prepared.run_id;
+  delete prepared.parent_run_id;
+  delete prepared.thread_id;
+  delete prepared.executionContext;
+  return prepared;
 }
 
 function isLangGraphRuntimeConfigKey(key: string): boolean {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -142,6 +142,7 @@ import { stableStringify } from '@/tools/eagerEventExecution';
 import { convertInjectedMessages } from '@/messages/injected';
 import { resolveClientOptionsModel } from '@/llm/request';
 import { composeAbortSignals } from '@/utils/misc';
+import { sleep } from '@/utils/run';
 import { HandlerRegistry } from '@/events';
 
 export {
@@ -1276,21 +1277,35 @@ export class SubagentExecutor {
         detachedGraphFactory ?? this.createChildGraphByKind,
     });
     try {
-      const result = await detached.execute({
-        ...params,
-        signal: undefined,
-        breaker: undefined,
-        hookSessionId: taskHookSessionId,
-        taskRuntime: runtime,
-        parentConfigurable: {
-          ...params.parentConfigurable,
-          run_id: taskHookSessionId,
-        },
-      });
-      if (runtime.signal.aborted) {
-        throw runtime.signal.reason instanceof Error
-          ? runtime.signal.reason
-          : new Error('Detached subagent task cancelled.');
+      const executeAttempt = async (): Promise<SubagentExecuteResult> => {
+        const result = await detached.execute({
+          ...params,
+          signal: undefined,
+          breaker: undefined,
+          hookSessionId: taskHookSessionId,
+          taskRuntime: runtime,
+          parentConfigurable: {
+            ...params.parentConfigurable,
+            run_id: taskHookSessionId,
+          },
+        });
+        if (runtime.signal.aborted) {
+          throw runtime.signal.reason instanceof Error
+            ? runtime.signal.reason
+            : new Error('Detached subagent task cancelled.');
+        }
+        return result;
+      };
+      let deliveryRetries = 0;
+      let result = await executeAttempt();
+      while (result.retryableDelivery === true) {
+        if (deliveryRetries > 0) {
+          await sleep(
+            Math.min(100 * 2 ** Math.min(deliveryRetries - 1, 6), 5_000)
+          );
+        }
+        deliveryRetries += 1;
+        result = await executeAttempt();
       }
       if (result.error != null) {
         throw new Error(result.error);

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2543,7 +2543,12 @@ export class SubagentExecutor {
         member.codeSessionKey = sessions.codeSessionKey;
         member.initialSessions = sessions.initialSessions;
       }
-    } catch {
+    } catch (error) {
+      if (childSignal.aborted) {
+        throw childSignal.reason instanceof Error
+          ? childSignal.reason
+          : error;
+      }
       return createSubagentFailure(
         'Subagent context is unavailable or access was denied.'
       );

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -173,6 +173,31 @@ function seedChildGraphSessions(
   seedAgentInitialSessions(childGraph.sessions, agents);
 }
 
+async function awaitWithAbort<T>(
+  promise: Promise<T>,
+  signal: AbortSignal
+): Promise<T> {
+  signal.throwIfAborted();
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = (): void => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error('Detached subagent task cancelled.')
+      );
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    return await Promise.race([promise, aborted]);
+  } finally {
+    if (onAbort != null) {
+      signal.removeEventListener('abort', onAbort);
+    }
+  }
+}
+
 async function dispatchObservationalSubagentUpdate(
   handler: EventHandler,
   event: SubagentUpdateEvent
@@ -3092,7 +3117,10 @@ export class SubagentExecutor {
     if (this.subagentContext?.complete == null) return result;
     try {
       input.signal.throwIfAborted();
-      const completed = await this.subagentContext.complete(input, result);
+      const completed = await awaitWithAbort(
+        this.subagentContext.complete(input, result),
+        input.signal
+      );
       input.signal.throwIfAborted();
       return { ...result, content: completed.content };
     } catch {

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2177,6 +2177,9 @@ export class SubagentExecutor {
     ) {
       return;
     }
+    if (settled.output.status === 'error' && config.signal?.aborted === true) {
+      return;
+    }
     const parentConfigurable = config.configurable as
       | Record<string, unknown>
       | undefined;

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -838,6 +838,8 @@ export type SubagentExecuteParams = {
 export type SubagentExecuteResult = SubagentContextResult & {
   /** Tagged internal failure; foreground callers retain the legacy content. */
   error?: string;
+  /** Completed child work whose host projection must be retried without re-execution. */
+  retryableDelivery?: true;
 };
 
 function createSubagentFailure(
@@ -2574,9 +2576,7 @@ export class SubagentExecutor {
     if (params.taskRuntime != null) {
       childGraph.hookRegistry = this.hookRegistry;
     }
-    if (cachedChildRun == null) {
-      seedChildGraphSessions(childGraph, childPlan.agents);
-    }
+    seedChildGraphSessions(childGraph, childPlan.agents);
     let forwarding: ForwarderCallback | undefined;
     if (forwardingEnabled) {
       forwarding = this.createForwarderCallback({
@@ -3078,7 +3078,10 @@ export class SubagentExecutor {
       input.signal.throwIfAborted();
       return { ...result, content: completed.content };
     } catch {
-      return createSubagentFailure('Subagent result delivery failed.');
+      return {
+        ...createSubagentFailure('Subagent result delivery failed.'),
+        retryableDelivery: true,
+      };
     }
   }
 

--- a/src/tools/subagent/SubagentExecutor.ts
+++ b/src/tools/subagent/SubagentExecutor.ts
@@ -2141,6 +2141,9 @@ export class SubagentExecutor {
       parentToolCallId,
       parentConfigurable,
     });
+    if (execution.completedResult != null && settled.output.status === 'error') {
+      return;
+    }
     const { resumeExecution } = execution;
     const resolvedSubagentType = getSubagentTypeFromArgs(settled.resolvedArgs);
     const resolvedDescription = getSubagentDescriptionFromArgs(

--- a/src/tools/subagent/__tests__/SubagentExecutionRegistry.test.ts
+++ b/src/tools/subagent/__tests__/SubagentExecutionRegistry.test.ts
@@ -481,6 +481,9 @@ describe('SubagentExecutionRegistry', () => {
     record.activate({ graphId: 'heavy-graph' });
     record.markStarted();
     record.markCompleted({ content: 'heavy execution result' });
+    expect(record.snapshot.resolvedConfig).toEqual({
+      agentId: 'heavy-agent-config',
+    });
 
     const first = record.settle(settlement, settledOutput, persist);
     const duplicate = record.settle(settlement, settledOutput, persist);

--- a/src/types/graph.ts
+++ b/src/types/graph.ts
@@ -395,6 +395,8 @@ export type StandardGraphInput = {
    * do not inherit it, keeping background nesting disabled for the MVP.
    */
   subagentTasks?: SubagentTaskConfig;
+  /** Host-owned context and result projection for each isolated child execution. */
+  subagentContext?: SubagentContextAdapter;
   /**
    * True when this graph IS a subagent child run (set by `SubagentExecutor`
    * when it constructs the child graph). Drives the hook-input `agentId`
@@ -667,6 +669,41 @@ export interface SubagentExecutionContext {
   readonly hookSessionId: string;
   readonly depth: number;
   readonly ancestry: readonly SubagentAncestryEntry[];
+}
+
+/** Trusted identity supplied before a child can access host-owned resources. */
+export interface SubagentContextInput {
+  executionContext: SubagentExecutionContext;
+  parentThreadId?: string;
+  memberAgentIds: readonly string[];
+  signal: AbortSignal;
+  resumed: boolean;
+}
+
+export interface PreparedSubagentContext {
+  /** Added to the initial child input; checkpoint recovery does not add them again. */
+  messages?: BaseMessage[];
+  /** Host configuration; SDK execution and checkpoint identities remain authoritative. */
+  configurable?: RunnableConfig['configurable'];
+  /** Each entry replaces that member's inherited code partition and initial sessions. */
+  agentSessions?: Readonly<
+    Record<string, Pick<AgentInputs, 'codeSessionKey' | 'initialSessions'>>
+  >;
+}
+
+export interface SubagentContextResult {
+  content: string;
+  messages: BaseMessage[];
+}
+
+export interface SubagentContextAdapter {
+  /** Reauthorizes reconstructed executions; durable work must be idempotent by child run ID. */
+  prepare(input: SubagentContextInput): Promise<PreparedSubagentContext>;
+  /** Projects durable references into the result returned to the parent. */
+  complete?(
+    input: SubagentContextInput,
+    result: SubagentContextResult
+  ): Promise<Pick<SubagentContextResult, 'content'>>;
 }
 
 /**

--- a/src/types/run.ts
+++ b/src/types/run.ts
@@ -291,6 +291,8 @@ export type RunConfig = {
    * Omit to preserve foreground-only subagent behavior.
    */
   subagentTasks?: SubagentTaskConfig;
+  /** Authorizes and supplies host-owned context to isolated child runs. */
+  subagentContext?: g.SubagentContextAdapter;
   /**
    * Pre-constructed hook registry for this run. Hooks fire at lifecycle
    * points in `processStream` (RunStart, UserPromptSubmit, Stop,

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -11,10 +11,10 @@ import type {
   ToolErrorData,
 } from './stream';
 import type { ToolOutputReferenceRegistry } from '@/tools/toolOutputReferences';
+import type { LangfuseConfig, SubagentExecutionContext } from './graph';
 import type { PreparedSubagents } from '@/tools/preparedSubagents';
 import type { RunBreakerScope } from '@/llm/streamLimits';
 import type { HumanInTheLoopConfig } from './hitl';
-import type { LangfuseConfig } from './graph';
 import type { HookRegistry } from '@/hooks';
 
 /** Replacement type for `import type { ToolCall } from '@langchain/core/messages/tool'` in order to have stringified args typed */
@@ -156,6 +156,8 @@ export type ToolNodeOptions = {
   /** ID of the agent that owns this tool node, surfaced to hooks as `executingAgentId`
    * so a batch can be attributed to a specific agent even where `agentId` is undefined. */
   executingAgentId?: string;
+  /** SDK-owned identity of the child execution, independent of reusable agent IDs. */
+  executionContext?: SubagentExecutionContext;
   /** Name of the agent that owns this tool node, used for active Langfuse attribution. */
   executingAgentName?: string;
   /** Root graph-agent identity retained alongside the currently executing tool owner. */
@@ -596,6 +598,8 @@ export type CallerCapabilityProjectionSnapshot = {
 
 /** Batch request containing ALL tool calls for a graph step */
 export type ToolExecuteBatchRequest = {
+  /** SDK-owned child lineage. Unset for tools in the root graph. */
+  executionContext?: SubagentExecutionContext;
   /** All tool calls from the AIMessage */
   toolCalls: ToolCallRequest[];
   /** User ID for context */

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -576,6 +576,8 @@ export type ToolCallRequest = {
     session_id: string;
     files?: CodeEnvFile[];
   };
+  /** Request-time execution session used to detect host session refreshes. */
+  codeSessionBaselineId?: string;
   /** Preserve request-provisioned code inputs after an eager identity mismatch. */
   retainCodeSessionInputs?: true;
   /**

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1231,6 +1231,7 @@ export type ProgrammaticHookContext = {
   runId: string;
   threadId?: string;
   agentId?: string;
+  executionContext?: SubagentExecutionContext;
   executingAgentId?: string;
 };
 

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -576,6 +576,8 @@ export type ToolCallRequest = {
     session_id: string;
     files?: CodeEnvFile[];
   };
+  /** Preserve request-provisioned code inputs after an eager identity mismatch. */
+  retainCodeSessionInputs?: true;
   /**
    * Stable runtime session hint for stateful sandbox sessions. Orthogonal to
    * `codeSessionContext` (which threads the transient exec-session for file

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -75,6 +75,7 @@ export type EagerEventToolExecution = {
   toolName: string;
   args: Record<string, unknown>;
   request: ToolCallRequest;
+  codeSessionBaselineByName?: ReadonlyMap<string, string>;
   promise: Promise<EagerEventToolExecutionOutcome>;
   /**
    * True when the streaming eager path already emitted the user-visible

--- a/src/utils/llmConfig.ts
+++ b/src/utils/llmConfig.ts
@@ -71,7 +71,6 @@ export const llmConfigs: Record<string, t.BuiltInLLMConfig | undefined> = {
   } as or.ChatOpenRouterCallOptions & t.BuiltInLLMConfig,
   [Providers.AZURE]: {
     provider: Providers.AZURE,
-    temperature: 0.7,
     streaming: true,
     streamUsage: true,
     azureOpenAIApiKey: process.env.AZURE_OPENAI_API_KEY,


### PR DESCRIPTION
When a host delegates work to concurrent copies of the same saved agent, the agent ID alone cannot identify which child may access a file or tool session. `Run.create({ subagentContext })` now gives the host a preparation and completion boundary for each SDK-owned child execution, including nested and graph subagents.

This supports run-scoped file sharing in [LibreChat #14261](https://github.com/danny-avila/LibreChat/issues/14261). Companion implementation: https://github.com/danny-avila/LibreChat/pull/15848.

- `prepare` authorizes access before the child graph runs, supplies actual messages and host configuration, and replaces per-member code-session seeds. Preparation failures or cancellation prevent child execution. SDK execution and checkpoint identities remain authoritative.
- The canonical child lineage reaches lifecycle/tool hooks, direct tool configuration and metadata, and event-driven/eager tool batches. Concurrent copies of the same agent retain distinct execution identities.
- `complete` projects a successful result into the text returned to the parent. If delivery fails, the SDK retains the completed work, reauthorizes on retry, and retries delivery without repeating model/tool side effects. Resuming a checkpoint preserves its messages rather than adding the initial context twice.
- Code-session tracking retains lazily provisioned input references when an execution errors or returns no usable artifact; newer references survive older results from the same batch, including eager execution.
- The Azure test/example preset uses provider-default temperature so the live fixture also works with reasoning deployments.

```mermaid
sequenceDiagram
    participant Parent as Parent Run
    participant SDK as SubagentExecutor
    participant Host as Host context adapter
    participant Child as Child graph and tools
    Parent->>SDK: Delegate task
    SDK->>Host: prepare(executionContext, members, signal)
    Host-->>SDK: Messages, configuration, member sessions
    SDK->>Child: Run with canonical child lineage
    Child-->>SDK: Successful result
    SDK->>Host: complete(context, retained result)
    Host-->>SDK: Result text with host-owned references
    SDK-->>Parent: Deliver result
```

The adapter contract and resume responsibilities are documented in [docs/subagent-context.md](https://github.com/usnavy13/agents/blob/c5f3f99e8a60e99d3c29412a67392dc2330ec7c9/docs/subagent-context.md). LibreChat supplies file authorization, storage, sandbox ownership, and the sharing tools through this interface. A code-session key partitions the SDK session map; hosts must enforce runtime workspace isolation and reconstruct their authorization on resume. Exported `SUBAGENT_CONTEXT_VERSION = 1` lets hosts check support before enabling their integration. Existing callers can omit the adapter.

Validation at `c5f3f99e8a60e99d3c29412a67392dc2330ec7c9`:

- Linux/Node 24 automated suite: **263 suites, 5,354 tests passed**, covering CI unit selection plus non-manual integrations and summarization. New coverage exercises concurrency, nested lineage, actual file messages, session replacement, denied/aborted preparation, result-delivery retries, resume, and eager input retention.
- **Five live Azure tests passed.** The companion LibreChat build using this packed SDK also passed all eight file-sharing browser scenarios with both memory and Redis configurations.
- Clean installs, full TypeScript checking, CJS/ESM/declaration builds, package packing, and circular-dependency checks passed. CI ESLint exited successfully with zero errors and 59 pre-existing warnings in untouched files. Changed-source import ordering passed; seven existing files retain baseline Prettier discrepancies with the repository's formatting hooks.
- Extra opt-in live ToolSearch integration: **2 passed, 12 failed** obsolete prose-output expectations against the current JSON response. A focused failure reproduced at base `b10ebb11`; implementation and test sources are unchanged. These are separate from the green automated suite. After the live follow-ups, 81 guarded cases remain unexecuted because they need other provider credentials or unavailable remote protocols, including nine `/exec/programmatic` cases.
- Native Windows had 31 platform-dependent failures; those tests passed unchanged on Linux. A separate whole-suite open-handle diagnostic run had four load-sensitive failures; focused reruns passed without persistent handles. Production dependency audit passed; the full audit retains one unchanged development dependency advisory.

Core local reproduction on Linux with Node 24.16.0 and npm 10.5.2:

```sh
npm ci
npx tsc --noEmit
npx eslint "src/**/*.ts"
npm run build
npm run test:circular-deps
npm run check:circular-deps
NODE_OPTIONS=--experimental-vm-modules NODE_ENV=test npx jest --roots=src --maxWorkers=2 --testPathIgnorePatterns=title.memory-leak.test.ts --testPathIgnorePatterns=llm.spec.ts
```

This remains a draft for coordinated SDK release and LibreChat adoption. The package version is unchanged; publishing a version containing this adapter and updating LibreChat's dependency/lockfile remain required before fresh installs can enable the feature.
